### PR TITLE
fix migrate-mongo-config.js connection fail

### DIFF
--- a/migrate-mongo-config.js
+++ b/migrate-mongo-config.js
@@ -21,7 +21,7 @@
 let auth = undefined;
 if (process.env.CLINICAL_DB_USERNAME && process.env.CLINICAL_DB_PASSWORD) {
   auth = {
-    user: process.env.CLINICAL_DB_USERNAME,
+    username: process.env.CLINICAL_DB_USERNAME,
     password: process.env.CLINICAL_DB_PASSWORD,
   };
 }
@@ -48,7 +48,7 @@ const config = {
 const configCopy = JSON.parse(JSON.stringify(config)); // a hack to deep copy
 if (configCopy.mongodb.options.auth) {
   console.log('hiding auth..');
-  configCopy.mongodb.options.auth.user = configCopy.mongodb.options.auth.user.length;
+  configCopy.mongodb.options.auth.username = configCopy.mongodb.options.auth.username.length;
   configCopy.mongodb.options.auth.password = configCopy.mongodb.options.auth.password.length;
 }
 console.log(JSON.stringify(configCopy));


### PR DESCRIPTION
**Description of changes**

mongodb expects `username` instead of `user` for connecting to db. 
 
<!-- Please add a brief description of the changes here. -->

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code