### PR TITLE
🐛 Correct ID_NOT_REGISTERED error text

### DIFF
--- a/src/submission/submission-error-messages.ts
+++ b/src/submission/submission-error-messages.ts
@@ -21,7 +21,7 @@ const ERROR_MESSAGES: { [key: string]: (errorData: any) => string } = {
   NEW_SAMPLE_ID_CONFLICT: () =>
     'You are trying to register the same sample either with multiple donors, specimens or rows. Samples can only be registered once to a single donor and specimen.',
   ID_NOT_REGISTERED: errorData =>
-    `${errorData.info.value} has not yet been registered. Please register here before submitting clinical data for this identifier.`,
+    `${errorData.info.value} has not yet been registered. Please register samples before submitting clinical data for this identifier.`,
   CONFLICTING_TIME_INTERVAL: () =>
     'survival_time cannot be less than Specimen acquisition_interval.',
   NOT_ENOUGH_INFO_TO_VALIDATE: errorData =>

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -773,7 +773,7 @@ describe('Submission Api', () => {
                         value: 'ICGC_0001',
                       },
                       message:
-                        'ICGC_0001 has not yet been registered. Please register here before submitting clinical data for this identifier.',
+                        'ICGC_0001 has not yet been registered. Please register samples before submitting clinical data for this identifier.',
                       index: 0,
                     },
                   ]);

--- a/test/unit/submission/validation.spec.ts
+++ b/test/unit/submission/validation.spec.ts
@@ -37,8 +37,7 @@ const programInvalidErr: SubmissionValidationError = {
     sampleSubmitterId: 'AM1',
     value: 'PEM-CA',
   },
-  message:
-    'Program ID does not match. Please include the correct Program ID.',
+  message: 'Program ID does not match. Please include the correct Program ID.',
   type: DataValidationErrors.INVALID_PROGRAM_ID,
 };
 const specimenMutatedErr: SubmissionValidationError = {
@@ -1122,7 +1121,7 @@ describe('data-validator', () => {
       );
       const specimenIdErr: SubmissionValidationError = {
         fieldName: FieldsEnum.submitter_specimen_id,
-        message: `SP2 has not yet been registered. Please register here before submitting clinical data for this identifier.`,
+        message: `SP2 has not yet been registered. Please register samples before submitting clinical data for this identifier.`,
         type: DataValidationErrors.ID_NOT_REGISTERED,
         index: 0,
         info: {
@@ -1133,7 +1132,7 @@ describe('data-validator', () => {
       const donorIdErr: SubmissionValidationError = {
         fieldName: FieldsEnum.submitter_donor_id,
         message:
-          'AB2 has not yet been registered. Please register here before submitting clinical data for this identifier.',
+          'AB2 has not yet been registered. Please register samples before submitting clinical data for this identifier.',
         type: DataValidationErrors.ID_NOT_REGISTERED,
         index: 1,
         info: {


### PR DESCRIPTION
**Description of changes**

Makes the error text correct:

`Please register samples before submitting clinical data for this identifier.`