### PR TITLE
Feat/clear submission if empty

### DIFF
--- a/src/submission/submission-repo.ts
+++ b/src/submission/submission-repo.ts
@@ -109,12 +109,12 @@ export const submissionRepository: ClinicalSubmissionRepository = {
   ): Promise<DeepReadonly<ActiveClinicalSubmission> | undefined> {
     try {
       if (_.has(updatingFields, 'clinicalEntities') && _.isEmpty(updatingFields.clinicalEntities)) {
-        await ActiveSubmissionModel.findOneAndDelete({ programId: programId });
+        await ActiveSubmissionModel.findOneAndDelete({ programId, version });
         return undefined;
       } else {
         const newVersion = uuid();
         const updated = await ActiveSubmissionModel.findOneAndUpdate(
-          { programId: programId, version: version },
+          { programId, version },
           { ...updatingFields, version: newVersion },
           { new: true },
         );

--- a/src/submission/submission-repo.ts
+++ b/src/submission/submission-repo.ts
@@ -108,7 +108,7 @@ export const submissionRepository: ClinicalSubmissionRepository = {
     updatingFields: DeepReadonly<ActiveClinicalSubmission>,
   ): Promise<DeepReadonly<ActiveClinicalSubmission> | undefined> {
     try {
-      if (_.isEmpty(updatingFields.clinicalEntities)) {
+      if (_.has(updatingFields, 'clinicalEntities') && _.isEmpty(updatingFields.clinicalEntities)) {
         await ActiveSubmissionModel.findOneAndDelete({ programId: programId });
         return undefined;
       } else {

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -205,22 +205,24 @@ export namespace operations {
       );
     } else {
       // Update clinical entities from the active submission
-      const updatedClinicalEntites: ClinicalEntities = {};
+      const updatedClinicalEntities: ClinicalEntities = {};
       if (command.fileType !== 'all') {
         for (const clinicalType in activeSubmission.clinicalEntities) {
           if (clinicalType !== command.fileType) {
-            updatedClinicalEntites[clinicalType] = {
+            updatedClinicalEntities[clinicalType] = {
               ...activeSubmission.clinicalEntities[clinicalType],
               ...emptyStats,
             };
           }
         }
       }
+      if (_.isEmpty(updatedClinicalEntities)) {
+      }
       const newActiveSubmission: ActiveClinicalSubmission = {
         programId: command.programId,
         state: SUBMISSION_STATE.OPEN,
         version: '', // version is irrelevant here, repo will set it
-        clinicalEntities: updatedClinicalEntites,
+        clinicalEntities: updatedClinicalEntities,
         updatedBy: command.updater,
       };
       // insert into database

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -216,8 +216,6 @@ export namespace operations {
           }
         }
       }
-      if (_.isEmpty(updatedClinicalEntities)) {
-      }
       const newActiveSubmission: ActiveClinicalSubmission = {
         programId: command.programId,
         state: SUBMISSION_STATE.OPEN,

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -738,7 +738,7 @@ describe('Submission Api', () => {
           done();
         });
     });
-    it.only('should clear active submission if there are upload errors that cause clinicalEntities to be empty', async () => {
+    it('should clear active submission if there are upload errors that cause clinicalEntities to be empty', async () => {
       const SUBMISSION = {
         state: SUBMISSION_STATE.VALID,
         programId: 'ABCD-EF',
@@ -1020,7 +1020,7 @@ describe('Submission Api', () => {
           res.should.have.status(409);
         });
     });
-    it.only('should return 200 when clear all is completed, and have no active submission for this program in the DB', async () => {
+    it('should return 200 when clear all is completed, and have no active submission for this program in the DB', async () => {
       await uploadSubmission();
       return chai
         .request(app)
@@ -1080,7 +1080,7 @@ describe('Submission Api', () => {
           chai.expect(dbRead[0].state).to.be.equal(SUBMISSION_STATE.OPEN);
         });
     });
-    it.only('should clear active submission record if all data is cleared', async () => {
+    it('should clear active submission record if all data is cleared', async () => {
       const SUBMISSION = {
         state: SUBMISSION_STATE.VALID,
         programId: 'ABCD-EF',

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -1057,29 +1057,6 @@ describe('Submission Api', () => {
           chai.expect(dbRead[0].clinicalEntities.specimen).to.exist;
         });
     });
-    it('should set the active submission state to OPEN', async () => {
-      const SUBMISSION = {
-        state: SUBMISSION_STATE.VALID,
-        programId: 'ABCD-EF',
-        version: 'asdf',
-        clinicalEntities: { donor: [{ submitterId: 123 }] },
-      };
-
-      await insertData(dburl, 'activesubmissions', SUBMISSION);
-      return chai
-        .request(app)
-        .delete(`/submission/program/ABCD-EF/clinical/asdf/all`)
-        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
-        .then(async (res: any) => {
-          res.should.have.status(200);
-          res.body.state.should.equal(SUBMISSION_STATE.OPEN);
-
-          const dbRead = await findInDb(dburl, 'activesubmissions', {
-            programId: 'ABCD-EF',
-          });
-          chai.expect(dbRead[0].state).to.be.equal(SUBMISSION_STATE.OPEN);
-        });
-    });
     it('should clear active submission record if all data is cleared', async () => {
       const SUBMISSION = {
         state: SUBMISSION_STATE.VALID,
@@ -1372,7 +1349,7 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .then(async (res: any) => {
           res.should.have.status(200);
-          res.body.should.eql({});
+          res.body.should.be.empty;
           await assertDbCollectionEmpty(dburl, 'activesubmissions');
           const [updatedDonor] = await findInDb(dburl, 'donors', {
             programId: programId,

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -738,6 +738,33 @@ describe('Submission Api', () => {
           done();
         });
     });
+    it.only('should clear active submission if there are upload errors that cause clinicalEntities to be empty', async () => {
+      const SUBMISSION = {
+        state: SUBMISSION_STATE.VALID,
+        programId: 'ABCD-EF',
+        version: 'asdf',
+        clinicalEntities: { donor: [{ submitterId: 123 }] },
+      };
+
+      await insertData(dburl, 'activesubmissions', SUBMISSION);
+      const files: Buffer[] = [];
+      try {
+        files.push(fs.readFileSync(__dirname + '/donor.invalid.tsv'));
+      } catch (err) {}
+      await chai
+        .request(app)
+        // data base is empty so ID shouldn't exist
+        .post('/submission/program/ABCD-EF/clinical/upload')
+        .auth(JWT_ABCDEF, { type: 'bearer' })
+        .attach('clinicalFiles', files[0], 'donor.invalid.tsv');
+
+      const dbRead = await findInDb(dburl, 'activesubmissions', {
+        programId: 'ABCD-EF',
+      });
+      chai
+        .expect(dbRead.length, 'There should be no active submission for this program')
+        .to.equal(0);
+    });
   });
 
   describe('clinical-submission: validate', function() {
@@ -993,7 +1020,7 @@ describe('Submission Api', () => {
           res.should.have.status(409);
         });
     });
-    it('should return 200 when clear all is completed, and have no clinicalEntities in DB', async () => {
+    it.only('should return 200 when clear all is completed, and have no active submission for this program in the DB', async () => {
       await uploadSubmission();
       return chai
         .request(app)
@@ -1001,20 +1028,17 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .then(async (res: any) => {
           res.should.have.status(200);
-          chai.expect(
-            res.body.clinicalEntities,
-            'Response should have empty clinicalEntities object',
-          ).to.be.empty;
+          chai.expect(res.body, 'Response should be empty object').to.be.empty;
 
           const dbRead = await findInDb(dburl, 'activesubmissions', {
             programId: 'ABCD-EF',
           });
-          chai.expect(
-            dbRead[0].clinicalEntities,
-            'DB Record for Active Submission should hae empty clincialEntities',
-          ).to.be.empty;
+          chai
+            .expect(dbRead.length, 'There should be no active submission for this program')
+            .to.equal(0);
         });
     });
+
     it('should return 200 when clear donor is completed, have specimen in clinicalEntities but no donor', async () => {
       await uploadSubmission();
       return chai
@@ -1054,6 +1078,29 @@ describe('Submission Api', () => {
             programId: 'ABCD-EF',
           });
           chai.expect(dbRead[0].state).to.be.equal(SUBMISSION_STATE.OPEN);
+        });
+    });
+    it.only('should clear active submission record if all data is cleared', async () => {
+      const SUBMISSION = {
+        state: SUBMISSION_STATE.VALID,
+        programId: 'ABCD-EF',
+        version: 'asdf',
+        clinicalEntities: { donor: [{ submitterId: 123 }] },
+      };
+
+      await insertData(dburl, 'activesubmissions', SUBMISSION);
+      return chai
+        .request(app)
+        .delete(`/submission/program/ABCD-EF/clinical/asdf/donor`)
+        .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
+        .then(async (res: any) => {
+          res.should.have.status(200);
+          res.body.should.be.empty;
+
+          const dbRead = await findInDb(dburl, 'activesubmissions', {
+            programId: 'ABCD-EF',
+          });
+          chai.expect(dbRead.length).to.equal(0);
         });
     });
   });


### PR DESCRIPTION
**Description of changes**

Any Active Submission update that clears all clinicalEntities will now remove the entire active submission.

This is tested working for upload with errors, clear, and clear all.

**Type of Change**

- [ ] Bug
- [ ] Refactor
- [x] New Feature

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
