### PR TITLE
Change the error message for an invalid file name

### DIFF
--- a/src/submission/submission-error-messages.ts
+++ b/src/submission/submission-error-messages.ts
@@ -59,7 +59,7 @@ const ERROR_MESSAGES: { [key: string]: (errorData: any) => string } = {
 const BATCH_ERROR_MESSAGES: Record<SubmissionBatchErrorTypes, (errorData: any) => string> = {
   [SubmissionBatchErrorTypes.TSV_PARSING_FAILED]: () => `Failed to parse the tsv file`,
   [SubmissionBatchErrorTypes.INVALID_FILE_NAME]: () =>
-    `Please retain the template file name and only append characters to the end. For example, sample_registration<_optional_extension>.tsv`,
+    `Improperly named files cannot be uploaded or validated. All files must start with the corresponding entity name and have the .tsv extension (e.g. donor<_optional_extension>.tsv).`,
   [SubmissionBatchErrorTypes.INCORRECT_SECTION]: () =>
     `Please upload this file in the Register Samples section.`,
   [SubmissionBatchErrorTypes.MULTIPLE_TYPED_FILES]: errorData =>

--- a/src/submission/submission-error-messages.ts
+++ b/src/submission/submission-error-messages.ts
@@ -58,8 +58,10 @@ const ERROR_MESSAGES: { [key: string]: (errorData: any) => string } = {
 
 const BATCH_ERROR_MESSAGES: Record<SubmissionBatchErrorTypes, (errorData: any) => string> = {
   [SubmissionBatchErrorTypes.TSV_PARSING_FAILED]: () => `Failed to parse the tsv file`,
-  [SubmissionBatchErrorTypes.INVALID_FILE_NAME]: () =>
-    `Improperly named files cannot be uploaded or validated. All files must start with the corresponding entity name and have the .tsv extension (e.g. donor<_optional_extension>.tsv).`,
+  [SubmissionBatchErrorTypes.INVALID_FILE_NAME]: (errorData: { isRegistration: Boolean }) => {
+    const exampleText = errorData.isRegistration ? 'sample_registration' : 'donor';
+    return `Improperly named files cannot be uploaded or validated. Please retain the template file name and only append characters to the end (e.g. ${exampleText}<_optional_extension>.tsv).`;
+  },
   [SubmissionBatchErrorTypes.INCORRECT_SECTION]: () =>
     `Please upload this file in the Register Samples section.`,
   [SubmissionBatchErrorTypes.MULTIPLE_TYPED_FILES]: errorData =>

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -867,12 +867,10 @@ export namespace operations {
     }
 
     if (mutableClinicalData.length > 0) {
-      const msg = expectedClinicalEntites.includes(ClinicalEntitySchemaNames.REGISTRATION)
-        ? `Improperly named files cannot be uploaded or validated. All files must start with the corresponding entity name and have the .tsv extension (e.g. sample_registration<_optional_extension>.tsv).`
-        : batchErrorMessage(SubmissionBatchErrorTypes.INVALID_FILE_NAME);
-
       dataToEntityMapErrors.push({
-        message: msg,
+        message: batchErrorMessage(SubmissionBatchErrorTypes.INVALID_FILE_NAME, {
+          isRegistration: expectedClinicalEntites.includes(ClinicalEntitySchemaNames.REGISTRATION),
+        }),
         batchNames: mutableClinicalData.map(data => data.batchName),
         code: SubmissionBatchErrorTypes.INVALID_FILE_NAME,
       });

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -867,8 +867,12 @@ export namespace operations {
     }
 
     if (mutableClinicalData.length > 0) {
+      const msg = expectedClinicalEntites.includes(ClinicalEntitySchemaNames.REGISTRATION)
+        ? `Improperly named files cannot be uploaded or validated. All files must start with the corresponding entity name and have the .tsv extension (e.g. sample_registration<_optional_extension>.tsv).`
+        : batchErrorMessage(SubmissionBatchErrorTypes.INVALID_FILE_NAME);
+
       dataToEntityMapErrors.push({
-        message: batchErrorMessage(SubmissionBatchErrorTypes.INVALID_FILE_NAME),
+        message: msg,
         batchNames: mutableClinicalData.map(data => data.batchName),
         code: SubmissionBatchErrorTypes.INVALID_FILE_NAME,
       });

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -250,7 +250,7 @@ const expectedDonorErrors = [
 ];
 
 const INVALID_FILENAME_ERROR =
-  'Improperly named files cannot be uploaded or validated. All files must start with the corresponding entity name and have the .tsv extension (e.g. donor<_optional_extension>.tsv).';
+  'Improperly named files cannot be uploaded or validated. Please retain the template file name and only append characters to the end (e.g. donor<_optional_extension>.tsv).';
 
 const clearCollections = async (dburl: string, collections: string[]) => {
   try {
@@ -627,7 +627,7 @@ describe('Submission Api', () => {
           try {
             res.should.have.status(422);
             res.body.batchErrors.should.deep.include({
-              message: `Improperly named files cannot be uploaded or validated. All files must start with the corresponding entity name and have the .tsv extension (e.g. sample_registration<_optional_extension>.tsv).`,
+              message: `Improperly named files cannot be uploaded or validated. Please retain the template file name and only append characters to the end (e.g. sample_registration<_optional_extension>.tsv).`,
               code: SubmissionBatchErrorTypes.INVALID_FILE_NAME,
               batchNames: ['thisIsARegistration.tsv'],
             });

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -250,7 +250,7 @@ const expectedDonorErrors = [
 ];
 
 const INVALID_FILENAME_ERROR =
-  'Please retain the template file name and only append characters to the end. For example, sample_registration<_optional_extension>.tsv';
+  'Improperly named files cannot be uploaded or validated. All files must start with the corresponding entity name and have the .tsv extension (e.g. donor<_optional_extension>.tsv).';
 
 const clearCollections = async (dburl: string, collections: string[]) => {
   try {

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -627,7 +627,7 @@ describe('Submission Api', () => {
           try {
             res.should.have.status(422);
             res.body.batchErrors.should.deep.include({
-              message: INVALID_FILENAME_ERROR,
+              message: `Improperly named files cannot be uploaded or validated. All files must start with the corresponding entity name and have the .tsv extension (e.g. sample_registration<_optional_extension>.tsv).`,
               code: SubmissionBatchErrorTypes.INVALID_FILE_NAME,
               batchNames: ['thisIsARegistration.tsv'],
             });


### PR DESCRIPTION
**Description of changes**

Changed the message for an invalid file name to these:

>Improperly named files cannot be uploaded or validated. Please retain the template file name >and only append characters to the end (e.g. donor<_optional_extension>.tsv).

>Improperly named files cannot be uploaded or validated. Please retain the template file name >and only append characters to the end (e.g. sample_registration<_optional_extension>.tsv).

**Type of Change**

- [ ] Bug
- [x] Refactor
- [ ] New Feature

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
