### PR TITLE
change already registered stat to be for samples

### DIFF
--- a/src/clinical/clinical-service.ts
+++ b/src/clinical/clinical-service.ts
@@ -2,7 +2,6 @@ import { donorDao, DONOR_FIELDS } from './donor-repo';
 import { Errors } from '../utils';
 import { Sample, Donor, SchemaMetadata } from './clinical-entities';
 import { DeepReadonly } from 'deep-freeze';
-import * as schmeaManager from '../submission/schema/schema-manager';
 import _ from 'lodash';
 
 export async function updateDonorSchemaMetadata(

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -694,10 +694,10 @@ export namespace operations {
       const existingSample = existingSpecimen.samples.find(
         sa => sa.submitterId === nd.sampleSubmitterId,
       );
-      if (!existingSample) return addNewSampleToStats(stats, nd, index);
 
+      if (!existingSample) return addNewSampleToStats(stats, nd, index);
       // otherwise it's already registered record
-      addRowNumberToStats(stats.alreadyRegistered, nd.donorSubmitterId, index);
+      addRowNumberToStats(stats.alreadyRegistered, nd.sampleSubmitterId, index);
       return;
     });
 

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -475,12 +475,14 @@ describe('Submission Api', () => {
         .end(async (err: any, res: any) => {
           try {
             await assertUploadOKRegistrationCreated(res, dburl);
-            chai.expect(res.body.registration.stats.newSampleIds).to.deep.eq([
-              { submitterId: 'sm123-4', rowNumbers: [0] },
-              { submitterId: 'sm123-5', rowNumbers: [1] },
-              { submitterId: 'sm123-6', rowNumbers: [2] },
-              { submitterId: 'sm123-7', rowNumbers: [3] },
-            ]);
+            chai
+              .expect(res.body.registration.stats.newSampleIds)
+              .to.deep.eq([
+                { submitterId: 'sm123-4', rowNumbers: [0] },
+                { submitterId: 'sm123-5', rowNumbers: [1] },
+                { submitterId: 'sm123-6', rowNumbers: [2] },
+                { submitterId: 'sm123-7', rowNumbers: [3] },
+              ]);
             const reg1Id = res.body.registration._id;
             chai
               .request(app)
@@ -505,6 +507,14 @@ describe('Submission Api', () => {
                         const reg2Id = res.body.registration._id;
                         chai.expect(reg2Id).to.not.eq(reg1Id);
                         chai.expect(res.body.registration.stats.newSampleIds).to.deep.eq([]);
+                        chai
+                          .expect(res.body.registration.stats.alreadyRegistered)
+                          .to.deep.eq([
+                            { submitterId: 'sm123-4', rowNumbers: [0] },
+                            { submitterId: 'sm123-5', rowNumbers: [1] },
+                            { submitterId: 'sm123-6', rowNumbers: [2] },
+                            { submitterId: 'sm123-7', rowNumbers: [3] },
+                          ]);
                         chai
                           .request(app)
                           .post(`/submission/program/ABCD-EF/registration/${reg2Id}/commit`)


### PR DESCRIPTION
**Description of changes**
The UI was using alreadyRegistered stat as part of total sample count, although it was intended at the time to be donor count. However it makes sense to be consistent and count samples since registration became sample registration not donor registration.

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
