### PR TITLE
submission unique record check

### DIFF
--- a/src/submission/schema/schema-api.ts
+++ b/src/submission/schema/schema-api.ts
@@ -93,10 +93,11 @@ export const getTemplate = async (req: Request, res: Response) => {
   }
 
   const template = createTemplate(schema);
+
   return res
     .status(200)
     .contentType('text/tab-separated-values')
-    .attachment(`${schemaName}.tsv`)
+    .attachment(`${schemaName}_dictionary_v${schemasDictionary.version}.tsv`)
     .send(template);
 };
 
@@ -106,7 +107,7 @@ export const getAllTemplates = async (req: Request, res: Response) => {
   res
     .status(200)
     .contentType('application/zip')
-    .attachment('argo_clinical_templates.zip');
+    .attachment(`argo_submission_templates_v${schemasDictionary.version}.zip`);
 
   schemasDictionary.schemas
     .filter(s => s.name !== ClinicalEntitySchemaNames.REGISTRATION)

--- a/src/submission/submission-entities.ts
+++ b/src/submission/submission-entities.ts
@@ -372,18 +372,39 @@ export const BatchNameRegex: Record<ClinicalEntitySchemaNames, RegExp[]> = {
   [ClinicalEntitySchemaNames.HORMONE_THERAPY]: [/^hormone_therapy.*\.tsv$/],
 };
 
-// assumption: one field uniquely identifies a clinical type record in a batch of records
-export const ClinicalUniqueIndentifier: {
-  [clinicalType: string]: ClinicalFields;
-} = {
+// This needed to be added to differentiate between multiple or single fields for identifying
+type TypeEntitySchemaNameToIndenfiterType = {
+  [ClinicalEntitySchemaNames.DONOR]: ClinicalFields;
+  [ClinicalEntitySchemaNames.SPECIMEN]: ClinicalFields;
+  [ClinicalEntitySchemaNames.PRIMARY_DIAGNOSIS]: ClinicalFields;
+  [ClinicalEntitySchemaNames.FOLLOW_UP]: ClinicalFields;
+  [ClinicalEntitySchemaNames.TREATMENT]: ClinicalFields;
+  [ClinicalEntitySchemaNames.CHEMOTHERAPY]: ClinicalFields[];
+  [ClinicalEntitySchemaNames.RADIATION]: ClinicalFields[];
+  [ClinicalEntitySchemaNames.HORMONE_THERAPY]: ClinicalFields[];
+};
+
+export const ClinicalUniqueIdentifier: TypeEntitySchemaNameToIndenfiterType = {
   [ClinicalEntitySchemaNames.DONOR]: DonorFieldsEnum.submitter_donor_id,
   [ClinicalEntitySchemaNames.SPECIMEN]: SpecimenFieldsEnum.submitter_specimen_id,
   [ClinicalEntitySchemaNames.PRIMARY_DIAGNOSIS]: PrimaryDiagnosisFieldsEnum.submitter_donor_id,
   [ClinicalEntitySchemaNames.FOLLOW_UP]: FollowupFieldsEnum.submitter_follow_up_id,
   [ClinicalEntitySchemaNames.TREATMENT]: TreatmentFieldsEnum.submitter_treatment_id,
-  [ClinicalEntitySchemaNames.CHEMOTHERAPY]: ChemotherapyFieldsEnum.chemotherapy_drug_name,
-  [ClinicalEntitySchemaNames.RADIATION]: RadiationFieldsEnum.radiation_therapy_modality,
-  [ClinicalEntitySchemaNames.HORMONE_THERAPY]: HormoneTherapyFieldsEnum.hormone_therapy_drug_name,
+  [ClinicalEntitySchemaNames.CHEMOTHERAPY]: [
+    ChemotherapyFieldsEnum.submitter_donor_id,
+    ChemotherapyFieldsEnum.submitter_treatment_id,
+    ChemotherapyFieldsEnum.chemotherapy_drug_name,
+  ],
+  [ClinicalEntitySchemaNames.RADIATION]: [
+    RadiationFieldsEnum.submitter_donor_id,
+    RadiationFieldsEnum.submitter_treatment_id,
+    RadiationFieldsEnum.radiation_therapy_modality,
+  ],
+  [ClinicalEntitySchemaNames.HORMONE_THERAPY]: [
+    HormoneTherapyFieldsEnum.submitter_donor_id,
+    HormoneTherapyFieldsEnum.submitter_treatment_id,
+    HormoneTherapyFieldsEnum.hormone_therapy_drug_name,
+  ],
 };
 
 export interface ClinicalSubmissionRecordsByDonorIdMap {

--- a/src/submission/submission-error-messages.ts
+++ b/src/submission/submission-error-messages.ts
@@ -32,7 +32,8 @@ const ERROR_MESSAGES: { [key: string]: (errorData: any) => string } = {
     )}] in order to complete validation.  Please upload data for all fields in this clinical data submission.`,
   FOUND_IDENTICAL_IDS: errorData => {
     if (errorData.info.useAllRecordValues === true) return `This row is identical to another row`;
-    return `You are trying to submit the same [${errorData.fieldName}] in multiple rows. [${errorData.fieldName}] can only be submitted once per file.`;
+    const duplicateFieldNames = errorData.info.uniqueIdNames.join(', ') || '';
+    return `You are trying to submit the same [${duplicateFieldNames}] in multiple rows. [${duplicateFieldNames}] can only be submitted once per file.`;
   },
   CLINICAL_ENTITY_BELONGS_TO_OTHER_DONOR: errorData => {
     const clinicalType = _.lowerCase(errorData.info.clinicalType);

--- a/src/submission/submission-to-clinical/submission-to-clinical.ts
+++ b/src/submission/submission-to-clinical/submission-to-clinical.ts
@@ -20,7 +20,7 @@ import {
   SampleRegistrationFieldsEnum,
   SUBMISSION_STATE,
   ClinicalEntitySchemaNames,
-  ClinicalUniqueIndentifier,
+  ClinicalUniqueIdentifier,
   ClinicalTherapySchemaNames,
 } from '../submission-entities';
 
@@ -402,12 +402,17 @@ export function getClinicalEntitiesFromDonorBySchemaName(
 export function getSingleClinicalEntityFromDonorBySchemanName(
   donor: DeepReadonly<Donor>,
   clinicalEntityType: ClinicalEntitySchemaNames,
-  uniqueIdValue: string,
+  clinicalInfoRef: ClinicalInfo, // this function will use the values of the clinicalInfoRef that are needed to uniquely find a clinical info
 ): ClinicalInfo | undefined {
+  if (clinicalEntityType === ClinicalEntitySchemaNames.REGISTRATION) {
+    throw new Error('Sample_registration has no clincal info to return');
+  }
+  const uniqueIdNames: string[] = _.concat([] || ClinicalUniqueIdentifier[clinicalEntityType]);
+  const constraints: ClinicalInfo = {};
+  uniqueIdNames.forEach(idN => (constraints[idN] = clinicalInfoRef[idN]));
+
   const clinicalInfos = getClinicalEntitiesFromDonorBySchemaName(donor, clinicalEntityType);
-  return clinicalInfos.find(
-    ci => ci[ClinicalUniqueIndentifier[clinicalEntityType]] === uniqueIdValue,
-  );
+  return _(clinicalInfos).find(constraints);
 }
 
 export interface CreateDonorSampleDto {

--- a/src/submission/validation-clinical/specimen.ts
+++ b/src/submission/validation-clinical/specimen.ts
@@ -5,7 +5,7 @@ import {
   ClinicalEntitySchemaNames,
   DonorFieldsEnum,
   SpecimenFieldsEnum,
-  ClinicalUniqueIndentifier,
+  ClinicalUniqueIdentifier,
   DonorVitalStatusValues,
 } from '../submission-entities';
 import { DeepReadonly } from 'deep-freeze';
@@ -58,7 +58,7 @@ function getSpecimenFromDonor(
     existentDonor,
     ClinicalEntitySchemaNames.SPECIMEN,
     {
-      submitterId: specimenRecord[ClinicalUniqueIndentifier[ClinicalEntitySchemaNames.SPECIMEN]],
+      submitterId: specimenRecord[ClinicalUniqueIdentifier[ClinicalEntitySchemaNames.SPECIMEN]],
     },
   ) as DeepReadonly<Specimen>;
 

--- a/src/submission/validation-clinical/treatment.ts
+++ b/src/submission/validation-clinical/treatment.ts
@@ -4,7 +4,7 @@ import {
   TreatmentFieldsEnum,
   SubmittedClinicalRecord,
   DataValidationErrors,
-  ClinicalUniqueIndentifier,
+  ClinicalUniqueIdentifier,
   ClinicalTherapyType,
   ClinicalTherapySchemaNames,
 } from '../submission-entities';
@@ -83,7 +83,7 @@ function checkTherapyFileNeeded(
 }
 
 function getTreatment(treatmentRecord: SubmittedClinicalRecord, donor: DeepReadonly<Donor>) {
-  const idFieldName = ClinicalUniqueIndentifier[ClinicalEntitySchemaNames.TREATMENT];
+  const idFieldName = ClinicalUniqueIdentifier[ClinicalEntitySchemaNames.TREATMENT];
   const treatmentId = treatmentRecord[idFieldName];
 
   return getSingleClinicalObjectFromDonor(donor, ClinicalEntitySchemaNames.TREATMENT, {

--- a/test/integration/submission/radiation.invalid.tsv
+++ b/test/integration/submission/radiation.invalid.tsv
@@ -1,0 +1,3 @@
+program_id	submitter_donor_id	submitter_treatment_id	radiation_therapy_modality	application_form	radiation_therapy_fractions	radiation_therapy_dosage	anatomical_site_irradiated
+ABCD-EF	ICGC_0001	T_02	Photon	External	5	9	Abdomen
+ABCD-EF	ICGC_0001	T_02	Photon	External	5	9	Abdomen

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -31,6 +31,7 @@ import {
   SubmissionBatchErrorTypes,
   ClinicalEntitySchemaNames,
   DonorFieldsEnum,
+  ClinicalUniqueIdentifier,
 } from '../../../src/submission/submission-entities';
 import { TsvUtils } from '../../../src/utils';
 import { donorDao } from '../../../src/clinical/donor-repo';
@@ -200,7 +201,7 @@ const ABCD_REGISTRATION_DOC: ActiveRegistration = {
     },
   ],
 };
-const expectedDonorErrors = [
+const expectedDonorBatchSubmissionSchemaErrors = [
   {
     index: 1,
     type: 'FOUND_IDENTICAL_IDS',
@@ -209,10 +210,11 @@ const expectedDonorErrors = [
       donorSubmitterId: 'ICGC_0001',
       useAllRecordValues: false,
       conflictingRows: [2],
+      uniqueIdNames: [ClinicalUniqueIdentifier[ClinicalEntitySchemaNames.DONOR]],
     },
     message:
       'You are trying to submit the same [submitter_donor_id] in multiple rows. [submitter_donor_id] can only be submitted once per file.',
-    fieldName: SampleRegistrationFieldsEnum.submitter_donor_id,
+    fieldName: DonorFieldsEnum.submitter_donor_id,
   },
   {
     index: 2,
@@ -222,10 +224,11 @@ const expectedDonorErrors = [
       donorSubmitterId: 'ICGC_0001',
       useAllRecordValues: false,
       conflictingRows: [1],
+      uniqueIdNames: [ClinicalUniqueIdentifier[ClinicalEntitySchemaNames.DONOR]],
     },
     message:
       'You are trying to submit the same [submitter_donor_id] in multiple rows. [submitter_donor_id] can only be submitted once per file.',
-    fieldName: SampleRegistrationFieldsEnum.submitter_donor_id,
+    fieldName: DonorFieldsEnum.submitter_donor_id,
   },
   {
     index: 0,
@@ -246,6 +249,36 @@ const expectedDonorErrors = [
     },
     message: 'The value is not permissible for this field.',
     fieldName: DonorFieldsEnum.vital_status,
+  },
+];
+const expectedRadiationBatchSubmissionSchemaErrors = [
+  {
+    index: 0,
+    type: 'FOUND_IDENTICAL_IDS',
+    info: {
+      value: 'ICGC_0001',
+      donorSubmitterId: 'ICGC_0001',
+      useAllRecordValues: false,
+      conflictingRows: [1],
+      uniqueIdNames: ClinicalUniqueIdentifier[ClinicalEntitySchemaNames.RADIATION],
+    },
+    message:
+      'You are trying to submit the same [submitter_donor_id, submitter_treatment_id, radiation_therapy_modality] in multiple rows. [submitter_donor_id, submitter_treatment_id, radiation_therapy_modality] can only be submitted once per file.',
+    fieldName: DonorFieldsEnum.submitter_donor_id,
+  },
+  {
+    index: 1,
+    type: 'FOUND_IDENTICAL_IDS',
+    info: {
+      value: 'ICGC_0001',
+      donorSubmitterId: 'ICGC_0001',
+      useAllRecordValues: false,
+      conflictingRows: [0],
+      uniqueIdNames: ClinicalUniqueIdentifier[ClinicalEntitySchemaNames.RADIATION],
+    },
+    message:
+      'You are trying to submit the same [submitter_donor_id, submitter_treatment_id, radiation_therapy_modality] in multiple rows. [submitter_donor_id, submitter_treatment_id, radiation_therapy_modality] can only be submitted once per file.',
+    fieldName: DonorFieldsEnum.submitter_donor_id,
   },
 ];
 
@@ -715,9 +748,10 @@ describe('Submission Api', () => {
     });
 
     it('should return 422 if try to upload invalid tsv files', done => {
-      let file: Buffer;
+      const files: Buffer[] = [];
       try {
-        file = fs.readFileSync(__dirname + '/donor.invalid.tsv');
+        files.push(fs.readFileSync(__dirname + '/donor.invalid.tsv'));
+        files.push(fs.readFileSync(__dirname + '/radiation.invalid.tsv'));
       } catch (err) {
         return done(err);
       }
@@ -726,11 +760,15 @@ describe('Submission Api', () => {
         // data base is empty so ID shouldn't exist
         .post('/submission/program/ABCD-EF/clinical/upload')
         .auth(JWT_ABCDEF, { type: 'bearer' })
-        .attach('clinicalFiles', file, 'donor.invalid.tsv')
+        .attach('clinicalFiles', files[0], 'donor.invalid.tsv')
+        .attach('clinicalFiles', files[1], 'radiation.invalid.tsv')
         .end((err: any, res: any) => {
           res.should.have.status(207);
           res.body.submission.clinicalEntities.donor.schemaErrors.should.deep.eq(
-            expectedDonorErrors,
+            expectedDonorBatchSubmissionSchemaErrors,
+          );
+          res.body.submission.clinicalEntities.radiation.schemaErrors.should.deep.eq(
+            expectedRadiationBatchSubmissionSchemaErrors,
           );
           res.body.successful.should.deep.eq(false);
           done();

--- a/test/unit/submission/validation.spec.ts
+++ b/test/unit/submission/validation.spec.ts
@@ -12,7 +12,7 @@ import {
   DonorFieldsEnum,
   TreatmentFieldsEnum,
   FollowupFieldsEnum,
-  ClinicalUniqueIndentifier,
+  ClinicalUniqueIdentifier,
 } from '../../../src/submission/submission-entities';
 import { Donor } from '../../../src/clinical/clinical-entities';
 import { stubs } from './stubs';
@@ -1459,7 +1459,7 @@ describe('data-validator', () => {
         submissionRecordsMap,
         {
           [SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB1',
-          [ClinicalUniqueIndentifier[ClinicalEntitySchemaNames.TREATMENT]]: 'T_03',
+          [ClinicalUniqueIdentifier[ClinicalEntitySchemaNames.TREATMENT]]: 'T_03',
           index: 0,
         },
       );
@@ -1680,7 +1680,7 @@ describe('data-validator', () => {
         submissionRecordsMap,
         {
           [SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB1',
-          [ClinicalUniqueIndentifier[ClinicalEntitySchemaNames.FOLLOW_UP]]: 'FF123',
+          [ClinicalUniqueIdentifier[ClinicalEntitySchemaNames.FOLLOW_UP]]: 'FF123',
           some_field: 'asdasd',
           index: 0,
         },


### PR DESCRIPTION
**Description of changes**

added BatchRecordUniqueIdentifier which sort of extends on ClinicalUniqueIdentifier by adding multiple fields for the therapy types

the main changes are in:
- test/integration/submission/submission.spec.ts 
- src/submission/validation-clinical/validation.ts
- src/submission/submission-entities.ts
- src/submission/submission-error-messages.ts
- src/submission/schema/schema-api.ts

**Type of Change**

- [x] Bug
- [x] Refactor
- [ ] New Feature

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
