### PR TITLE
Add Clear Active Submission endpoints

### DIFF
--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -275,12 +275,7 @@ paths:
       tags:
         - Submission
       parameters:
-        - name: programId
-          description: the short name of the program
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/PathProgramId'
       requestBody:
         content:
           multipart/form-data:
@@ -313,6 +308,68 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateSubmission'
+  /submission/program/{programId}/clinical/{versionId}/{fileType}:
+    delete:
+      tags:
+        - Submission
+      parameters:
+        - $ref: '#/components/parameters/PathProgramId'
+        - $ref: '#/components/parameters/PathVersionId'
+        - name: fileType
+          description: the type name of the file that should be cleared, ex. 'specimen'
+          in: path
+          required: true
+          schema:
+            type: string
+      summary: Remove file from the active submission
+      description: Clears data for the specified file type from the active submission, removes all validation and resets the submission status to OPEN. Cannot be performed if the submission is in PENDING_APPROVAL state.
+      responses:
+        '200':
+          description: 'Data cleared succesfully. Returns the current active clinical submission or empty body if no submission data is available.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClinicalSubmission'
+        '400':
+          description: Version ID does not match version of active submission.
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '409':
+          description: Active submission is not in a state that can be cleared (ex. PENDING_APPROVAL)
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /submission/program/{programId}/clinical/{versionId}/all:
+    delete:
+      tags:
+        - Submission
+      parameters:
+        - $ref: '#/components/parameters/PathProgramId'
+        - $ref: '#/components/parameters/PathVersionId'
+      summary: Remove all data from the active clinical submission
+      description: Clears all data from the active submission. Removes all validation and resets the submission status to OPEN. Cannot be performed if the submission is in PENDING_APPROVAL state.
+      responses:
+        '200':
+          description: 'Data cleared succesfully. Returns the current active clinical submission or empty body if no submission data is available.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClinicalSubmission'
+        '400':
+          description: Version ID does not match version of active submission.
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '409':
+          description: Active submission is not in a state that can be cleared (ex. PENDING_APPROVAL)
+        '500':
+          $ref: '#/components/responses/ServerError'
   /submission/program/{programId}/clinical/validate/{versionId}:
     post:
       tags:

--- a/src/routes/submission.ts
+++ b/src/routes/submission.ts
@@ -14,9 +14,12 @@ router.post(
   upload.array('clinicalFiles'),
   wrapAsync(submissionAPI.saveClinicalTsvFiles),
 );
+
 router.post('/validate/:versionId', wrapAsync(submissionAPI.validateActiveSubmission));
 
 router.post('/commit/:versionId', wrapAsync(submissionAPI.commitActiveSubmission));
 router.post('/approve/:versionId', wrapAsync(submissionAPI.approveActiveSubmission));
+
+router.delete('/:versionId/:fileType', wrapAsync(submissionAPI.clearFileFromActiveSubmission));
 
 export default router;

--- a/src/submission/submission-api.ts
+++ b/src/submission/submission-api.ts
@@ -45,6 +45,18 @@ type ClinicalEnityFileMap = {
 
 class SubmissionController {
   @HasProgramWriteAccess((req: Request) => req.params.programId)
+  async clearFileFromActiveSubmission(req: Request, res: Response) {
+    const { programId, versionId, fileType } = req.params;
+    L.debug(`Entering clearFileFromActiveSubmission: ${{ programId, versionId, fileType }}`);
+    const updatedRegistration = await submission.operations.clearSubmissionData({
+      programId,
+      versionId,
+      fileType,
+    });
+    return res.status(200).send(updatedRegistration);
+  }
+
+  @HasProgramWriteAccess((req: Request) => req.params.programId)
   async getRegistrationByProgramId(req: Request, res: Response) {
     L.debug('in getRegistrationByProgramId');
     const programId = req.params.programId;

--- a/src/submission/submission-entities.ts
+++ b/src/submission/submission-entities.ts
@@ -135,6 +135,12 @@ export interface ClinicalSubmissionCommand {
   readonly clinicalType: string;
 }
 
+export interface ClearSubmissionCommand {
+  readonly programId: string;
+  readonly versionId: string;
+  readonly fileType: string;
+}
+
 export interface MultiClinicalSubmissionCommand {
   newClinicalEntities: Readonly<{ [clinicalType: string]: NewClinicalEntity }>;
   readonly programId: string;

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -11,6 +11,7 @@ import {
   CreateRegistrationRecord,
   CreateRegistrationCommand,
   CreateRegistrationResult,
+  ClearSubmissionCommand,
   FieldsEnum,
   ClinicalSubmissionCommand,
   MultiClinicalSubmissionCommand,
@@ -165,6 +166,50 @@ export namespace operations {
    */
   export const findSubmissionByProgramId = async (programId: string) => {
     return await submissionRepository.findByProgramId(programId);
+  };
+
+  export const clearSubmissionData = async (command: ClearSubmissionCommand) => {
+    // Get active submission
+    const activeSubmission = await submissionRepository.findByProgramId(command.programId);
+
+    if (activeSubmission === undefined) {
+      throw new Errors.NotFound('No active submission data found for this program.');
+    } else if (activeSubmission.version !== command.versionId) {
+      throw new Errors.InvalidArgument(
+        'Version ID provided does not match the latest submission version for this program.',
+      );
+    } else if (activeSubmission.state === SUBMISSION_STATE.PENDING_APPROVAL) {
+      // confirm that the state is VALID
+      throw new Errors.StateConflict(
+        'Active submission is in PENDING_APPROVAL state and cannot be modified.',
+      );
+    } else {
+      // Update clinical entities from the active submission
+      const updatedClinicalEntites: ClinicalEntities = {};
+      if (command.fileType !== 'all') {
+        for (const clinicalType in activeSubmission.clinicalEntities) {
+          if (clinicalType !== command.fileType) {
+            updatedClinicalEntites[clinicalType] = {
+              ...activeSubmission.clinicalEntities[clinicalType],
+              ...emptyStats,
+            };
+          }
+        }
+      }
+      const newActiveSubmission: ActiveClinicalSubmission = {
+        programId: command.programId,
+        state: SUBMISSION_STATE.OPEN,
+        version: '', // version is irrelevant here, repo will set it
+        clinicalEntities: updatedClinicalEntites,
+      };
+      // insert into database
+      const updated = await submissionRepository.updateSubmissionWithVersion(
+        command.programId,
+        activeSubmission.version,
+        newActiveSubmission,
+      );
+      return updated;
+    }
   };
 
   /**
@@ -327,7 +372,9 @@ export namespace operations {
     };
   };
 
-  /************* Private methods *************/
+  /* *************** *
+   * Private Methods
+   * *************** */
 
   const addNewDonorToStats = (
     stats: RegistrationStats,

--- a/src/submission/submission-to-clinical.ts
+++ b/src/submission/submission-to-clinical.ts
@@ -114,8 +114,6 @@ const performCommitSubmission = async (
     } catch (err) {
       throw new Error(`Failure occured saving clinical data: ${err}`);
     }
-
-    // Remove active submission
   }
 };
 

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -854,9 +854,11 @@ describe('Submission Api', () => {
     let submissionVersion: string;
 
     const uploadSubmission = async () => {
-      let file: Buffer;
+      let donorFile: Buffer;
+      let specimenFile: Buffer;
       try {
-        file = fs.readFileSync(__dirname + '/donor.tsv');
+        donorFile = fs.readFileSync(__dirname + '/donor.tsv');
+        specimenFile = fs.readFileSync(__dirname + '/specimen.tsv');
       } catch (err) {
         return err;
       }
@@ -865,23 +867,8 @@ describe('Submission Api', () => {
         .request(app)
         .post(`/submission/program/${programId}/clinical/upload`)
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
-        .attach('clinicalFiles', file, 'donor.tsv')
-        .then((res: any) => {
-          submissionVersion = res.body.submission.version;
-        })
-        .catch(err => chai.assert.fail(err));
-
-      try {
-        file = fs.readFileSync(__dirname + '/specimen.tsv');
-      } catch (err) {
-        return err;
-      }
-
-      await chai
-        .request(app)
-        .post(`/submission/program/${programId}/clinical/upload`)
-        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
-        .attach('clinicalFiles', file, 'specimen.tsv')
+        .attach('clinicalFiles', donorFile, 'donor.tsv')
+        .attach('clinicalFiles', specimenFile, 'specimen.tsv')
         .then((res: any) => {
           submissionVersion = res.body.submission.version;
         })

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -33,7 +33,6 @@ import { donorDao } from '../../../src/clinical/donor-repo';
 import { Donor } from '../../../src/clinical/clinical-entities';
 import { ErrorCodes, FileType } from '../../../src/submission/submission-api';
 import * as manager from '../../../src/lectern-client/schema-manager';
-import { submissionRepository } from '../../../src/submission/submission-repo';
 import AdmZip from 'adm-zip';
 
 import * as _ from 'lodash';

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -915,8 +915,7 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .then((res: any) => {
           res.should.have.status(400);
-        })
-        .catch(err => chai.assert.fail(err));
+        });
     });
     it('should return 409 if an active submission is available but in PENDING_APPROVAL state', async () => {
       const SUBMISSION_PENDING_APPROVAL = {
@@ -933,8 +932,7 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .then((res: any) => {
           res.should.have.status(409);
-        })
-        .catch(err => chai.assert.fail(err));
+        });
     });
     it('should return 200 when clear all is completed, and have no clinicalEntities in DB', async () => {
       await uploadSubmission();
@@ -956,8 +954,7 @@ describe('Submission Api', () => {
             dbRead[0].clinicalEntities,
             'DB Record for Active Submission should hae empty clincialEntities',
           ).to.be.empty;
-        })
-        .catch(err => chai.assert.fail(err));
+        });
     });
     it('should return 200 when clear donor is completed, have specimen in clinicalEntities but no donor', async () => {
       await uploadSubmission();
@@ -975,6 +972,29 @@ describe('Submission Api', () => {
           });
           chai.expect(dbRead[0].clinicalEntities.donor).to.be.undefined;
           chai.expect(dbRead[0].clinicalEntities.specimen).to.exist;
+        });
+    });
+    it('should set the active submission state to OPEN', async () => {
+      const SUBMISSION = {
+        state: SUBMISSION_STATE.VALID,
+        programId: 'ABCD-EF',
+        version: 'asdf',
+        clinicalEntities: { donor: [{ submitterId: 123 }] },
+      };
+
+      await insertData(dburl, 'activesubmissions', SUBMISSION);
+      return chai
+        .request(app)
+        .delete(`/submission/program/ABCD-EF/clinical/asdf/all`)
+        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
+        .then(async (res: any) => {
+          res.should.have.status(200);
+          res.body.state.should.equal(SUBMISSION_STATE.OPEN);
+
+          const dbRead = await findInDb(dburl, 'activesubmissions', {
+            programId: 'ABCD-EF',
+          });
+          chai.expect(dbRead[0].state).to.be.equal(SUBMISSION_STATE.OPEN);
         });
     });
   });
@@ -1101,8 +1121,7 @@ describe('Submission Api', () => {
         .attach('clinicalFiles', file, 'donor.tsv')
         .then((res: any) => {
           submissionVersion = res.body.submission.version;
-        })
-        .catch(err => chai.assert.fail(err));
+        });
     };
     const uploadSubmissionWithUpdates = async () => {
       let file: Buffer;

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -17,6 +17,7 @@ import {
   resetCounters,
   generateDonor,
   assertDbCollectionEmpty,
+  findInDb,
 } from '../testutils';
 import { TEST_PUB_KEY, JWT_CLINICALSVCADMIN, JWT_ABCDEF, JWT_WXYZEF } from '../test.jwt';
 import {
@@ -32,7 +33,10 @@ import { donorDao } from '../../../src/clinical/donor-repo';
 import { Donor } from '../../../src/clinical/clinical-entities';
 import { ErrorCodes, FileType } from '../../../src/submission/submission-api';
 import * as manager from '../../../src/lectern-client/schema-manager';
+import { submissionRepository } from '../../../src/submission/submission-repo';
 import AdmZip from 'adm-zip';
+
+import * as _ from 'lodash';
 
 chai.use(require('chai-http'));
 chai.should();
@@ -844,6 +848,151 @@ describe('Submission Api', () => {
     });
   });
 
+  describe('clinical-submission: clear', function() {
+    const programId = 'ABCD-EF';
+    let donor: any;
+    let submissionVersion: string;
+
+    const uploadSubmission = async () => {
+      let file: Buffer;
+      try {
+        file = fs.readFileSync(__dirname + '/donor.tsv');
+      } catch (err) {
+        return err;
+      }
+
+      await chai
+        .request(app)
+        .post(`/submission/program/${programId}/clinical/upload`)
+        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
+        .attach('clinicalFiles', file, 'donor.tsv')
+        .then((res: any) => {
+          submissionVersion = res.body.submission.version;
+        })
+        .catch(err => chai.assert.fail(err));
+
+      try {
+        file = fs.readFileSync(__dirname + '/specimen.tsv');
+      } catch (err) {
+        return err;
+      }
+
+      await chai
+        .request(app)
+        .post(`/submission/program/${programId}/clinical/upload`)
+        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
+        .attach('clinicalFiles', file, 'specimen.tsv')
+        .then((res: any) => {
+          submissionVersion = res.body.submission.version;
+        })
+        .catch(err => chai.assert.fail(err));
+    };
+
+    this.beforeEach(async () => {
+      await clearCollections(dburl, ['donors', 'activesubmissions']);
+      donor = await generateDonor(dburl, programId, 'ICGC_0001');
+    });
+    it('should return 401 if no auth is provided', done => {
+      chai
+        .request(app)
+        .delete('/submission/program/ABCD-EF/clinical/asdf/asdf')
+        .end((err: any, res: any) => {
+          res.should.have.status(401);
+          done();
+        });
+    });
+    it('should return 403 if the user is not an admin for that program', done => {
+      chai
+        .request(app)
+        .delete('/submission/program/ABCD-EF/clinical/asdf/asdf')
+        .auth(JWT_WXYZEF, { type: 'bearer' })
+        .end((err: any, res: any) => {
+          res.should.have.status(403);
+          done();
+        });
+    });
+    it('should return 404 if no active submission is available', done => {
+      chai
+        .request(app)
+        .delete('/submission/program/WRONG-ID/clinical/asdf/asdf')
+        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
+        .end((err: any, res: any) => {
+          res.should.have.status(404);
+          done();
+        });
+    });
+    it('should return 400 if an active submission is available with a different version ID', async () => {
+      await uploadSubmission();
+      return chai
+        .request(app)
+        .delete(`/submission/program/${programId}/clinical/wrong-version-id/asdf`)
+        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
+        .then((res: any) => {
+          res.should.have.status(400);
+        })
+        .catch(err => chai.assert.fail(err));
+    });
+    it('should return 409 if an active submission is available but in PENDING_APPROVAL state', async () => {
+      const SUBMISSION_PENDING_APPROVAL = {
+        state: SUBMISSION_STATE.PENDING_APPROVAL,
+        programId: 'ABCD-EF',
+        version: 'asdf',
+        clinicalEntities: { donor: [{ submitterId: 123 }] },
+      };
+
+      await insertData(dburl, 'activesubmissions', SUBMISSION_PENDING_APPROVAL);
+      return chai
+        .request(app)
+        .delete(`/submission/program/ABCD-EF/clinical/asdf/donor`)
+        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
+        .then((res: any) => {
+          res.should.have.status(409);
+        })
+        .catch(err => chai.assert.fail(err));
+    });
+    it('should return 200 when clear all is completed, and have no clinicalEntities in DB', async () => {
+      await uploadSubmission();
+      return chai
+        .request(app)
+        .delete(`/submission/program/${programId}/clinical/${submissionVersion}/all`)
+        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
+        .then(async (res: any) => {
+          res.should.have.status(200);
+          chai.expect(
+            res.body.clinicalEntities,
+            'Response should have empty clinicalEntities object',
+          ).to.be.empty;
+
+          const dbRead = await findInDb(dburl, 'activesubmissions', {
+            programId: 'ABCD-EF',
+          });
+          chai.expect(
+            dbRead[0].clinicalEntities,
+            'DB Record for Active Submission should hae empty clincialEntities',
+          ).to.be.empty;
+        })
+        .catch(err => chai.assert.fail(err));
+    });
+    it('should return 200 when clear donor is completed, have specimen in clinicalEntities but no donor', async () => {
+      await uploadSubmission();
+      return chai
+        .request(app)
+        .delete(`/submission/program/${programId}/clinical/${submissionVersion}/donor`)
+        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
+        .then(async (res: any) => {
+          res.should.have.status(200);
+          chai.expect(res.body.clinicalEntities.donor).to.be.undefined;
+          chai.expect(res.body.clinicalEntities.specimen).to.exist;
+
+          const dbRead = await findInDb(dburl, 'activesubmissions', {
+            programId: 'ABCD-EF',
+          });
+          chai.expect(dbRead[0].clinicalEntities.donor).to.be.undefined;
+          chai.expect(dbRead[0].clinicalEntities.specimen).to.exist;
+        });
+    });
+  });
+
   describe('clinical-submission: commit', function() {
     const programId = 'ABCD-EF';
     let donor: any;
@@ -863,17 +1012,19 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .attach('clinicalFiles', file, 'donor.tsv')
         .then((res: any) => {
-          submissionVersion = res.submission.version;
+          submissionVersion = res.body.submission.version;
         })
-        .catch(err => err);
+        .catch(err => chai.assert.fail(err));
     };
     const validateSubmission = async () => {
       return chai
         .request(app)
         .post(`/submission/program/${programId}/clinical/validate/${submissionVersion}`)
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
-        .then((res: any) => {})
-        .catch(err => err);
+        .then((res: any) => {
+          submissionVersion = res.body.submission.version;
+        })
+        .catch(err => chai.assert.fail(err));
     };
 
     this.beforeEach(async () => {
@@ -917,8 +1068,7 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .then((res: any) => {
           res.should.have.status(400);
-        })
-        .catch(err => err);
+        });
     });
     it('should return 409 if an active submission is available but not in VALID state', async () => {
       await uploadSubmission();
@@ -928,8 +1078,7 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .then((res: any) => {
           res.should.have.status(409);
-        })
-        .catch(err => err);
+        });
     });
     it('should return 200 when commit is completed', async () => {
       await uploadSubmission();
@@ -942,8 +1091,7 @@ describe('Submission Api', () => {
           res.should.have.status(200);
           // TODO: check that merge and save were successful
           // TODO: ensure the active submission was removed
-        })
-        .catch(err => err);
+        });
     });
   });
 
@@ -966,9 +1114,9 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .attach('clinicalFiles', file, 'donor.tsv')
         .then((res: any) => {
-          submissionVersion = res.submission.version;
+          submissionVersion = res.body.submission.version;
         })
-        .catch(err => err);
+        .catch(err => chai.assert.fail(err));
     };
     const uploadSubmissionWithUpdates = async () => {
       let file: Buffer;
@@ -984,25 +1132,26 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .attach('clinicalFiles', file, 'donor.tsv')
         .then((res: any) => {
-          submissionVersion = res.submission.version;
-        })
-        .catch(err => err);
+          submissionVersion = res.body.submission.version;
+        });
     };
     const validateSubmission = async () => {
       return chai
         .request(app)
         .post(`/submission/program/${programId}/clinical/validate/${submissionVersion}`)
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
-        .then((res: any) => {})
-        .catch(err => err);
+        .then((res: any) => {
+          submissionVersion = res.body.submission.version;
+        });
     };
     const commitActiveSubmission = async () => {
       return chai
         .request(app)
         .post(`/submission/program/${programId}/clinical/commit/${submissionVersion}`)
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
-        .then((res: any) => {})
-        .catch(err => err);
+        .then((res: any) => {
+          submissionVersion = res.body.version;
+        });
     };
 
     this.beforeEach(async () => {
@@ -1046,8 +1195,7 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .then((res: any) => {
           res.should.have.status(400);
-        })
-        .catch(err => err);
+        });
     });
     it('should return 409 if an active submission is available but not in PENDING_APPROVAL state', async () => {
       await uploadSubmission();
@@ -1059,8 +1207,7 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .then((res: any) => {
           res.should.have.status(409);
-        })
-        .catch(err => err);
+        });
     });
     it('should return 200 when commit is completed', async () => {
       // To get submission into correct state (pending approval) we need to already have a completed submission...
@@ -1078,8 +1225,7 @@ describe('Submission Api', () => {
           res.should.have.status(200);
           // TODO: check that merge and save were successful
           // TODO: ensure the active submission was removed
-        })
-        .catch(err => err);
+        });
     });
   });
 
@@ -1124,23 +1270,19 @@ describe('Submission Api', () => {
           });
         })
         .end((err: any, res: any) => {
-          try {
-            // array of file content (which are just the field headers for each clinical type)
-            const downloadedFiles: string[] = res.body
-              .getEntries()
-              .map((fileEntry: any) => res.body.readAsText(fileEntry));
-            const refFiles: string[] = refZip
-              .getEntries()
-              .map((fileEntry: any) => refZip.readAsText(fileEntry));
+          // array of file content (which are just the field headers for each clinical type)
+          const downloadedFiles: string[] = res.body
+            .getEntries()
+            .map((fileEntry: any) => res.body.readAsText(fileEntry));
+          const refFiles: string[] = refZip
+            .getEntries()
+            .map((fileEntry: any) => refZip.readAsText(fileEntry));
 
-            console.log(`Ref data is: [${refFiles}]`);
-            console.log(`Downloaded data is: [${downloadedFiles}]`);
+          console.log(`Ref data is: [${refFiles}]`);
+          console.log(`Downloaded data is: [${downloadedFiles}]`);
 
-            chai.expect(refFiles).to.eql(downloadedFiles);
-            return done();
-          } catch (err) {
-            return done(err);
-          }
+          chai.expect(refFiles).to.eql(downloadedFiles);
+          return done();
         });
     });
     it('get template not found', done => {

--- a/test/integration/testutils.ts
+++ b/test/integration/testutils.ts
@@ -87,3 +87,14 @@ export async function assertDbCollectionEmpty(dburl: string, collection: string)
   await conn.close();
   chai.expect(count).to.eq(0);
 }
+
+export async function findInDb(dburl: string, collection: string, filter: any) {
+  const conn = await mongo.connect(dburl);
+  const result = await conn
+    .db('clinical')
+    .collection(collection)
+    .find(filter)
+    .toArray();
+  await conn.close();
+  return result;
+}


### PR DESCRIPTION
**Description of changes**

DELETE method request that accepts the filetype to clear or the value `all` for clearing everything.

Swagger docs updated and tests included.

Some changes were made to existing tests that were failing but catching the AssertionErrors so they appeared to be passing.

For tests, added a new util method to do a find call to mongo db so we can test that the db is being updated correctly, not just the API returns.

**Type of Change**

- [X] Bug
- [ ] Refactor
- [x] New Feature

**Checklist before requesting review:**

- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
