### PR TITLE
feature to validate immunotherapy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ Add new entity in the following files:
 - update `test/integration/stub-schema.json` if a new schema is added
 - add a new sample tsv to `sampleFiles/clinical`
 
+Add submission validation for the new entity in the following files:
+
+- `src/submission/validation-clinical/index.ts`:
+
+```
+const availableValidators: { [k: string]: any } = {
+  [ClinicalEntitySchemaNames.DONOR]: donor,
+  [ClinicalEntitySchemaNames.SPECIMEN]: specimen,
+  [ClinicalEntitySchemaNames.PRIMARY_DIAGNOSIS]: primaryDiagnosis,
+  [ClinicalEntitySchemaNames.FOLLOW_UP]: follow_up,
+  [ClinicalEntitySchemaNames.NEW_ENTITY]: new_entity <--------- add here to trigger validation
+}
+```
+
 ## Debugging Notes:
 
 If file upload fails with the error `TypeError: Cannot read property 'readFile' of undefined`, make sure you are running Node 12+

--- a/src/submission/validation-clinical/index.ts
+++ b/src/submission/validation-clinical/index.ts
@@ -36,6 +36,7 @@ const availableValidators: { [k: string]: any } = {
   [ClinicalEntitySchemaNames.CHEMOTHERAPY]: therapy,
   [ClinicalEntitySchemaNames.RADIATION]: therapy,
   [ClinicalEntitySchemaNames.HORMONE_THERAPY]: therapy,
+  [ClinicalEntitySchemaNames.IMMUNOTHERAPY]: therapy,
 };
 
 export const submissionValidator = (clinicalType: string): any => {

--- a/src/submission/validation-clinical/therapy.ts
+++ b/src/submission/validation-clinical/therapy.ts
@@ -78,11 +78,11 @@ function checkTreatementHasCorrectTypeForTherapy(
 }
 
 function getTreatment(
-  chemoRecord: DeepReadonly<SubmittedClinicalRecord>,
+  therapyRecord: DeepReadonly<SubmittedClinicalRecord>,
   mergedDonor: Donor,
   errors: SubmissionValidationError[],
 ) {
-  const treatmentId = chemoRecord[TreatmentFieldsEnum.submitter_treatment_id];
+  const treatmentId = therapyRecord[TreatmentFieldsEnum.submitter_treatment_id];
   const treatment = getSingleClinicalObjectFromDonor(
     mergedDonor,
     ClinicalEntitySchemaNames.TREATMENT,
@@ -91,7 +91,7 @@ function getTreatment(
   if (!treatment || treatment.clinicalInfo === {}) {
     errors.push(
       utils.buildSubmissionError(
-        chemoRecord,
+        therapyRecord,
         DataValidationErrors.TREATMENT_ID_NOT_FOUND,
         TreatmentFieldsEnum.submitter_treatment_id,
       ),

--- a/test/integration/submission/stub_clinical_files/immunotherapy.tsv
+++ b/test/integration/submission/stub_clinical_files/immunotherapy.tsv
@@ -1,2 +1,2 @@
 program_id	submitter_donor_id	submitter_treatment_id	drug_rxnormcui	drug_name	immunotherapy_type
-ABCD-EF	ICGC_0001	T_02	423	drugA	Cell-based
+ABCD-EF	ICGC_0001	T_01	423	drugA	Cell-based

--- a/test/integration/submission/stub_clinical_files/immunotherapy_update.tsv
+++ b/test/integration/submission/stub_clinical_files/immunotherapy_update.tsv
@@ -1,2 +1,2 @@
 program_id	submitter_donor_id	submitter_treatment_id	drug_rxnormcui	drug_name	immunotherapy_type
-ABCD-EF	ICGC_0001	T_02	423	drugA	Immune checkpoint inhibitors
+ABCD-EF	ICGC_0001	T_01	423	drugA	Immune checkpoint inhibitors

--- a/test/integration/submission/stub_clinical_files/treatment.tsv
+++ b/test/integration/submission/stub_clinical_files/treatment.tsv
@@ -1,3 +1,5 @@
 program_id	submitter_donor_id	submitter_primary_diagnosis_id	submitter_treatment_id	treatment_type	age_at_consent_for_treatment	is_primary_treatment	treatment_start_interval	treatment_duration	therapeutic_intent	response_to_therapy
 ABCD-EF	ICGC_0001	P-1	T_02	chemotherapy|radiation therapy	99	Yes	5	6	Unknown	NED
 ABCD-EF	ICGC_0001	P-1	T_03	Hormonal Therapy	99	Yes	5	6	Unknown	NED
+ABCD-EF	ICGC_0001	P-1	T_01	Immunotherapy	99	Yes	5	6	Unknown	NED
+

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -185,6 +185,7 @@ describe('Submission Api', () => {
   after(async () => {
     await mongoose.disconnect();
     await mongoContainer.stop();
+    await mysqlContainer.stop();
   });
 
   describe('registration', function() {
@@ -1615,11 +1616,11 @@ describe('Submission Api', () => {
             .expect(updatedDonor.treatments?.[0].clinicalInfo[TreatmentFieldsEnum.treatment_type])
             .to.deep.eq(['Chemotherapy', 'Surgery']);
 
-          chai.expect(updatedDonor.treatments?.[0].therapies.length).to.eq(2);
+          chai.expect(updatedDonor.treatments?.[0].therapies.length).to.eq(1);
 
           chai.expect(updatedDonor.treatments?.[0].therapies[0].therapyType).to.eq('chemotherapy');
 
-          chai.expect(updatedDonor.treatments?.[0].therapies[1].therapyType).to.eq('immunotherapy');
+          chai.expect(updatedDonor.treatments?.[2].therapies[0].therapyType).to.eq('immunotherapy');
           chai
             .expect(
               updatedDonor.treatments?.[0].therapies[0].clinicalInfo['cumulative_drug_dosage'],
@@ -1628,7 +1629,7 @@ describe('Submission Api', () => {
 
           // immunotherapy
           chai
-            .expect(updatedDonor.treatments?.[0].therapies[1].clinicalInfo['immunotherapy_type'])
+            .expect(updatedDonor.treatments?.[2].therapies[0].clinicalInfo['immunotherapy_type'])
             .to.equal('Immune checkpoint inhibitors');
 
           // hormone therapy

--- a/test/unit/submission/validation.spec.ts
+++ b/test/unit/submission/validation.spec.ts
@@ -1851,7 +1851,11 @@ describe('data-validator', () => {
           [SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB1',
           [TreatmentFieldsEnum.submitter_treatment_id]: 'T_02',
           [PrimaryDiagnosisFieldsEnum.submitter_primary_diagnosis_id]: 'PP-2',
-          [TreatmentFieldsEnum.treatment_type]: ['Chemotherapy', 'Radiation therapy'],
+          [TreatmentFieldsEnum.treatment_type]: [
+            'Chemotherapy',
+            'Radiation therapy',
+            'Immunotherapy',
+          ],
           index: 0,
         },
       );
@@ -1862,29 +1866,41 @@ describe('data-validator', () => {
 
       const treatmentTherapyErr: SubmissionValidationError = {
         fieldName: TreatmentFieldsEnum.treatment_type,
-        message: `Treatments of type [Chemotherapy,Radiation therapy] need a corresponding [chemotherapy] record.`,
+        message: `Treatments of type [Chemotherapy,Radiation therapy,Immunotherapy] need a corresponding [chemotherapy] record.`,
         type: DataValidationErrors.MISSING_THERAPY_DATA,
         index: 0,
         info: {
           donorSubmitterId: 'AB1',
-          value: ['Chemotherapy', 'Radiation therapy'],
+          value: ['Chemotherapy', 'Radiation therapy', 'Immunotherapy'],
           therapyType: ClinicalEntitySchemaNames.CHEMOTHERAPY,
         },
       };
       const treatmentTherapyErr2: SubmissionValidationError = {
         fieldName: TreatmentFieldsEnum.treatment_type,
-        message: `Treatments of type [Chemotherapy,Radiation therapy] need a corresponding [radiation] record.`,
+        message: `Treatments of type [Chemotherapy,Radiation therapy,Immunotherapy] need a corresponding [radiation] record.`,
         type: DataValidationErrors.MISSING_THERAPY_DATA,
         index: 0,
         info: {
           donorSubmitterId: 'AB1',
-          value: ['Chemotherapy', 'Radiation therapy'],
+          value: ['Chemotherapy', 'Radiation therapy', 'Immunotherapy'],
           therapyType: ClinicalEntitySchemaNames.RADIATION,
         },
       };
-      chai.expect(result.treatment.dataErrors.length).to.eq(2);
+      const treatmentTherapyErr3: SubmissionValidationError = {
+        fieldName: TreatmentFieldsEnum.treatment_type,
+        message: `Treatments of type [Chemotherapy,Radiation therapy,Immunotherapy] need a corresponding [immunotherapy] record.`,
+        type: DataValidationErrors.MISSING_THERAPY_DATA,
+        index: 0,
+        info: {
+          donorSubmitterId: 'AB1',
+          value: ['Chemotherapy', 'Radiation therapy', 'Immunotherapy'],
+          therapyType: ClinicalEntitySchemaNames.IMMUNOTHERAPY,
+        },
+      };
+      chai.expect(result.treatment.dataErrors.length).to.eq(3);
       chai.expect(result.treatment.dataErrors).to.deep.include(treatmentTherapyErr);
       chai.expect(result.treatment.dataErrors).to.deep.include(treatmentTherapyErr2);
+      chai.expect(result.treatment.dataErrors).to.deep.include(treatmentTherapyErr3);
     });
 
     it('should detect missing or invalid treatment for chemotherapy', async () => {
@@ -1923,7 +1939,7 @@ describe('data-validator', () => {
         .validateSubmissionData({ AB1: newDonorAB1Records }, { AB1: existingDonorMock })
         .catch((err: any) => fail(err));
 
-      const chemoTretmentIdErr: SubmissionValidationError = {
+      const chemoTreatmentIdErr: SubmissionValidationError = {
         fieldName: TreatmentFieldsEnum.submitter_treatment_id,
         message: `Treatment and treatment_type files are required to be initialized together. Please upload a corresponding treatment file in this submission.`,
         type: DataValidationErrors.TREATMENT_ID_NOT_FOUND,
@@ -1933,7 +1949,7 @@ describe('data-validator', () => {
           value: 'T_03',
         },
       };
-      const chemoTretmentInvalidErr: SubmissionValidationError = {
+      const chemoTreatmentInvalidErr: SubmissionValidationError = {
         fieldName: TreatmentFieldsEnum.submitter_treatment_id,
         message: `[Chemotherapy] records can not be submitted for treatment types of [Ablation].`,
         type: DataValidationErrors.INCOMPATIBLE_PARENT_TREATMENT_TYPE,
@@ -1946,8 +1962,76 @@ describe('data-validator', () => {
         },
       };
       chai.expect(result.chemotherapy.dataErrors.length).to.eq(2);
-      chai.expect(result.chemotherapy.dataErrors).to.deep.include(chemoTretmentIdErr);
-      chai.expect(result.chemotherapy.dataErrors).to.deep.include(chemoTretmentInvalidErr);
+      chai.expect(result.chemotherapy.dataErrors).to.deep.include(chemoTreatmentIdErr);
+      chai.expect(result.chemotherapy.dataErrors).to.deep.include(chemoTreatmentInvalidErr);
+    });
+
+    it('should detect missing or invalid treatment for immunotheraoy', async () => {
+      const existingDonorMock: Donor = stubs.validation.existingDonor01();
+      const newDonorAB1Records = {};
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.TREATMENT,
+        newDonorAB1Records,
+        {
+          [SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB1',
+          [TreatmentFieldsEnum.submitter_treatment_id]: 'T_02',
+          [TreatmentFieldsEnum.treatment_type]: ['Ablation'],
+          index: 0,
+        },
+      );
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.IMMUNOTHERAPY,
+        newDonorAB1Records,
+        {
+          [SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB1',
+          [TreatmentFieldsEnum.submitter_treatment_id]: 'T_03',
+          index: 0,
+        },
+      );
+
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.IMMUNOTHERAPY,
+        newDonorAB1Records,
+        {
+          [SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB1',
+          [TreatmentFieldsEnum.submitter_treatment_id]: 'T_02',
+          index: 1,
+        },
+      );
+
+      const result = await dv
+        .validateSubmissionData({ AB1: newDonorAB1Records }, { AB1: existingDonorMock })
+        .catch((err: any) => fail(err));
+
+      const immunotherapyTreatmentIdErr: SubmissionValidationError = {
+        fieldName: TreatmentFieldsEnum.submitter_treatment_id,
+        message: `Treatment and treatment_type files are required to be initialized together. Please upload a corresponding treatment file in this submission.`,
+        type: DataValidationErrors.TREATMENT_ID_NOT_FOUND,
+        index: 0,
+        info: {
+          donorSubmitterId: 'AB1',
+          value: 'T_03',
+        },
+      };
+
+      const immunotherapyTreatmentInvalidErr: SubmissionValidationError = {
+        fieldName: TreatmentFieldsEnum.submitter_treatment_id,
+        message: `[Immunotherapy] records can not be submitted for treatment types of [Ablation].`,
+        type: DataValidationErrors.INCOMPATIBLE_PARENT_TREATMENT_TYPE,
+        index: 1,
+        info: {
+          donorSubmitterId: 'AB1',
+          value: 'T_02',
+          treatment_type: ['Ablation'],
+          therapyType: ClinicalEntitySchemaNames.IMMUNOTHERAPY,
+        },
+      };
+
+      chai.expect(result.immunotherapy.dataErrors.length).to.eq(2);
+      chai.expect(result.immunotherapy.dataErrors).to.deep.include(immunotherapyTreatmentIdErr);
+      chai
+        .expect(result.immunotherapy.dataErrors)
+        .to.deep.include(immunotherapyTreatmentInvalidErr);
     });
 
     it('should detect deleted therapies from treatement', async () => {


### PR DESCRIPTION
**Description of changes**

<!-- Please add a brief description of the changes here. -->

Feature to provide immunotherapy validation, there are 2 scenarios:
- case 1  - treatment type = `Chemotherapy|Immunotherapy`
require chemo + immuno tsv
in chemo and immuno files, must have records for that submitter_treatment_id
1.1 - if treatment is missing - both chemo and immuno should error
TREATMENT_ID_NOT_FOUND
1.2 - chemo is provided but immuno is missing
treatment should error `MISSING_THERAPY_DATA`
- case 2 = treatment type = `Immunotherapy`
if no Immunotherapy is uploaded, treatment should error `MISSING_THERAPY_DATA`


**Type of Change**

- [ ] Bug
- [ ] Refactor
- [x] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code