### PR TITLE
Fix/specimen validation bug

### DIFF
--- a/src/submission/validation-clinical/specimen.ts
+++ b/src/submission/validation-clinical/specimen.ts
@@ -105,17 +105,20 @@ const getDataFromDonorRecordOrDonor = (
   let missingDonorFields: string[] = [];
   let donorVitalStatus: string = '';
   let donorSurvivalTime: number = NaN;
-  const donorDataSource = donor.clinicalInfo;
+  const donorDataSource = donor.clinicalInfo || {};
 
-  if (!donorDataSource) {
+  if (_.isEmpty(donorDataSource)) {
     missingDonorFields = [DonorFieldsEnum.vital_status, DonorFieldsEnum.survival_time];
   } else {
-    donorVitalStatus = donorDataSource[DonorFieldsEnum.vital_status] as string;
+    donorVitalStatus = (donorDataSource[DonorFieldsEnum.vital_status] as string) || '';
     donorSurvivalTime = Number(donorDataSource[DonorFieldsEnum.survival_time]) || NaN;
 
-    if (isEmptyString(donorVitalStatus)) missingDonorFields.push(DonorFieldsEnum.vital_status);
-    if (donorVitalStatus.toString().toLowerCase() === 'deceased' && isNaN(donorSurvivalTime))
+    if (isEmptyString(donorVitalStatus)) {
+      missingDonorFields.push(DonorFieldsEnum.vital_status);
+    }
+    if (donorVitalStatus.toString().toLowerCase() === 'deceased' && isNaN(donorSurvivalTime)) {
       missingDonorFields.push(DonorFieldsEnum.survival_time);
+    }
   }
 
   if (missingDonorFields.length > 0) {

--- a/src/submission/validation-clinical/specimen.ts
+++ b/src/submission/validation-clinical/specimen.ts
@@ -114,7 +114,8 @@ const getDataFromDonorRecordOrDonor = (
     donorSurvivalTime = Number(donorDataSource[DonorFieldsEnum.survival_time]) || NaN;
 
     if (isEmptyString(donorVitalStatus)) missingDonorFields.push(DonorFieldsEnum.vital_status);
-    if (isNaN(donorSurvivalTime)) missingDonorFields.push(DonorFieldsEnum.survival_time);
+    if (donorVitalStatus.toString().toLowerCase() === 'deceased' && isNaN(donorSurvivalTime))
+      missingDonorFields.push(DonorFieldsEnum.survival_time);
   }
 
   if (missingDonorFields.length > 0) {

--- a/test/unit/submission/stubs.ts
+++ b/test/unit/submission/stubs.ts
@@ -199,7 +199,9 @@ export const stubs = {
       submitterId: 'AB2',
       programId: 'PEME-CA',
       donorId: 10,
-      clinicalInfo: {},
+      clinicalInfo: {
+        [DonorFieldsEnum.vital_status]: 'deceased',
+      },
       gender: 'Female',
       specimens: [
         {

--- a/test/unit/submission/validation.spec.ts
+++ b/test/unit/submission/validation.spec.ts
@@ -1314,7 +1314,7 @@ describe('data-validator', () => {
         {
           [SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB2',
           [SampleRegistrationFieldsEnum.program_id]: 'PEME-CA',
-          [SampleRegistrationFieldsEnum.submitter_specimen_id]: 'SP13',
+          [SampleRegistrationFieldsEnum.submitter_specimen_id]: 'SP1',
           [SpecimenFieldsEnum.specimen_acquisition_interval]: 5020,
           index: 0,
         },
@@ -1324,11 +1324,14 @@ describe('data-validator', () => {
         .validateSubmissionData({ AB1: submittedAB1Records }, { AB1: existingDonorAB1Mock })
         .catch(err => fail(err));
 
-      // donor is alive so should skip time interval validation
+      // donor is alive so should have no time interval validation errors
       chai.expect(result[ClinicalEntitySchemaNames.DONOR].dataErrors.length).to.eq(0);
+      chai.expect(result[ClinicalEntitySchemaNames.SPECIMEN].dataErrors.length).to.eq(0);
     });
     it('should detect not enough info to validate specimen file', async () => {
-      const existingDonorMock: Donor = stubs.validation.existingDonor01();
+      const existingDonorAB1Mock: Donor = stubs.validation.existingDonor01();
+      const existingDonorAB2Mock: Donor = stubs.validation.existingDonor06();
+      // Donor AB1 has no clinical info
       const newDonorAB1Records = {};
       ClinicalSubmissionRecordsOperations.addRecord(
         ClinicalEntitySchemaNames.SPECIMEN,
@@ -1350,12 +1353,27 @@ describe('data-validator', () => {
           index: 1,
         },
       );
+      // Donor AB2 here has clinicalInfo where vital_status===deceased but no survival_time is given
+      const newDonorAB2Records = {};
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.SPECIMEN,
+        newDonorAB2Records,
+        {
+          [SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB2',
+          [SampleRegistrationFieldsEnum.submitter_specimen_id]: 'SP1',
+          [SpecimenFieldsEnum.specimen_acquisition_interval]: 200,
+          index: 2,
+        },
+      );
 
       const result = await dv
-        .validateSubmissionData({ AB1: newDonorAB1Records }, { AB1: existingDonorMock })
+        .validateSubmissionData(
+          { AB1: newDonorAB1Records, AB2: newDonorAB2Records },
+          { AB1: existingDonorAB1Mock, AB2: existingDonorAB2Mock },
+        )
         .catch((err: any) => fail(err));
 
-      const specimenIdErr1: SubmissionValidationError = {
+      const specimenMisisngDonorAB1FieldsErr: SubmissionValidationError = {
         fieldName: SpecimenFieldsEnum.specimen_acquisition_interval,
         message: `[specimen_acquisition_interval] requires [donor.vital_status], [donor.survival_time] in order to complete validation.  Please upload data for all fields in this clinical data submission.`,
         type: DataValidationErrors.NOT_ENOUGH_INFO_TO_VALIDATE,
@@ -1370,23 +1388,28 @@ describe('data-validator', () => {
         },
       };
 
-      const specimenIdErr2: SubmissionValidationError = {
+      const specimenMissingDonorAB2FieldErr: SubmissionValidationError = {
         fieldName: SpecimenFieldsEnum.specimen_acquisition_interval,
-        message: `[specimen_acquisition_interval] requires [donor.vital_status], [donor.survival_time] in order to complete validation.  Please upload data for all fields in this clinical data submission.`,
+        message: `[specimen_acquisition_interval] requires [donor.survival_time] in order to complete validation.  Please upload data for all fields in this clinical data submission.`,
         type: DataValidationErrors.NOT_ENOUGH_INFO_TO_VALIDATE,
-        index: 1,
+        index: 2,
         info: {
-          donorSubmitterId: 'AB1',
+          donorSubmitterId: 'AB2',
           value: 200,
-          missingField: [
-            ClinicalEntitySchemaNames.DONOR + '.' + DonorFieldsEnum.vital_status,
-            ClinicalEntitySchemaNames.DONOR + '.' + DonorFieldsEnum.survival_time,
-          ],
+          missingField: [ClinicalEntitySchemaNames.DONOR + '.' + DonorFieldsEnum.survival_time],
         },
       };
-      chai.expect(result.specimen.dataErrors.length).to.eq(2);
-      chai.expect(result.specimen.dataErrors).to.deep.include(specimenIdErr1);
-      chai.expect(result.specimen.dataErrors).to.deep.include(specimenIdErr2);
+
+      chai.expect(result.specimen.dataErrors.length).to.eq(3);
+
+      chai
+        .expect(result.specimen.dataErrors)
+        .to.deep.include({ ...specimenMisisngDonorAB1FieldsErr, index: 0 });
+      chai
+        .expect(result.specimen.dataErrors)
+        .to.deep.include({ ...specimenMisisngDonorAB1FieldsErr, index: 1 });
+
+      chai.expect(result.specimen.dataErrors).to.deep.include(specimenMissingDonorAB2FieldErr);
     });
   });
 

--- a/test/unit/submission/validation.spec.ts
+++ b/test/unit/submission/validation.spec.ts
@@ -1295,7 +1295,7 @@ describe('data-validator', () => {
       chai.expect(errors.donor.dataErrors.length).to.eq(1);
       chai.expect(errors.donor.dataErrors[0]).to.deep.include(donorSurvivalTimeErr);
     });
-    it.only('should validate time intervals between alive donor and specimen', async () => {
+    it('should validate time intervals between alive donor and specimen', async () => {
       const existingDonorAB1Mock: Donor = stubs.validation.existingDonor01();
       const submittedAB1Records = {};
       ClinicalSubmissionRecordsOperations.addRecord(


### PR DESCRIPTION
**Description of changes**

This fixes a bug where specimen submission was saying error when donor clinicalInfo had `vital_status===Alive`

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
