### PR TITLE
fix duplicate recrods in biomarker table

### DIFF
--- a/sampleFiles/clinical/biomarker.tsv
+++ b/sampleFiles/clinical/biomarker.tsv
@@ -1,6 +1,6 @@
 program_id	submitter_donor_id	submitter_specimen_id	submitter_primary_diagnosis_id	submitter_treatment_id	submitter_follow_up_id	test_interval	ca19-9_level	crp_levels	ldl_level	anc	alc	brca_carrier	er_status	er_allred_score	her2_ihc_status	her2_ish_status	pr_status	pr_allred_score	pd-l1_status	alk_ihc_status	alk_ihc_intensity	alk_fish_status	ros1_ihc_status	pan-trk_ihc_status	ret_fish_status
-TEST-CA	ICGC_0002	sub-sp-pacaau-124	P4	T_02	FLL1234		11	12	13
-TEST-CA	ICGC_0002	sub-sp-pacaau-124	P4	T_02			11	12	13
-TEST-CA	ICGC_0002	sub-sp-pacaau-124	P4				11	12	13
 TEST-CA	ICGC_0002	sub-sp-pacaau-124					11	12	13
+TEST-CA	ICGC_0002		P4				11	12	13
+TEST-CA	ICGC_0002			T_02			11	12	13
+TEST-CA	ICGC_0002				FLL1234		11	12	13
 TEST-CA	ICGC_0002					99	11	12	13

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -846,19 +846,8 @@ export namespace operations {
   ) => {
     const schemaName = command.clinicalType as ClinicalEntitySchemaNames;
 
-    let useAllRecordValues = false;
-    // Biomarker allows multiple records for the same submitter_donor_id
-    // link to the bug: https://github.com/icgc-argo/argo-clinical/issues/713
-    if (schemaName === ClinicalEntitySchemaNames.BIOMARKER) {
-      useAllRecordValues = true;
-    }
-
     // check records are unique
-    const errors: SubmissionValidationError[] = checkUniqueRecords(
-      schemaName,
-      command.records,
-      useAllRecordValues,
-    );
+    const errors: SubmissionValidationError[] = checkUniqueRecords(schemaName, command.records);
 
     let errorsAccumulator: DeepReadonly<SubmissionValidationError[]> = [];
     const validRecordsAccumulator: any[] = [];


### PR DESCRIPTION
**Description of changes**

<!-- Please add a brief description of the changes here. -->

Fix for allowing duplicates records in biomarker table. Should not enable flag `useAllRecordValues` for biomarker schema, if flag is true, clinical will count records with different non-id fields as valid, however it should be considered as duplicate. 

for example, if these records are submitted, they should be counted as duplicates as they have the same `submitter_donor_id ` + `submitter_specimen_id`. 
```
ALEXIS-CA	DASH-2	dashsp-2					11	12	13
ALEXIS-CA	DASH-2	dashsp-2					999	12	13

```
**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code