### PR TITLE
Feature/194 submitter id dots

### DIFF
--- a/sampleFiles/donor.tsv
+++ b/sampleFiles/donor.tsv
@@ -1,4 +1,4 @@
 submitter_donor_id	vital_status	cause_of_death	survival_time
-ICGC_0001	deceased	died of cancer	540
+ICGC_0001.1	deceased	died of cancer	540
 ICGC_0002	deceased	died of cancer	
 ICGC_0003	deceased	died of cancer	522

--- a/sampleFiles/sample_registration.short.tsv
+++ b/sampleFiles/sample_registration.short.tsv
@@ -1,4 +1,4 @@
 program_id	submitter_donor_id	gender	submitter_specimen_id	specimen_tissue_source	tumour_normal_designation	submitter_sample_id	sample_type
-PACA-AU	ICGC_0001	Male	ss123-adsasd-dads	Other	Normal	sm123-1	Total DNA	
+PACA-AU	ICGC_0001.1	Male	ss123-adsasd-dads	Other	Normal	sm123-1	Total DNA	
 PACA-AU	ICGC_0002	Female	ss123-sira0	Saliva	Primary tumour	sm123-2	Total RNA	
 PACA-AU	ICGC_0003	Male	ss123-sira	Saliva	Primary tumour	sm123-3	Amplified DNA

--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -261,7 +261,7 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '500':
           $ref: '#/components/responses/ServerError'
-  /submission/program/{programId}/clinical/upload:
+  /submission/program/{programId}/clinical/:
     get:
       tags:
         - Submission
@@ -287,6 +287,7 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '500':
           $ref: '#/components/responses/ServerError'
+  /submission/program/{programId}/clinical/upload:
     post:
       tags:
         - Submission

--- a/src/routes/submission.ts
+++ b/src/routes/submission.ts
@@ -8,7 +8,7 @@ const router = express.Router({ mergeParams: true });
 
 const upload = multer({ dest: '/tmp' });
 
-router.get('/upload', wrapAsync(submissionAPI.getActiveSubmissionByProgramId));
+router.get('/', wrapAsync(submissionAPI.getActiveSubmissionByProgramId));
 router.post(
   '/upload',
   upload.array('clinicalFiles'),

--- a/src/submission/submission-entities.ts
+++ b/src/submission/submission-entities.ts
@@ -80,7 +80,10 @@ export enum DataValidationErrors {
   NOT_ENOUGH_INFO_TO_VALIDATE = 'NOT_ENOUGH_INFO_TO_VALIDATE',
 }
 
-export type RegistrationStat = { [submitterId: string]: number[] };
+export type RegistrationStat = Array<{
+  submitterId: string;
+  rowNumbers: number[];
+}>;
 
 export interface RegistrationStats {
   newDonorIds: RegistrationStat;

--- a/src/submission/submission-to-clinical.ts
+++ b/src/submission/submission-to-clinical.ts
@@ -153,7 +153,7 @@ export const commitRegisteration = async (command: Readonly<CommitRegistrationCo
   return (
     (registration.stats &&
       registration.stats.newSampleIds &&
-      Object.keys(registration.stats.newSampleIds)) ||
+      registration.stats.newSampleIds.map(s => s.submitterId)) ||
     []
   );
 };

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -114,16 +114,25 @@ const expectedResponse1 = {
     programId: 'ABCD-EF',
     creator: 'Test User',
     stats: {
-      alreadyRegistered: {},
-      newDonorIds: {
-        abcd123: [0],
-      },
-      newSpecimenIds: {
-        ss123: [0],
-      },
-      newSampleIds: {
-        sm123: [0],
-      },
+      alreadyRegistered: [],
+      newDonorIds: [
+        {
+          submitterId: 'abcd123',
+          rowNumbers: [0],
+        },
+      ],
+      newSpecimenIds: [
+        {
+          submitterId: 'ss123',
+          rowNumbers: [0],
+        },
+      ],
+      newSampleIds: [
+        {
+          submitterId: 'sm123',
+          rowNumbers: [0],
+        },
+      ],
     },
     records: [
       {
@@ -147,16 +156,25 @@ const ABCD_REGISTRATION_DOC: ActiveRegistration = {
   creator: 'Test User',
   batchName: `${FileType.REGISTRATION}.tsv`,
   stats: {
-    newDonorIds: {
-      abcd123: [0],
-    },
-    newSpecimenIds: {
-      ss123: [0],
-    },
-    newSampleIds: {
-      sm123: [0],
-    },
-    alreadyRegistered: {},
+    newDonorIds: [
+      {
+        submitterId: 'abcd123',
+        rowNumbers: [0],
+      },
+    ],
+    newSpecimenIds: [
+      {
+        submitterId: 'ss123',
+        rowNumbers: [0],
+      },
+    ],
+    newSampleIds: [
+      {
+        submitterId: 'sm123',
+        rowNumbers: [0],
+      },
+    ],
+    alreadyRegistered: [],
   },
   records: [
     {
@@ -408,12 +426,14 @@ describe('Submission Api', () => {
         .end(async (err: any, res: any) => {
           try {
             await assertUploadOKRegistrationCreated(res, dburl);
-            chai.expect(res.body.registration.stats.newSampleIds).to.deep.eq({
-              'sm123-4': [0],
-              'sm123-5': [1],
-              'sm123-6': [2],
-              'sm123-7': [3],
-            });
+            chai
+              .expect(res.body.registration.stats.newSampleIds)
+              .to.deep.eq([
+                { submitterId: 'sm123-4', rowNumbers: [0] },
+                { submitterId: 'sm123-5', rowNumbers: [1] },
+                { submitterId: 'sm123-6', rowNumbers: [2] },
+                { submitterId: 'sm123-7', rowNumbers: [3] },
+              ]);
             const reg1Id = res.body.registration._id;
             chai
               .request(app)
@@ -433,7 +453,7 @@ describe('Submission Api', () => {
                         await assertUploadOKRegistrationCreated(res, dburl);
                         const reg2Id = res.body.registration._id;
                         chai.expect(reg2Id).to.not.eq(reg1Id);
-                        chai.expect(res.body.registration.stats.newSampleIds).to.deep.eq({});
+                        chai.expect(res.body.registration.stats.newSampleIds).to.deep.eq([]);
                         chai
                           .request(app)
                           .post(`/submission/program/ABCD-EF/registration/${reg2Id}/commit`)

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -609,7 +609,7 @@ describe('Submission Api', () => {
     it('should return 200 and empty json for no activesubmisison in program', done => {
       chai
         .request(app)
-        .get('/submission/program/ABCD-EF/clinical/upload')
+        .get('/submission/program/ABCD-EF/clinical/')
         .auth(JWT_ABCDEF, { type: 'bearer' })
         .end((err: any, res: any) => {
           res.should.have.status(200);

--- a/test/unit/submission/submission-to-clinical.spec.ts
+++ b/test/unit/submission/submission-to-clinical.spec.ts
@@ -15,16 +15,25 @@ const reg1: ActiveRegistration = {
   programId: 'ABCD-EF',
   batchName: 'registration1.tsv',
   stats: {
-    alreadyRegistered: {},
-    newDonorIds: {
-      abcd123: [0],
-    },
-    newSpecimenIds: {
-      ss123: [0],
-    },
-    newSampleIds: {
-      sm123: [0],
-    },
+    alreadyRegistered: [],
+    newDonorIds: [
+      {
+        submitterId: 'abcd123',
+        rowNumbers: [0],
+      },
+    ],
+    newSpecimenIds: [
+      {
+        submitterId: 'ss123',
+        rowNumbers: [0],
+      },
+    ],
+    newSampleIds: [
+      {
+        submitterId: 'sm123',
+        rowNumbers: [0],
+      },
+    ],
   },
   records: [
     {
@@ -46,14 +55,20 @@ const reg2: ActiveRegistration = {
   programId: 'ABCD-EF',
   batchName: 'registration2.tsv',
   stats: {
-    alreadyRegistered: {},
-    newDonorIds: {},
-    newSpecimenIds: {
-      ss123: [0],
-    },
-    newSampleIds: {
-      sm123: [0],
-    },
+    alreadyRegistered: [],
+    newDonorIds: [],
+    newSpecimenIds: [
+      {
+        submitterId: 'ss123',
+        rowNumbers: [0],
+      },
+    ],
+    newSampleIds: [
+      {
+        submitterId: 'sm123',
+        rowNumbers: [0],
+      },
+    ],
   },
   records: [
     {


### PR DESCRIPTION
**Description of changes**
change of the registration data model, the submitter id was used as object key in the stats sub objects, and that caused mongo to complain since those can have dots in them

example
was:
```
stats: [
  newDonors: { 'abcd.1' : [1,2,3] }
] 
```
Now
```
stats: [
  newDonors: { submitterId: 'abcd.1', rowNumbers: [1,2,3] }
] 
```

**_I'll update the gateway to handle this change too in a PR there_**


<!-- Please add a brief description of the changes here. -->

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
