### PR TITLE
Allow clinical to run >1 script

### DIFF
--- a/src/lectern-client/schema-entities.ts
+++ b/src/lectern-client/schema-entities.ts
@@ -60,7 +60,7 @@ export interface FieldDefinition {
   restrictions?: {
     codeList?: Array<string | number>;
     regex?: string;
-    script?: string;
+    script?: Array<string>;
     required?: boolean;
     range: {
       min?: number;

--- a/src/lectern-client/schema-entities.ts
+++ b/src/lectern-client/schema-entities.ts
@@ -60,7 +60,7 @@ export interface FieldDefinition {
   restrictions?: {
     codeList?: Array<string | number>;
     regex?: string;
-    script?: Array<string>;
+    script?: Array<string> | string;
     required?: boolean;
     range: {
       min?: number;

--- a/src/lectern-client/schema-functions.ts
+++ b/src/lectern-client/schema-functions.ts
@@ -475,7 +475,7 @@ namespace validation {
       (range.exclusiveMin !== undefined && value <= range.exclusiveMin) ||
       // bigger than max if defined ?
       (range.max !== undefined && value > range.max) ||
-      (range.exclusiveMax !== undefined && value >= range.exclusiveMax);
+        (range.exclusiveMax !== undefined && value >= range.exclusiveMax);
     return invalidRange;
   };
   const isInvalidEnumValue = (

--- a/src/lectern-client/schema-functions.ts
+++ b/src/lectern-client/schema-functions.ts
@@ -475,7 +475,7 @@ namespace validation {
       (range.exclusiveMin !== undefined && value <= range.exclusiveMin) ||
       // bigger than max if defined ?
       (range.max !== undefined && value > range.max) ||
-        (range.exclusiveMax !== undefined && value >= range.exclusiveMax);
+      (range.exclusiveMax !== undefined && value >= range.exclusiveMax);
     return invalidRange;
   };
   const isInvalidEnumValue = (
@@ -511,6 +511,14 @@ namespace validation {
       if (!field.restrictions || !field.restrictions.script) {
         throw new Error('called validation by script without script provided');
       }
+
+      // scripts should already be strings inside arrays, but ensure that they are to help transition between lectern versions
+      // checking for this can be removed in future versions of lectern (feb 2020)
+      const scripts =
+        typeof field.restrictions.script === 'string'
+          ? [field.restrictions.script]
+          : field.restrictions.script;
+
       const ctx = vm.createContext(sandbox);
 
       let result: {
@@ -521,7 +529,7 @@ namespace validation {
         message: '',
       };
 
-      for (const scriptString of field.restrictions.script) {
+      for (const scriptString of scripts) {
         const script = new vm.Script(scriptString);
         result = script.runInContext(ctx);
         /* Return the first script that's invalid. Otherwise result will be valid with message: 'ok'*/


### PR DESCRIPTION
**Description of changes**

- Instead of running one script, it loops through an array of scripts, breaking on the first one that returns an invalid result. 
- If somehow a string is still passed, it's placed inside an array first (backwards-compatibility) 
___
- I think the tsc linter reformatted some things too
- I think Jenkins is failing because of [npm being down ](https://status.npmjs.org/)

**Type of Change**

- [ ] Bug
- [ ] Refactor
- [x] New Feature

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
