### PR TITLE
update filters & remove extended field stats

### DIFF
--- a/src/clinical/clinical-entities.ts
+++ b/src/clinical/clinical-entities.ts
@@ -18,16 +18,16 @@ export interface Donor {
 
 export interface AggregateClinicalInfoStats {
   submittedCoreFields: number;
-  submittedExtendedFields: number;
+  submittedExtendedFields?: number;
   expectedCoreFields: number;
-  expectedExtendedFields: number;
+  expectedExtendedFields?: number;
 }
 
 export interface ClinicalInfoStats {
   submittedCoreFields: number;
-  submittedExtendedFields: number;
+  submittedExtendedFields?: number;
   expectedCoreFields: number;
-  expectedExtendedFields: number;
+  expectedExtendedFields?: number;
 }
 
 export interface SchemaMetadata {

--- a/src/submission/schema/schema-manager.ts
+++ b/src/submission/schema/schema-manager.ts
@@ -51,8 +51,8 @@ class SchemaManager {
   };
 
   getSchemasWithFields = (
-    schemaDefConstratint: object = {}, // k-v SchemaDefinition property constraints; e.g. { name: 'donor' }
-    fieldDefConstraint: object = {}, // k-v FieldDefinition property constraints; e.g. { restrictions: { required: true } }
+    schemaDefConstratint: object | Function = {}, // k-v SchemaDefinition property constraints; e.g. { name: 'donor' } or function executed on each schema def
+    fieldDefConstraint: object | Function = {}, // k-v FieldDefinition property constraints; e.g. { restrictions: { required: true } }  or function executed on each field def
   ): {
     name: string;
     fields: string[];

--- a/src/submission/submission-to-clinical/stat-calculator.ts
+++ b/src/submission/submission-to-clinical/stat-calculator.ts
@@ -16,9 +16,7 @@ import _ from 'lodash';
 
 const emptyStats: ClinicalInfoStats = {
   submittedCoreFields: 0,
-  submittedExtendedFields: 0,
   expectedCoreFields: 0,
-  expectedExtendedFields: 0,
 };
 
 // this function will reset stats and recalculate
@@ -98,9 +96,7 @@ const calcNewStats = (
 
   return {
     submittedCoreFields,
-    submittedExtendedFields: 0,
     expectedCoreFields: expectedCoreFields.length,
-    expectedExtendedFields: 0,
   };
 };
 
@@ -110,30 +106,22 @@ function calcAggregateStats(
   originalStats: ClinicalInfoStats,
 ): AggregateClinicalInfoStats {
   const currentSubmittedCoreFields = aggregatedStats?.submittedCoreFields || 0;
-  const currentSubmittedExtendedFields = aggregatedStats?.submittedExtendedFields || 0;
   const currentAvailableCoreFields = aggregatedStats?.expectedCoreFields || 0;
-  const currentAvailableExtendedFields = aggregatedStats?.expectedExtendedFields || 0;
 
   const updatedSubmittedCoreFields: number =
     currentSubmittedCoreFields - originalStats.submittedCoreFields + newStats.submittedCoreFields;
-  const updatedSubmittedExtendedFields: number =
-    currentSubmittedExtendedFields -
-    originalStats.submittedExtendedFields +
-    newStats.submittedExtendedFields;
   const updatedAvailableCoreFields: number =
     currentAvailableCoreFields - originalStats.expectedCoreFields + newStats.expectedCoreFields;
-  const updatedAvailableExtendedFields: number =
-    currentAvailableExtendedFields -
-    originalStats.expectedExtendedFields +
-    newStats.expectedExtendedFields;
 
   return {
     submittedCoreFields: updatedSubmittedCoreFields,
-    submittedExtendedFields: updatedSubmittedExtendedFields,
     expectedCoreFields: updatedAvailableCoreFields,
-    expectedExtendedFields: updatedAvailableExtendedFields,
   };
 }
+
+// meta fields have no validation in lectern so its possible that it is a string instead of boolean
+const fieldDefWithMetaCoreTruePredicate = (fieldDef: any) =>
+  fieldDef?.meta?.core?.toString().toLowerCase() === 'true';
 
 function getCoreFields(
   clinicalType: ClinicalEntitySchemaNames,
@@ -143,12 +131,12 @@ function getCoreFields(
     return (
       overrideSchema.schemas
         .find(s => s.name === clinicalType)
-        ?.fields.filter(f => f.meta?.core === true)
+        ?.fields.filter(fieldDefWithMetaCoreTruePredicate)
         .map(f => f.name) || []
     );
   }
   const clinicalSchemaDef = schemaManager
     .instance()
-    .getSchemasWithFields({ name: clinicalType }, { meta: { core: true } })[0];
+    .getSchemasWithFields({ name: clinicalType }, fieldDefWithMetaCoreTruePredicate)[0];
   return clinicalSchemaDef.fields || [];
 }

--- a/test/integration/submission/stub-schema.json
+++ b/test/integration/submission/stub-schema.json
@@ -338,7 +338,7 @@
               "description": "Interval of how long the donor has survived since primary diagnosis, in days.",
               "meta": {
                 "units": "days",
-                "core": true
+                "core": "true"
               },
               "name": "survival_time",
               "valueType": "integer"
@@ -4629,7 +4629,7 @@
               "description": "Interval of how long the donor has survived since primary diagnosis, in days.",
               "meta": {
                 "units": "days",
-                "core": true
+                "core": "true"
               },
               "name": "survival_time",
               "valueType": "integer"


### PR DESCRIPTION
**Description of changes**

- It looks like meta fields are not specifically typed in [lectern](https://github.com/overture-stack/lectern/blob/develop/src/config/MetaSchema.json#L2) so its possible to have meta.core="true" instead of Boolean `true`, so I updated to use a predicate instead of an object to do the filter
- also I thought about it and I think we shouldn't store extended field stats, that way when we do the migration after adding extended field calculation we will know what to look for (the missing extended stat field).


**Type of Change**

- [ ] Bug
- [x] Refactor
- [ ] New Feature

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
