### PR TITLE
update notEmpty to consider empty object

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,7 +115,7 @@ export namespace MongooseUtils {
 // type gaurd to filter out undefined and null
 // https://stackoverflow.com/questions/43118692/typescript-filter-out-nulls-from-an-array
 export function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
-  return value !== null && value !== undefined;
+  return value !== null && value !== undefined && !_.isEmpty(value);
 }
 
 export function isString(value: any): value is string {

--- a/test/integration/submission/stub-schema.json
+++ b/test/integration/submission/stub-schema.json
@@ -38,6 +38,40 @@
               }
             }
           }
+        ],
+        [
+          "specimen.anatomic_location_of_specimen_collection",
+          {
+            "left": {
+              "description": "Anatomic location of a specimen when it was collected.",
+              "name": "anatomic_location_of_specimen_collection",
+              "restrictions": {
+                "codeList": ["Muscle", "Other", "Wrist"],
+                "required": true
+              },
+              "valueType": "string"
+            },
+            "right": {
+              "description": "Anatomic location of a specimen when it was collected.",
+              "name": "anatomic_location_of_specimen_collection",
+              "restrictions": {
+                "codeList": ["Muscle", "Wrist"],
+                "required": true
+              },
+              "valueType": "string"
+            },
+            "diff": {
+              "restrictions": {
+                "codeList": {
+                  "type": "updated",
+                  "data": {
+                    "added": [],
+                    "deleted": ["Other"]
+                  }
+                }
+              }
+            }
+          }
         ]
       ]
     }
@@ -1784,7 +1818,7 @@
               "valueType": "string",
               "restrictions": {
                 "required": true,
-                "codeList": ["Muscle", "Other", "Wrist"]
+                "codeList": ["Muscle", "Wrist"]
               }
             },
             {

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -475,14 +475,12 @@ describe('Submission Api', () => {
         .end(async (err: any, res: any) => {
           try {
             await assertUploadOKRegistrationCreated(res, dburl);
-            chai
-              .expect(res.body.registration.stats.newSampleIds)
-              .to.deep.eq([
-                { submitterId: 'sm123-4', rowNumbers: [0] },
-                { submitterId: 'sm123-5', rowNumbers: [1] },
-                { submitterId: 'sm123-6', rowNumbers: [2] },
-                { submitterId: 'sm123-7', rowNumbers: [3] },
-              ]);
+            chai.expect(res.body.registration.stats.newSampleIds).to.deep.eq([
+              { submitterId: 'sm123-4', rowNumbers: [0] },
+              { submitterId: 'sm123-5', rowNumbers: [1] },
+              { submitterId: 'sm123-6', rowNumbers: [2] },
+              { submitterId: 'sm123-7', rowNumbers: [3] },
+            ]);
             const reg1Id = res.body.registration._id;
             chai
               .request(app)
@@ -1822,11 +1820,22 @@ describe('Submission Api', () => {
         programId,
         clinicalInfo: {
           program_id: 'ABCD-EF',
-          vital_status: 'Unknown',
+          vital_status: 'Alive',
           cause_of_death: 'Died of cancer',
           submitter_donor_id: 'ICGC_0002',
           survival_time: 67,
         },
+        specimens: [
+          {
+            samples: [{ sampleType: 'Total RNA', submitterId: 'sm123-2', sampleId: 610001 }],
+            clinicalInfo: {},
+            specimenTissueSource: 'Saliva',
+            tumourNormalDesignation: 'Tumour',
+            specimenType: 'Primary tumour',
+            submitterId: 'sub-sp-pacaau-124',
+            specimenId: 210001,
+          },
+        ],
       });
 
       this.beforeEach(async () => {
@@ -1838,7 +1847,7 @@ describe('Submission Api', () => {
       });
 
       // very simple smoke test of the migration to be expanded along developement
-      it('should update the schema ', async () => {
+      it('should update the schema - happy path', async () => {
         await chai
           .request(app)
           .patch('/submission/schema?sync=true')
@@ -1873,6 +1882,7 @@ describe('Submission Api', () => {
               throw new Error('migration in db with no id');
             }
             migrations[0]._id.toString().should.eq(migrationId);
+            migrations[0].invalidDonorsErrors.length.should.eq(0);
           });
       });
 


### PR DESCRIPTION
**Description of changes**

- add empty object check in addition to null and undefined
- also updated migration test to check that there are no invalid donor errors

This bug never occurred before because migration schema validation only runs if there are breaking changes for a clinical entity schema, which never happened before.

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
