### PR TITLE
should not fail validation when specimen is uploaded without primary diagnosis

### DIFF
--- a/src/submission/validation-clinical/specimen.ts
+++ b/src/submission/validation-clinical/specimen.ts
@@ -237,9 +237,9 @@ const checkRequiredFields = (
       ClinicalEntitySchemaNames.PRIMARY_DIAGNOSIS,
       specimenRecord[entitySubmitterIdField] as string,
       mergedDonor,
-    ) as DeepReadonly<PrimaryDiagnosis>;
-
+    ) as DeepReadonly<PrimaryDiagnosis | undefined>;
     if (
+      // already checking primary diagnosis existence in checkRelatedEntityExists function
       primaryDiagnosisEntity &&
       isEmpty(specimenRecord[SpecimenFieldsEnum.pathological_tumour_staging_system]) &&
       isEmpty(

--- a/src/submission/validation-clinical/specimen.ts
+++ b/src/submission/validation-clinical/specimen.ts
@@ -240,6 +240,7 @@ const checkRequiredFields = (
     ) as DeepReadonly<PrimaryDiagnosis>;
 
     if (
+      primaryDiagnosisEntity &&
       isEmpty(specimenRecord[SpecimenFieldsEnum.pathological_tumour_staging_system]) &&
       isEmpty(
         primaryDiagnosisEntity.clinicalInfo[


### PR DESCRIPTION
**Description of changes**

<!-- Please add a brief description of the changes here. -->
This PR fixes validation failure when only specimen is uploaded without primary diagnosis being present, specimen validation logic should not fail if associated pd entity is not found. 

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code