### PR TITLE
Remove Family History from completion stats

### DIFF
--- a/src/clinical/clinical-entities.ts
+++ b/src/clinical/clinical-entities.ts
@@ -104,7 +104,6 @@ export interface CoreCompletionFields {
   donor: number;
   specimens: number;
   primaryDiagnosis: number;
-  familyHistory: number;
   followUps: number;
   treatments: number;
 }

--- a/src/submission/submission-to-clinical/stat-calculator.ts
+++ b/src/submission/submission-to-clinical/stat-calculator.ts
@@ -37,7 +37,6 @@ type ForceRecaculateFlags = {
 type CoreClinicalSchemaName =
   | ClinicalEntitySchemaNames.DONOR
   | ClinicalEntitySchemaNames.PRIMARY_DIAGNOSIS
-  | ClinicalEntitySchemaNames.FAMILY_HISTORY
   | ClinicalEntitySchemaNames.TREATMENT
   | ClinicalEntitySchemaNames.FOLLOW_UP
   | ClinicalEntitySchemaNames.SPECIMEN;
@@ -56,7 +55,6 @@ const schemaNameToCoreCompletenessStat: Record<
 > = {
   [ClinicalEntitySchemaNames.DONOR]: 'donor',
   [ClinicalEntitySchemaNames.PRIMARY_DIAGNOSIS]: 'primaryDiagnosis',
-  [ClinicalEntitySchemaNames.FAMILY_HISTORY]: 'familyHistory',
   [ClinicalEntitySchemaNames.TREATMENT]: 'treatments',
   [ClinicalEntitySchemaNames.FOLLOW_UP]: 'followUps',
   [ClinicalEntitySchemaNames.SPECIMEN]: 'specimens',
@@ -229,7 +227,6 @@ const getEmptyCoreStats = (): CoreCompletionFields => {
     donor: 0,
     specimens: 0,
     primaryDiagnosis: 0,
-    familyHistory: 0,
     followUps: 0,
     treatments: 0,
   });
@@ -271,7 +268,9 @@ function noNeedToCalcCoreStat(
   return false;
 }
 
-function isValidCoreStatOverride(updatedCompletion: any): updatedCompletion is CoreCompletionFields {
+function isValidCoreStatOverride(
+  updatedCompletion: any,
+): updatedCompletion is CoreCompletionFields {
   return Object.entries(updatedCompletion).every(
     ([type, val]) =>
       Object.values(schemaNameToCoreCompletenessStat).find(field => type === field) &&

--- a/test/integration/submission/submission-schema-migration.spec.ts
+++ b/test/integration/submission/submission-schema-migration.spec.ts
@@ -316,7 +316,6 @@ describe('schema migration api', () => {
           coreCompletion: {
             donor: 1,
             primaryDiagnosis: 0,
-            familyHistory: 0,
             treatments: 1, // treatment has been overridden because donor never got any treatment
             followUps: 0,
             specimens: 0,

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -1672,7 +1672,6 @@ describe('Submission Api', () => {
       DonorBeforeUpdate.completionStats.coreCompletion.should.deep.include({
         donor: 1,
         primaryDiagnosis: 1,
-        familyHistory: 0,
         treatments: 1,
         followUps: 0,
         specimens: 0,
@@ -1906,7 +1905,6 @@ describe('Submission Api', () => {
           coreCompletion: {
             donor: 0,
             primaryDiagnosis: 1,
-            familyHistory: 0,
             treatments: 1, // overridden stat
             followUps: 0,
             specimens: 0.5,
@@ -1937,7 +1935,6 @@ describe('Submission Api', () => {
           updatedDonor.completionStats.coreCompletion.should.deep.include({
             donor: 1,
             primaryDiagnosis: 1,
-            familyHistory: 0,
             treatments: 1, // overridden field is same as before, despite no treatment record
             followUps: 0,
             specimens: 0.5, // one of the tumour/normal specimen has record


### PR DESCRIPTION
**Description of changes**
Family History was mistakenly added to completion stats when this schema was added to clincial. This removes family history from the completion stats and related tests.

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Check copyrights for new files
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
- [x] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
