### PR TITLE
Ensure Clear Active Submission returns json

### DIFF
--- a/src/submission/submission-api.ts
+++ b/src/submission/submission-api.ts
@@ -168,7 +168,8 @@ class SubmissionController {
       fileType,
       updater,
     });
-    return res.status(200).send(updatedSubmission);
+    // Handle case where submission was cleared and is now undefined
+    return res.status(200).send(updatedSubmission || {});
   }
 
   @HasProgramWriteAccess((req: Request) => req.params.programId)

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -1028,7 +1028,8 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .then(async (res: any) => {
           res.should.have.status(200);
-          chai.expect(res.body, 'Response should be empty object').to.be.empty;
+          chai.expect(res.text, 'Response should be empty object').to.equal('{}');
+          chai.expect(res.type, 'Response should be json type').to.equal('application/json');
 
           const dbRead = await findInDb(dburl, 'activesubmissions', {
             programId: 'ABCD-EF',
@@ -1072,7 +1073,8 @@ describe('Submission Api', () => {
         .auth(JWT_CLINICALSVCADMIN, { type: 'bearer' })
         .then(async (res: any) => {
           res.should.have.status(200);
-          res.body.should.be.empty;
+          chai.expect(res.text, 'Response should be empty object').to.equal('{}');
+          chai.expect(res.type, 'Response should be json type').to.equal('application/json');
 
           const dbRead = await findInDb(dburl, 'activesubmissions', {
             programId: 'ABCD-EF',


### PR DESCRIPTION
**Description of changes**

Clearing submission changes from yesterday are resulting in gateway crashes on clear all or on clear file when the submission becomes empty. This updates the test to ensure we get the correct empty object response with valid json format from the clear submission service.

**Type of Change**

- [X] Bug
- [ ] Refactor
- [ ] New Feature

**Checklist before requesting review:**

- [X] Check branch (code change PRs go to `develop` not master)
- [X] Manual testing
- [X] Regression tests completed and passing (double check number of tests).
- [X] Spelling has been checked.
- [X] Updated swagger docs accordingly (check it's still valid)
