### PR TITLE
⬆️ update adm-zip to fix corrupt zips on mac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "argo-clinical",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -558,9 +558,9 @@
       }
     },
     "adm-zip": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
     },
     "ajv": {
       "version": "6.10.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@overturebio-stack/lectern-client": "1.1.0",
-    "adm-zip": "^0.4.13",
+    "adm-zip": "^0.4.16",
     "async": "^3.0.1",
     "bcrypt-nodejs": "^0.0.3",
     "bluebird": "^3.5.5",


### PR DESCRIPTION
- Upgraded adm-zip to 0.4.16, the latest version that's compatible with the @types library.
- Issue: ZIP downloads in gateway weren't opening in MacOS Catalina in Finder.
- Tested locally with Postman.