### PR TITLE
Standardize Error Message Construction 

### DIFF
--- a/src/lectern-client/schema-entities.ts
+++ b/src/lectern-client/schema-entities.ts
@@ -64,4 +64,5 @@ export interface SchemaValidationError {
   readonly index: number;
   readonly fieldName: string;
   readonly info: object;
+  readonly message: string;
 }

--- a/src/lectern-client/schema-error-messages.ts
+++ b/src/lectern-client/schema-error-messages.ts
@@ -1,0 +1,18 @@
+const INVALID_VALUE_ERROR_MESSAGE = 'The value is not permissible for this field.';
+const ERROR_MESSAGES: { [key: string]: (errorData: any) => string } = {
+  INVALID_FIELD_VALUE_TYPE: () => INVALID_VALUE_ERROR_MESSAGE,
+  INVALID_BY_REGEX: () => INVALID_VALUE_ERROR_MESSAGE,
+  INVALID_BY_SCRIPT: () => INVALID_VALUE_ERROR_MESSAGE,
+  INVALID_ENUM_VALUE: () => INVALID_VALUE_ERROR_MESSAGE,
+  MISSING_REQUIRED_FIELD: errorData => `${errorData.fieldName} is a required field.`,
+};
+
+// Returns the formatted message for the given error key, taking any required properties from the info object
+// Default value is the errorType itself (so we can identify errorTypes that we are missing messages for and the user could look up the error meaning in our docs)
+const schemaErrorMessage = (errorType: string, errorData: any = {}): string => {
+  return errorType && Object.keys(ERROR_MESSAGES).includes(errorType)
+    ? ERROR_MESSAGES[errorType](errorData)
+    : errorType;
+};
+
+export default schemaErrorMessage;

--- a/src/lectern-client/schema-functions.ts
+++ b/src/lectern-client/schema-functions.ts
@@ -23,6 +23,7 @@ import {
   F,
   isNotAbsent,
 } from '../utils';
+import schemaErrorMessage from './schema-error-messages';
 const L = loggerFor(__filename);
 
 export const process = (
@@ -437,6 +438,7 @@ namespace validation {
     index: number,
     info: object = {},
   ): SchemaValidationError => {
-    return { errorType, fieldName, index, info };
+    const errorData = { errorType, fieldName, index, info };
+    return { ...errorData, message: schemaErrorMessage(errorType, errorData) };
   };
 }

--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -666,10 +666,11 @@ components:
     ValidationError:
       type: object
       required:
-        - fieldName
-        - info
         - index
         - type
+        - fieldName
+        - message
+        - info
       properties:
         fieldName:
           type: string
@@ -695,15 +696,18 @@ components:
           type: string
           description: The name of the parameter
           enum:
-            # data validation errors
-            - SPECIMEN_BELONGS_TO_OTHER_DONOR
-            - MUTATING_EXISTING_DATA
-            - SAMPLE_BELONGS_TO_OTHER_SPECIMEN
-            - NEW_SPECIMEN_ID_CONFLICT
-            - NEW_SPECIMEN_ATTR_CONFLICT
-            - NEW_SAMPLE_ID_CONFLICT
-            - NEW_SAMPLE_ATTR_CONFLICT
+            - CONFLICTING_TIME_INTERVAL
+            - ID_NOT_REGISTERED
             - INVALID_PROGRAM_ID
+            - MUTATING_EXISTING_DATA
+            - NEW_DONOR_CONFLICT
+            - NEW_SAMPLE_ATTR_CONFLICT
+            - NEW_SAMPLE_ID_CONFLICT
+            - NEW_SPECIMEN_ATTR_CONFLICT
+            - NEW_SPECIMEN_ID_CONFLICT
+            - NOT_ENOUGH_INFO_TO_VALIDATE
+            - SAMPLE_BELONGS_TO_OTHER_SPECIMEN
+            - SPECIMEN_BELONGS_TO_OTHER_DONOR
             # dictionary schema errors
             - MISSING_REQUIRED_FIELD
             - INVALID_FIELD_VALUE_TYPE

--- a/src/submission/submission-entities.ts
+++ b/src/submission/submission-entities.ts
@@ -53,6 +53,7 @@ export type SubmissionValidationError = {
   fieldName: string;
   info: object;
   index: number;
+  message: string;
 };
 
 export type SubmissionValidationUpdate = {

--- a/src/submission/submission-error-messages.ts
+++ b/src/submission/submission-error-messages.ts
@@ -1,0 +1,39 @@
+const ERROR_MESSAGES: { [key: string]: (errorData: any) => string } = {
+  /* ***************** *
+   * VALIDATION ERRORS
+   * ***************** */
+  NEW_DONOR_CONFLICT: () =>
+    'You are trying to register the same donor twice with different genders.',
+  SAMPLE_BELONGS_TO_OTHER_SPECIMEN: errorData =>
+    `Samples can only be registered to a single specimen. This sample has already been registered to specimen ${errorData.info.otherSpecimenSubmitterId}. Please correct your file or contact DCC to update the registered data.`,
+  SPECIMEN_BELONGS_TO_OTHER_DONOR: errorData =>
+    `Specimen can only be registered to a single donor. This specimen has already been registered to donor ${errorData.info.otherDonorSubmitterId}. Please correct your file or contact DCC to update the registered data.`,
+  INVALID_PROGRAM_ID: () =>
+    'Program ID does not match the program you are uploading to. Please include the correct Program ID.',
+  MUTATING_EXISTING_DATA: errorData =>
+    `The value does not match the previously registered value of ${errorData.info.originalValue}. Please correct your file or contact DCC to update the registered data.`,
+  NEW_SAMPLE_ATTR_CONFLICT: () =>
+    'You are trying to register the same sample with different sample types.',
+  NEW_SPECIMEN_ATTR_CONFLICT: () =>
+    'You are trying to register the same specimen with different values.',
+  NEW_SPECIMEN_ID_CONFLICT: () =>
+    'You are trying to register the same sample to multiple donors. Specimens can only be registered to a single donor.',
+  NEW_SAMPLE_ID_CONFLICT: () =>
+    'You are trying to register the same sample with multiple donors or specimens. Samples can only be registered to a single donor and specimen.',
+  ID_NOT_REGISTERED: errorData =>
+    `${errorData.info.value} has not yet been registered. Please register here before submitting clinical data for this identifier.`,
+  CONFLICTING_TIME_INTERVAL: () =>
+    'survival_time cannot be less than Specimen acquisition_interval.',
+  NOT_ENOUGH_INFO_TO_VALIDATE: errorData =>
+    `${errorData.info.field1} requires ${errorData.info.field2} in order to complete validation.  Please upload data for both fields in this clinical data submission.`,
+};
+
+// Returns the formatted message for the given error key, taking any required properties from the info object
+// Default value is the errorType itself (so we can identify errorTypes that we are missing messages for and the user could look up the error meaning in our docs)
+const validationErrorMessage = (errorType: string, errorData: any = {}): string => {
+  return errorType && Object.keys(ERROR_MESSAGES).includes(errorType)
+    ? ERROR_MESSAGES[errorType](errorData)
+    : errorType;
+};
+
+export default validationErrorMessage;

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -39,6 +39,7 @@ import { FileType } from './submission-api';
 import { submissionRepository } from './submission-repo';
 import { v1 as uuid } from 'uuid';
 import { validateSubmissionData } from './validation';
+import validationErrorMessage from './submission-error-messages';
 const L = loggerFor(__filename);
 
 const emptyStats = {
@@ -464,6 +465,7 @@ export namespace operations {
         type: schemaErr.errorType,
         info: getInfoObject(type, schemaErr, records[schemaErr.index]),
         fieldName: schemaErr.fieldName,
+        message: schemaErr.message,
       });
     });
     return F(errorsList);

--- a/src/submission/validation-clinical/donor.ts
+++ b/src/submission/validation-clinical/donor.ts
@@ -85,7 +85,6 @@ function checkTimeConflictWithSpecimen(
         DataValidationErrors.CONFLICTING_TIME_INTERVAL,
         ClinicalInfoFieldsEnum.survival_time,
         {
-          msg: `${ClinicalInfoFieldsEnum.survival_time} can't be less than a specimen's acquistion time`,
           conflictingSpecimenSubmitterIds: specimenIdsWithTimeConflicts,
         },
       ),

--- a/src/submission/validation-clinical/specimen.ts
+++ b/src/submission/validation-clinical/specimen.ts
@@ -82,9 +82,7 @@ function checkTimeConflictWithDonor(
         specimenRecord,
         DataValidationErrors.CONFLICTING_TIME_INTERVAL,
         ClinicalInfoFieldsEnum.acquisition_interval,
-        {
-          msg: `${ClinicalInfoFieldsEnum.acquisition_interval} can't be greater than ${ClinicalInfoFieldsEnum.survival_time}`,
-        },
+        {},
       ),
     );
   }

--- a/src/submission/validation-clinical/utils.ts
+++ b/src/submission/validation-clinical/utils.ts
@@ -10,6 +10,7 @@ import {
 } from '../submission-entities';
 import { DeepReadonly } from 'deep-freeze';
 import { Donor, Specimen } from '../../clinical/clinical-entities';
+import validationErrorMessage from '../submission-error-messages';
 import _ from 'lodash';
 
 export const checkDonorRegistered = (
@@ -27,7 +28,7 @@ export const buildSubmissionError = (
 ): SubmissionValidationError => {
   // typescript refused to take this directly
   const index: number = newRecord.index;
-  return {
+  const errorData = {
     type,
     fieldName,
     index,
@@ -36,6 +37,10 @@ export const buildSubmissionError = (
       donorSubmitterId: newRecord[FieldsEnum.submitter_donor_id],
       value: newRecord[fieldName],
     },
+  };
+  return {
+    ...errorData,
+    message: validationErrorMessage(type, errorData),
   };
 };
 

--- a/src/submission/validation.ts
+++ b/src/submission/validation.ts
@@ -17,6 +17,7 @@ import { DeepReadonly } from 'deep-freeze';
 import { DataRecord } from '../lectern-client/schema-entities';
 import { FileType } from './submission-api';
 import { submissionValidator } from './validation-clinical/index';
+import validationErrorMessage from './submission-error-messages';
 
 export const validateRegistrationData = async (
   expectedProgram: string,
@@ -132,6 +133,7 @@ export const usingInvalidProgramId = (
         fieldName: FieldsEnum.program_id,
         index: newDonorIndex,
         info: getInfoObject(type, record, expectedProgram),
+        message: validationErrorMessage(DataValidationErrors.INVALID_PROGRAM_ID),
       });
     }
     return errors;
@@ -448,19 +450,19 @@ const specimenBelongsToOtherDonor = async (
   programId: string,
 ) => {
   const errors: SubmissionValidationError[] = [];
-  const count = await donorDao.countBy({
-    [DONOR_FIELDS.PROGRAM_ID]: { $eq: programId },
-    [DONOR_FIELDS.SUBMITTER_ID]: { $ne: newDonor.donorSubmitterId },
-    [DONOR_FIELDS.SPECIMEN_SUBMITTER_ID]: { $eq: newDonor.specimenSubmitterId },
+  const existingDonor = await donorDao.findBySpecimenSubmitterIdAndProgramId({
+    programId,
+    submitterId: newDonor.specimenSubmitterId,
   });
-  if (count > 0) {
+  if (existingDonor !== undefined && existingDonor.submitterId !== newDonor.donorSubmitterId) {
     errors.push(
       buildError(
         newDonor,
         DataValidationErrors.SPECIMEN_BELONGS_TO_OTHER_DONOR,
         FieldsEnum.submitter_specimen_id,
         index,
-        {},
+        // Value check is to deal with undefined case, which should never occur due to
+        { otherDonorSubmitterId: existingDonor ? existingDonor.submitterId : '' },
       ),
     );
   }
@@ -473,22 +475,25 @@ const sampleBelongsToAnotherSpecimen = async (
   programId: string,
 ) => {
   const errors: SubmissionValidationError[] = [];
-  const count = await donorDao.countBy({
-    [DONOR_FIELDS.PROGRAM_ID]: { $eq: programId },
-    [DONOR_FIELDS.SPECIMEN_SUBMITTER_ID]: { $ne: newDonor.specimenSubmitterId },
-    [DONOR_FIELDS.SPECIMEN_SAMPLE_SUBMITTER_ID]: { $eq: newDonor.sampleSubmitterId },
+  const existingDonor = await donorDao.findBySampleSubmitterIdAndProgramId({
+    programId,
+    submitterId: newDonor.sampleSubmitterId,
   });
-
-  if (count > 0) {
-    errors.push(
-      buildError(
-        newDonor,
-        DataValidationErrors.SAMPLE_BELONGS_TO_OTHER_SPECIMEN,
-        FieldsEnum.submitter_sample_id,
-        index,
-        {},
-      ),
+  if (existingDonor !== undefined) {
+    const existingSpecimen = existingDonor.specimens.find(specimen =>
+      specimen.samples.some(sample => sample.submitterId === newDonor.sampleSubmitterId),
     );
+    if (existingSpecimen && existingSpecimen.submitterId !== newDonor.specimenSubmitterId) {
+      errors.push(
+        buildError(
+          newDonor,
+          DataValidationErrors.SAMPLE_BELONGS_TO_OTHER_SPECIMEN,
+          FieldsEnum.submitter_sample_id,
+          index,
+          { otherSpecimenSubmitterId: existingSpecimen.submitterId },
+        ),
+      );
+    }
   }
 
   return errors;
@@ -501,7 +506,7 @@ const buildError = (
   index: number,
   info: object = {},
 ): SubmissionValidationError => {
-  return {
+  const errorData = {
     type,
     fieldName,
     index,
@@ -512,6 +517,11 @@ const buildError = (
       sampleSubmitterId: newDonor.sampleSubmitterId,
       value: newDonor[RegistrationToCreateRegistrationFieldsMap[fieldName]],
     },
+  };
+
+  return {
+    message: validationErrorMessage(type, errorData),
+    ...errorData,
   };
 };
 
@@ -528,7 +538,7 @@ function checkSampleMutations(
         DataValidationErrors.MUTATING_EXISTING_DATA,
         FieldsEnum.sample_type,
         index,
-        {},
+        { originalValue: existingSample.sampleType },
       ),
     );
   }
@@ -542,13 +552,9 @@ function checkDonorMutations(
 ) {
   if (newDonor.gender != existingDonor.gender) {
     errors.push(
-      buildError(
-        newDonor,
-        DataValidationErrors.MUTATING_EXISTING_DATA,
-        FieldsEnum.gender,
-        index,
-        {},
-      ),
+      buildError(newDonor, DataValidationErrors.MUTATING_EXISTING_DATA, FieldsEnum.gender, index, {
+        originalValue: existingDonor.gender,
+      }),
     );
   }
 }
@@ -580,7 +586,7 @@ function checkSpecimenMutations(
         DataValidationErrors.MUTATING_EXISTING_DATA,
         FieldsEnum.specimen_tissue_source,
         index,
-        {},
+        { originalValue: existingSpecimen.specimenTissueSource },
       ),
     );
   }
@@ -591,7 +597,7 @@ function checkSpecimenMutations(
         DataValidationErrors.MUTATING_EXISTING_DATA,
         FieldsEnum.tumour_normal_designation,
         index,
-        {},
+        { originalValue: existingSpecimen.tumourNormalDesignation },
       ),
     );
   }

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -198,6 +198,7 @@ const expectedDonorErrors = [
       value: 'died of other reasons',
     },
     type: 'UNRECOGNIZED_FIELD',
+    message: 'UNRECOGNIZED_FIELD',
   },
   {
     index: 0,

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -206,7 +206,7 @@ const expectedDonorErrors = [
       value: 'acdc',
       donorSubmitterId: 'ICGC_0002',
     },
-
+    message: 'The value is not permissible for this field.',
     fieldName: ClinicalInfoFieldsEnum.survival_time,
   },
   {
@@ -216,6 +216,7 @@ const expectedDonorErrors = [
       value: 'undecided',
       donorSubmitterId: 'ICGC_0002',
     },
+    message: 'The value is not permissible for this field.',
     fieldName: ClinicalInfoFieldsEnum.vital_status,
   },
 ];
@@ -743,6 +744,8 @@ describe('Submission Api', () => {
                         donorSubmitterId: 'ICGC_0001',
                         value: 'ICGC_0001',
                       },
+                      message:
+                        'ICGC_0001 has not yet been registered. Please register here before submitting clinical data for this identifier.',
                       index: 0,
                     },
                   ]);

--- a/test/unit/lectern-client/schema-functions.spec.ts
+++ b/test/unit/lectern-client/schema-functions.spec.ts
@@ -272,6 +272,7 @@ describe('schema-functions', () => {
     chai.expect(result.validationErrors.length).to.eq(1);
     chai.expect(result.validationErrors).to.deep.include({
       errorType: SchemaValidationErrorTypes.UNRECOGNIZED_FIELD,
+      message: SchemaValidationErrorTypes.UNRECOGNIZED_FIELD,
       fieldName: 'hackField',
       index: 0,
       info: {},

--- a/test/unit/lectern-client/schema-functions.spec.ts
+++ b/test/unit/lectern-client/schema-functions.spec.ts
@@ -63,6 +63,7 @@ describe('schema-functions', () => {
       fieldName: 'gender',
       index: 0,
       info: {},
+      message: 'gender is a required field.',
     });
   });
 
@@ -83,6 +84,7 @@ describe('schema-functions', () => {
       fieldName: 'program_id',
       index: 0,
       info: {},
+      message: 'program_id is a required field.',
     });
   });
 
@@ -99,6 +101,7 @@ describe('schema-functions', () => {
       fieldName: 'unit_number',
       index: 0,
       info: {},
+      message: 'The value is not permissible for this field.',
     });
   });
 
@@ -135,6 +138,7 @@ describe('schema-functions', () => {
       fieldName: 'program_id',
       index: 0,
       info: {},
+      message: 'The value is not permissible for this field.',
     });
   });
 
@@ -159,12 +163,14 @@ describe('schema-functions', () => {
       fieldName: 'postal_code',
       index: 0,
       info: { message: 'invalid postal code for US' },
+      message: 'The value is not permissible for this field.',
     });
     chai.expect(result.validationErrors).to.deep.include({
       errorType: SchemaValidationErrorTypes.INVALID_BY_SCRIPT,
       fieldName: 'postal_code',
       index: 1,
       info: { message: 'invalid postal code for CANADA' },
+      message: 'The value is not permissible for this field.',
     });
   });
 
@@ -220,6 +226,7 @@ describe('schema-functions', () => {
       fieldName: 'survival_time',
       index: 0,
       info: {},
+      message: 'The value is not permissible for this field.',
     });
   });
 

--- a/test/unit/submission/validation.spec.ts
+++ b/test/unit/submission/validation.spec.ts
@@ -21,7 +21,10 @@ const genderMutatedErr: SubmissionValidationError = {
     sampleSubmitterId: 'AM1',
     specimenSubmitterId: 'SP1',
     value: 'Male',
+    originalValue: 'Female',
   },
+  message:
+    'The value does not match the previously registered value of Female. Please correct your file or contact DCC to update the registered data.',
   type: DataValidationErrors.MUTATING_EXISTING_DATA,
 };
 const programInvalidErr: SubmissionValidationError = {
@@ -34,17 +37,22 @@ const programInvalidErr: SubmissionValidationError = {
     sampleSubmitterId: 'AM1',
     value: 'PEM-CA',
   },
+  message:
+    'Program ID does not match the program you are uploading to. Please include the correct Program ID.',
   type: DataValidationErrors.INVALID_PROGRAM_ID,
 };
 const specimenMutatedErr: SubmissionValidationError = {
   fieldName: FieldsEnum.specimen_tissue_source,
   index: 0,
   info: {
+    originalValue: 'XYZ',
     donorSubmitterId: 'AB1',
     specimenSubmitterId: 'SP1',
     sampleSubmitterId: 'AM1',
     value: 'XYZ1',
   },
+  message:
+    'The value does not match the previously registered value of XYZ. Please correct your file or contact DCC to update the registered data.',
   type: DataValidationErrors.MUTATING_EXISTING_DATA,
 };
 const tndError: SubmissionValidationError = {
@@ -55,7 +63,10 @@ const tndError: SubmissionValidationError = {
     specimenSubmitterId: 'SP1',
     sampleSubmitterId: 'AM1',
     value: 'Normal2',
+    originalValue: 'Normal',
   },
+  message:
+    'The value does not match the previously registered value of Normal. Please correct your file or contact DCC to update the registered data.',
   type: DataValidationErrors.MUTATING_EXISTING_DATA,
 };
 
@@ -67,7 +78,10 @@ const sampleTypeMutatedError: SubmissionValidationError = {
     specimenSubmitterId: 'SP1',
     sampleSubmitterId: 'AM1',
     value: 'ST11',
+    originalValue: 'ST1',
   },
+  message:
+    'The value does not match the previously registered value of ST1. Please correct your file or contact DCC to update the registered data.',
   type: DataValidationErrors.MUTATING_EXISTING_DATA,
 };
 
@@ -79,7 +93,10 @@ const specimenBelongsToOtherDonor: SubmissionValidationError = {
     specimenSubmitterId: 'SP1',
     sampleSubmitterId: 'AM1',
     value: 'SP1',
+    otherDonorSubmitterId: 'AB1',
   },
+  message:
+    'Specimen can only be registered to a single donor. This specimen has already been registered to donor AB1. Please correct your file or contact DCC to update the registered data.',
   type: DataValidationErrors.SPECIMEN_BELONGS_TO_OTHER_DONOR,
 };
 
@@ -91,7 +108,10 @@ const sampleBelongsToOtherSpecimenAB2: SubmissionValidationError = {
     specimenSubmitterId: 'SP2',
     sampleSubmitterId: 'AM1',
     value: 'AM1',
+    otherSpecimenSubmitterId: 'SP1',
   },
+  message:
+    'Samples can only be registered to a single specimen. This sample has already been registered to specimen SP1. Please correct your file or contact DCC to update the registered data.',
   type: DataValidationErrors.SAMPLE_BELONGS_TO_OTHER_SPECIMEN,
 };
 
@@ -103,7 +123,10 @@ const sampleBelongsToOtherSpecimenAB1: SubmissionValidationError = {
     specimenSubmitterId: 'SP2',
     sampleSubmitterId: 'AM1',
     value: 'AM1',
+    otherSpecimenSubmitterId: 'SP1',
   },
+  message:
+    'Samples can only be registered to a single specimen. This sample has already been registered to specimen SP1. Please correct your file or contact DCC to update the registered data.',
   type: DataValidationErrors.SAMPLE_BELONGS_TO_OTHER_SPECIMEN,
 };
 
@@ -306,7 +329,10 @@ describe('data-validator', () => {
           specimenSubmitterId: 'SP1',
           sampleSubmitterId: 'AM1',
           value: 'XYZQ',
+          originalValue: 'XYZ',
         },
+        message:
+          'The value does not match the previously registered value of XYZ. Please correct your file or contact DCC to update the registered data.',
         type: DataValidationErrors.MUTATING_EXISTING_DATA,
       };
       chai.expect(result.errors).to.deep.include(specimenMutatedError);
@@ -315,11 +341,12 @@ describe('data-validator', () => {
     });
 
     it('should detect specimen belongs to other donor', async () => {
-      donorDaoCountByStub
-        .onFirstCall()
-        .returns(Promise.resolve(1))
-        .onSecondCall()
-        .returns(Promise.resolve(0));
+      donorDaoFindBySpecimenSubmitterIdAndProgramIdStub.returns(
+        Promise.resolve<Donor>(stubs.validation.existingDonor02()),
+      );
+      donorDaoFindBySampleSubmitterIdAndProgramIdStub.returns(
+        Promise.resolve<Donor>(stubs.validation.existingDonor02()),
+      );
 
       // test call
       const result = await dv.validateRegistrationData(
@@ -340,25 +367,19 @@ describe('data-validator', () => {
       );
 
       // assertions
-      chai.expect(result.errors.length).to.eq(1);
-      chai.expect(result.errors[0]).to.deep.eq(specimenBelongsToOtherDonor);
+      chai.expect(result.errors.length).to.eq(2);
+      chai.expect(result.errors).to.deep.include(specimenBelongsToOtherDonor);
     });
 
     // see issue https://github.com/icgc-argo/argo-clinical/issues/112
     it('should detect specimen belongs to other donor and specimen type changed', async () => {
       donorDaoFindBySampleSubmitterIdAndProgramIdStub.returns(
-        Promise.resolve(stubs.validation.existingDonor03()),
+        Promise.resolve(stubs.validation.existingDonor02()),
       );
 
       donorDaoFindBySpecimenSubmitterIdAndProgramIdStub.returns(
         Promise.resolve<Donor>(stubs.validation.existingDonor02()),
       );
-
-      donorDaoCountByStub
-        .onFirstCall()
-        .returns(Promise.resolve(1))
-        .onSecondCall()
-        .returns(Promise.resolve(0));
 
       // test call
       const result = await dv.validateRegistrationData(
@@ -372,16 +393,6 @@ describe('data-validator', () => {
             specimenTissueSource: 'XYZ',
             sampleType: 'ST11',
             specimenSubmitterId: 'SP1',
-            tumourNormalDesignation: 'Normal',
-          },
-          {
-            donorSubmitterId: 'AB3',
-            gender: 'Female',
-            programId: 'PEME-CA',
-            sampleSubmitterId: 'AM1',
-            specimenTissueSource: 'XYZ',
-            sampleType: 'ST11',
-            specimenSubmitterId: 'SPY',
             tumourNormalDesignation: 'Normal',
           },
         ],
@@ -396,35 +407,26 @@ describe('data-validator', () => {
           specimenSubmitterId: 'SP1',
           sampleSubmitterId: 'AM1',
           value: 'XYZ',
+          originalValue: 'XYZZ',
         },
-        type: DataValidationErrors.MUTATING_EXISTING_DATA,
-      };
-
-      const sampleTypeMutatedErr: SubmissionValidationError = {
-        fieldName: FieldsEnum.sample_type,
-        index: 1,
-        info: {
-          donorSubmitterId: 'AB3',
-          specimenSubmitterId: 'SPY',
-          sampleSubmitterId: 'AM1',
-          value: 'ST11',
-        },
+        message:
+          'The value does not match the previously registered value of XYZZ. Please correct your file or contact DCC to update the registered data.',
         type: DataValidationErrors.MUTATING_EXISTING_DATA,
       };
 
       // assertions
-      chai.expect(result.errors.length).to.eq(3);
-      chai.expect(result.errors[0]).to.deep.eq(specimenTypeMutatedErr);
-      chai.expect(result.errors[1]).to.deep.eq(specimenBelongsToOtherDonor);
-      chai.expect(result.errors[2]).to.deep.eq(sampleTypeMutatedErr);
+      chai.expect(result.errors.length).to.eq(2);
+      chai.expect(result.errors[0]).to.deep.include(specimenTypeMutatedErr);
+      chai.expect(result.errors[1]).to.deep.include(specimenBelongsToOtherDonor);
     });
 
     it('should detect sample belongs to other specimen, same donor', async () => {
-      donorDaoCountByStub
-        .onFirstCall()
-        .returns(Promise.resolve(0))
-        .onSecondCall()
-        .returns(Promise.resolve(1));
+      donorDaoFindBySpecimenSubmitterIdAndProgramIdStub.returns(
+        Promise.resolve<Donor>(stubs.validation.existingDonor02()),
+      );
+      donorDaoFindBySampleSubmitterIdAndProgramIdStub.returns(
+        Promise.resolve<Donor>(stubs.validation.existingDonor02()),
+      );
       const existingDonorMock: Donor = stubs.validation.existingDonor01();
       // test call
       const result = await dv.validateRegistrationData(
@@ -450,11 +452,12 @@ describe('data-validator', () => {
     });
 
     it('should detect sample belongs to other specimen, different donor', async () => {
-      donorDaoCountByStub
-        .onFirstCall()
-        .returns(Promise.resolve(0))
-        .onSecondCall()
-        .returns(Promise.resolve(1));
+      donorDaoFindBySpecimenSubmitterIdAndProgramIdStub.returns(
+        Promise.resolve<Donor>(stubs.validation.existingDonor02()),
+      );
+      donorDaoFindBySampleSubmitterIdAndProgramIdStub.returns(
+        Promise.resolve<Donor>(stubs.validation.existingDonor02()),
+      );
       // test call
       const result = await dv.validateRegistrationData(
         'PEME-CA',
@@ -474,8 +477,8 @@ describe('data-validator', () => {
       );
 
       // assertions
-      chai.expect(result.errors.length).to.eq(1);
-      chai.expect(result.errors[0]).to.deep.eq(sampleBelongsToOtherSpecimenAB2);
+      chai.expect(result.errors.length).to.eq(2);
+      chai.expect(result.errors).to.deep.include(sampleBelongsToOtherSpecimenAB2);
     });
 
     // different donor different specimen same sample id
@@ -521,6 +524,8 @@ describe('data-validator', () => {
           value: 'AM1',
         },
         type: DataValidationErrors.NEW_SAMPLE_ID_CONFLICT,
+        message:
+          'You are trying to register the same sample with multiple donors or specimens. Samples can only be registered to a single donor and specimen.',
       };
 
       const row1Err = {
@@ -533,6 +538,8 @@ describe('data-validator', () => {
           specimenSubmitterId: 'SP1',
           value: 'AM1',
         },
+        message:
+          'You are trying to register the same sample with multiple donors or specimens. Samples can only be registered to a single donor and specimen.',
         type: DataValidationErrors.NEW_SAMPLE_ID_CONFLICT,
       };
 
@@ -594,6 +601,8 @@ describe('data-validator', () => {
           specimenSubmitterId: 'SP1',
           value: 'SP1',
         },
+        message:
+          'You are trying to register the same sample to multiple donors. Specimens can only be registered to a single donor.',
         type: DataValidationErrors.NEW_SPECIMEN_ID_CONFLICT,
       };
 
@@ -607,6 +616,8 @@ describe('data-validator', () => {
           specimenSubmitterId: 'SP1',
           value: 'SP1',
         },
+        message:
+          'You are trying to register the same sample to multiple donors. Specimens can only be registered to a single donor.',
         type: DataValidationErrors.NEW_SPECIMEN_ID_CONFLICT,
       };
 
@@ -668,6 +679,7 @@ describe('data-validator', () => {
           value: 'XYX',
           conflictingRows: [2],
         },
+        message: 'You are trying to register the same specimen with different values.',
         type: DataValidationErrors.NEW_SPECIMEN_ATTR_CONFLICT,
       };
 
@@ -681,6 +693,7 @@ describe('data-validator', () => {
           value: 'XYz',
           conflictingRows: [0],
         },
+        message: 'You are trying to register the same specimen with different values.',
         type: DataValidationErrors.NEW_SPECIMEN_ATTR_CONFLICT,
       };
 
@@ -742,6 +755,7 @@ describe('data-validator', () => {
           value: 'ST-2',
           conflictingRows: [2],
         },
+        message: 'You are trying to register the same sample with different sample types.',
         type: DataValidationErrors.NEW_SAMPLE_ATTR_CONFLICT,
       };
 
@@ -755,6 +769,7 @@ describe('data-validator', () => {
           value: 'ST2',
           conflictingRows: [0],
         },
+        message: 'You are trying to register the same sample with different sample types.',
         type: DataValidationErrors.NEW_SAMPLE_ATTR_CONFLICT,
       };
 
@@ -815,6 +830,7 @@ describe('data-validator', () => {
           value: 'Male',
           conflictingRows: [2],
         },
+        message: 'You are trying to register the same donor twice with different genders.',
         type: DataValidationErrors.NEW_DONOR_CONFLICT,
       };
 
@@ -828,6 +844,7 @@ describe('data-validator', () => {
           value: 'Female',
           conflictingRows: [0],
         },
+        message: 'You are trying to register the same donor twice with different genders.',
         type: DataValidationErrors.NEW_DONOR_CONFLICT,
       };
 
@@ -888,6 +905,8 @@ describe('data-validator', () => {
           value: 'AM1',
           conflictingRows: [2],
         },
+        message:
+          'You are trying to register the same sample with multiple donors or specimens. Samples can only be registered to a single donor and specimen.',
         type: DataValidationErrors.NEW_SAMPLE_ID_CONFLICT,
       };
 
@@ -901,6 +920,8 @@ describe('data-validator', () => {
           value: 'AM1',
           conflictingRows: [0],
         },
+        message:
+          'You are trying to register the same sample with multiple donors or specimens. Samples can only be registered to a single donor and specimen.',
         type: DataValidationErrors.NEW_SAMPLE_ID_CONFLICT,
       };
 
@@ -961,6 +982,7 @@ describe('data-validator', () => {
           value: 'ST-2',
           conflictingRows: [2],
         },
+        message: 'You are trying to register the same sample with different sample types.',
         type: DataValidationErrors.NEW_SAMPLE_ATTR_CONFLICT,
       };
 
@@ -974,6 +996,7 @@ describe('data-validator', () => {
           value: 'ST2',
           conflictingRows: [0],
         },
+        message: 'You are trying to register the same sample with different sample types.',
         type: DataValidationErrors.NEW_SAMPLE_ATTR_CONFLICT,
       };
 
@@ -1009,6 +1032,7 @@ describe('data-validator', () => {
       );
       const specimenIdErr: SubmissionValidationError = {
         fieldName: FieldsEnum.submitter_specimen_id,
+        message: `SP2 has not yet been registered. Please register here before submitting clinical data for this identifier.`,
         type: DataValidationErrors.ID_NOT_REGISTERED,
         index: 0,
         info: {
@@ -1018,6 +1042,8 @@ describe('data-validator', () => {
       };
       const donorIdErr: SubmissionValidationError = {
         fieldName: FieldsEnum.submitter_donor_id,
+        message:
+          'AB2 has not yet been registered. Please register here before submitting clinical data for this identifier.',
         type: DataValidationErrors.ID_NOT_REGISTERED,
         index: 1,
         info: {
@@ -1068,31 +1094,31 @@ describe('data-validator', () => {
       );
       const specimenIntervalErr: SubmissionValidationError = {
         fieldName: ClinicalInfoFieldsEnum.acquisition_interval,
+        message: 'survival_time cannot be less than Specimen acquisition_interval.',
         type: DataValidationErrors.CONFLICTING_TIME_INTERVAL,
         index: 1,
         info: {
-          msg: `${ClinicalInfoFieldsEnum.acquisition_interval} can't be greater than ${ClinicalInfoFieldsEnum.survival_time}`,
           donorSubmitterId: 'AB2',
           value: '5020',
         },
       };
       const specimenIntervalErr2: SubmissionValidationError = {
         fieldName: ClinicalInfoFieldsEnum.acquisition_interval,
+        message: 'survival_time cannot be less than Specimen acquisition_interval.',
         type: DataValidationErrors.CONFLICTING_TIME_INTERVAL,
         index: 2,
         info: {
-          msg: `${ClinicalInfoFieldsEnum.acquisition_interval} can't be greater than ${ClinicalInfoFieldsEnum.survival_time}`,
           donorSubmitterId: 'AB3',
           value: '2000',
         },
       };
       const donorSurvivalTimeErr: SubmissionValidationError = {
         fieldName: ClinicalInfoFieldsEnum.survival_time,
+        message: 'survival_time cannot be less than Specimen acquisition_interval.',
         type: DataValidationErrors.CONFLICTING_TIME_INTERVAL,
         index: 1,
         info: {
           conflictingSpecimenSubmitterIds: ['SP12'],
-          msg: `${ClinicalInfoFieldsEnum.survival_time} can't be less than a specimen's acquistion time`,
           donorSubmitterId: 'AB3',
           value: '522',
         },


### PR DESCRIPTION
**Description of changes**

Move error message text into Clinical codebase, instead of passing data and filling this in at the gateway level.

This updates the error type for everything after the file checks, adding a message property. 

The error messages themselves are constructed through a method in a dedicated file for the messages so that the text isn't spread throughout the codebase.

Some validations had to be updated so that they can fetch the parameters desired for the error messages. The tests that use these tests were all corrected to use the suitable sinon method stubs.

**Type of Change**

- [ ] Bug
- [ ] Refactor
- [X] New Feature

**Checklist before requesting review:**

- [X] Check branch (code change PRs go to `develop` not master)
- [X] Manual testing
- [X] Regression tests completed and passing (double check number of tests).
- [X] Spelling has been checked.
- [X] Updated swagger docs accordingly (check it's still valid)
