### PR TITLE
Donor Query API Updates

### DIFF
--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -3,7 +3,8 @@ version: '3.8'
 services:
   rxnormdb:
     container_name: clinical_rxnormdb
-    image: mysql:5.7
+    # mariadb is a direct swap for mysql but it has a docker image that works on Apple Silicon
+    image: mariadb:10.7.1
     restart: always
     environment:
       MYSQL_DATABASE: 'rxnorm'

--- a/migrate-mongo-config.js
+++ b/migrate-mongo-config.js
@@ -18,6 +18,9 @@
  */
 
 // In this file you can configure migrate-mongo
+const dotenv = require('dotenv');
+dotenv.config();
+
 let auth = undefined;
 if (process.env.CLINICAL_DB_USERNAME && process.env.CLINICAL_DB_PASSWORD) {
   auth = {

--- a/sampleFiles/clinical/primary_diagnosis.tsv
+++ b/sampleFiles/clinical/primary_diagnosis.tsv
@@ -1,5 +1,5 @@
-program_id	number_lymph_nodes_positive	submitter_donor_id	submitter_primary_diagnosis_id	age_at_diagnosis	cancer_type_code	clinical_tumour_staging_system	presenting_symptoms	clinical_stage_group	clinical_t_category	clinical_n_category	clinical_m_category
-TEST-CA	2	ICGC_0001.1	P1	96	C41.1	Binet staging system	None|Unknown	Stage A
-TEST-CA	2	ICGC_0001.1	P2	96	C41.1	Binet staging system	None	Stage A
-TEST-CA	2	ICGC_0003	P3	96	C41.1	Binet staging system	None|Unknown	Stage A
-TEST-CA	2	ICGC_0002	P4	96	C41.1	Binet staging system	None	Stage A
+program_id	number_lymph_nodes_positive	submitter_donor_id	submitter_primary_diagnosis_id	age_at_diagnosis	cancer_type_code	clinical_tumour_staging_system	presenting_symptoms	clinical_stage_group	lymph_nodes_examined_status	clinical_t_category	clinical_n_category	clinical_m_category
+TEST-CA	2	ICGC_0001.1	P1	86	C41.1	Binet staging system	None|Unknown	Stage A	Yes			
+TEST-CA	2	ICGC_0001.1	P2	86	C41.1	Binet staging system	None	Stage A	Yes			
+TEST-CA	2	ICGC_0003	P3	86	C41.1	Binet staging system	None|Unknown	Stage A	Yes			
+TEST-CA	2	ICGC_0002	P4	86	C41.1	Binet staging system	None	Stage A	Yes			

--- a/src/app-health.ts
+++ b/src/app-health.ts
@@ -62,27 +62,34 @@ const health: AppHealth = {
 };
 
 export function setStatus(component: keyof AppHealth, status: ComponentStatus) {
-  if (status.status == Status.OK) {
+  if (status.status === Status.OK) {
     status.statusText = 'OK';
   }
-  if (status.status == Status.UNKNOWN) {
+  if (status.status === Status.UNKNOWN) {
     status.statusText = 'N/A';
   }
-  if (status.status == Status.ERROR) {
+  if (status.status === Status.ERROR) {
     status.statusText = 'ERROR';
   }
   health[component] = status;
   for (const k in health) {
     const key = k as keyof AppHealth;
-    if (key == 'all') {
+    if (key === 'all') {
       continue;
     }
-    if (health[key].status !== Status.OK) {
+    if (health[key].status === Status.ERROR) {
       health['all'].status = Status.ERROR;
+      health['all'].statusText = 'ERROR';
+      return;
+    }
+    if (health[key].status === Status.UNKNOWN) {
+      health['all'].status = Status.UNKNOWN;
+      health['all'].statusText = 'N/A';
       return;
     }
   }
   health['all'].status = Status.OK;
+  health['all'].statusText = 'OK';
 }
 
 export function getHealth(): AppHealth {

--- a/src/clinical/clinical-api.ts
+++ b/src/clinical/clinical-api.ts
@@ -19,17 +19,25 @@
 
 import { Request, Response } from 'express';
 import * as service from './clinical-service';
-import { HasFullWriteAccess, ProtectTestEndpoint, HasProgramWriteAccess } from '../decorators';
-import { ControllerUtils, TsvUtils } from '../utils';
+import {
+  HasFullWriteAccess,
+  ProtectTestEndpoint,
+  HasProgramReadAccess,
+  HasFullReadAccess,
+} from '../decorators';
+import { ControllerUtils, DonorUtils, TsvUtils } from '../utils';
 import AdmZip from 'adm-zip';
+import { Donor } from './clinical-entities';
+import { omit } from 'lodash';
+import { DeepReadonly } from 'deep-freeze';
 
 class ClinicalController {
-  @HasFullWriteAccess()
+  @HasFullReadAccess()
   async findDonors(req: Request, res: Response) {
     return res.status(200).send(await service.getDonors(req.query.programId));
   }
 
-  @HasProgramWriteAccess((req: Request) => req.params.programId)
+  @HasProgramReadAccess((req: Request) => req.params.programId)
   async getProgramClinicalDataAsTsvsInZip(req: Request, res: Response) {
     const programId = req.params.programId;
     if (!programId) {
@@ -85,10 +93,7 @@ class ClinicalController {
 
   @HasFullWriteAccess()
   async patchDonorCompletionStats(req: Request, res: Response) {
-    const strDonorId = req.params.donorId;
-
-    // extract number only since that's what is stored in db
-    const donorId: number = Number(strDonorId.replace('DO', ''));
+    const donorId = DonorUtils.parseDonorId(req.params.donorId);
 
     if (!donorId) {
       return ControllerUtils.badRequest(res, 'Invalid/Missing donorId, e.g. DO123');
@@ -99,16 +104,82 @@ class ClinicalController {
     const upadtedDonor = await service.updateDonorStats(donorId, coreCompletionOverride);
 
     if (!upadtedDonor) {
-      return ControllerUtils.notFound(res, `Donor with donorId:${strDonorId} not found`);
+      return ControllerUtils.notFound(res, `Donor with donorId:${donorId} not found`);
     }
 
     return res.status(200).send(upadtedDonor);
+  }
+
+  @HasProgramReadAccess((req: Request) => req.params.programId)
+  async getDonorById(req: Request, res: Response) {
+    const programId = req.params.programId;
+    if (!programId) {
+      return ControllerUtils.badRequest(res, 'Invalid/Missing programId, e.g. ABCD-CA');
+    }
+    const donorId = DonorUtils.parseDonorId(req.params.donorId);
+    if (!donorId) {
+      return ControllerUtils.badRequest(res, 'Invalid/Missing donorId, e.g. DO123');
+    }
+    const donor = await service.findDonorByDonorId(donorId, programId);
+    if (donor) {
+      return res.status(200).json(sanitizeDonorOutput(donor));
+    } else {
+      return ControllerUtils.notFound(
+        res,
+        `No donor found with donorId: '${donorId}' in program: '${programId}'`,
+      );
+    }
+  }
+
+  /**
+   * Returns every donor JSON document delmited by a new line character. Each document is written to the response stream as it is read in.
+   * @param req
+   * @param res
+   * @returns
+   */
+  @HasProgramReadAccess((req: Request) => req.params.programId)
+  async streamProgramDonors(req: Request, res: Response) {
+    console.log(req.params);
+    const programId = req.params.programId;
+    if (!programId) {
+      return ControllerUtils.badRequest(res, 'Invalid/Missing programId, e.g. ABCD-CA');
+    }
+
+    res.setHeader('Transfer-Encoding', 'chunked');
+    res.setHeader('Content-Type', 'application/x-ndjson');
+
+    for await (const donor of service.iterateAllDonorsByProgramId(programId)) {
+      res.write(JSON.stringify(sanitizeDonorOutput(donor)) + '\n');
+    }
+
+    res.end();
   }
 }
 
 function currentDateFormatted() {
   const now = new Date();
   return `${now.getFullYear()}${now.getMonth()}${now.getDate()}`;
+}
+
+/**
+ * loop through all donor, specimen, and sample IDs and apply the require prefixes.
+ * We also remove mongo specific properties and internal props that are not needed by consumers (e.g. `createBy`)
+ * @param donor
+ * @returns
+ */
+function sanitizeDonorOutput(donor: DeepReadonly<Donor>): any {
+  return {
+    ...omit(donor, '_id', '__v', 'createBy'),
+    donorId: donor.donorId ? DonorUtils.prefixDonorId(donor.donorId) : '',
+    specimens: donor.specimens.map(specimen => ({
+      ...specimen,
+      specimenId: specimen.specimenId ? DonorUtils.prefixSpecimenId(specimen.specimenId) : '',
+      samples: specimen.samples.map(sample => ({
+        ...sample,
+        sampleId: sample.sampleId ? DonorUtils.prefixSampleId(sample.sampleId) : '',
+      })),
+    })),
+  };
 }
 
 export default new ClinicalController();

--- a/src/clinical/clinical-entities.ts
+++ b/src/clinical/clinical-entities.ts
@@ -21,6 +21,8 @@ import { DeepReadonly } from 'deep-freeze';
 
 export interface Donor {
   _id?: string;
+  __v?: number; // mongodb property not being filtered out
+  createBy?: string;
   schemaMetadata: SchemaMetadata;
   donorId?: number;
   gender: string;

--- a/src/clinical/clinical-service.ts
+++ b/src/clinical/clinical-service.ts
@@ -80,7 +80,7 @@ export async function getDonors(programId: string) {
 }
 
 export async function findDonorId(submitterId: string, programId: string) {
-  const donor = await findDonor(submitterId, programId);
+  const donor = await findDonorBySubmitterId(submitterId, programId);
   if (!donor) {
     throw new Errors.NotFound('Donor not found');
   }
@@ -124,19 +124,16 @@ export async function findSampleId(submitterId: string, programId: string) {
   return `SA${sample.sampleId}`;
 }
 
-export async function findDonor(submitterId: string, programId: string) {
-  const donors = await donorDao.findByProgramAndSubmitterId([
-    {
-      programId: programId,
-      submitterId: submitterId,
-    },
-  ]);
+export async function findDonorBySubmitterId(submitterId: string, programId: string) {
+  return await donorDao.findOneBy({ programId, submitterId });
+}
 
-  if (!donors || donors.length == 0) {
-    return undefined;
-  }
+export async function findDonorByDonorId(donorId: number, programId: string) {
+  return await donorDao.findOneBy({ programId, donorId });
+}
 
-  return donors[0];
+export function iterateAllDonorsByProgramId(programId: string) {
+  return donorDao.iterateAllByProgramId(programId);
 }
 
 export async function deleteDonors(programId: string) {

--- a/src/clinical/service-worker-thread/runner.ts
+++ b/src/clinical/service-worker-thread/runner.ts
@@ -37,8 +37,8 @@ const pool = new StaticPool({
   task: jsWorkerLocation,
 });
 
-export async function runTaskInWorkerThread(taskToRun: WorkerTasks, taskArgs: any) {
+export async function runTaskInWorkerThread<T>(taskToRun: WorkerTasks, taskArgs: any): Promise<T> {
   const poolExecArgs = { taskToRun, taskArgs };
   const result = await pool.exec(poolExecArgs, poolTimeOutMs);
-  return result;
+  return result as T;
 }

--- a/src/clinical/service-worker-thread/worker.js
+++ b/src/clinical/service-worker-thread/worker.js
@@ -28,8 +28,6 @@ if (!process[tsNode.REGISTER_INSTANCE]) {
 const { WorkerTasksMap } = require('./tasks');
 
 function run({ taskToRun, taskArgs }) {
-  console.log('in worker run');
-
   try {
     const task = WorkerTasksMap[taskToRun];
     if (!task) {

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -123,6 +123,19 @@ export function HasProgramWriteAccess(programIdExtractor: Function) {
   );
 }
 
+export function HasProgramReadAccess(programIdExtractor: Function) {
+  return scopeCheckGenerator(
+    'HasProgramReadAccess',
+    programId => [
+      `PROGRAMDATA-${programId}.WRITE`,
+      `PROGRAMDATA-${programId}.READ`,
+      'CLINICALSERVICE.READ',
+      'CLINICALSERVICE.WRITE',
+    ],
+    programIdExtractor,
+  );
+}
+
 export function HasFullWriteAccess() {
   return scopeCheckGenerator('HasFullWriteAccess', () => ['CLINICALSERVICE.WRITE']);
 }

--- a/src/dictionary/manager.ts
+++ b/src/dictionary/manager.ts
@@ -36,7 +36,7 @@ const L = loggerFor(__filename);
 
 let manager: SchemaManager;
 
-type SchemaWithFields = {
+export type SchemaWithFields = {
   name: string;
   fields: string[];
 };

--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -692,10 +692,12 @@ paths:
       responses:
         '201':
           description: imported successfully - will indicate number of new donors and number of updated donors
+
   /clinical/donors:
     get:
+      deprecated: true
       tags:
-        - Clinical Data
+        - Deprecated
       summary: Get all program donors from db
       parameters:
         - $ref: '#/components/parameters/QueryProgramId'
@@ -716,7 +718,7 @@ paths:
                   type: object
     delete:
       tags:
-        - Clinical Data
+        - Test
       summary: Test endpoint to delete program donors in db (disabled in prod)
       parameters:
         - $ref: '#/components/parameters/QueryProgramId'
@@ -729,7 +731,74 @@ paths:
           $ref: '#/components/responses/ServerError'
         '200':
           description: 'all donors deleted'
+  /clinical/program/{programId}/donor/{donorId}:
+    get:
+      tags:
+        - Clinical Data
+      summary: Get all clinical data for a single donor, using the DonorID
+      parameters:
+        - $ref: '#/components/parameters/PathProgramId'
+        - $ref: '#/components/parameters/PathDonorId'
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '200':
+          description: 'All clinical data for a donor'
+          content:
+            application/json:
+              schema:
+                type: object
+  /clinical/program/{programId}/donors:
+    get:
+      tags:
+        - Clinical Data
+      summary: Get all program donors from db, returns as stream
+      parameters:
+        - $ref: '#/components/parameters/PathProgramId'
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '200':
+          description: 'Stream of newline `\n` delmited JSON objects'
+
   /clinical/program/{programId}/tsv-export:
+    parameters:
+      - $ref: '#/components/parameters/PathProgramId'
+    get:
+      deprecated: true
+      tags:
+        - Deprecated
+      summary: Get all commited clinical data for a program
+      description: Returns a zip file with all commited clinical and sample_registration data in tsvs. Exported data may not be valid with current dictionary.
+      responses:
+        '200':
+          description: 'A zip file with tsv file(s) inside'
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid programId provided
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /clinical/program/{programId}/tsv/all:
     parameters:
       - $ref: '#/components/parameters/PathProgramId'
     get:
@@ -804,7 +873,6 @@ paths:
                 type: string
         '404':
           description: no matching sample found
-
   /clinical/donor/{donorId}/completion-stats:
     patch:
       tags:
@@ -926,6 +994,8 @@ tags:
     description: APIs to do the icgc import
   - name: Admin
     description: Admin operations collected for convenience
+  - name: Test
+    description: Protected endpoints that run in dev only, not in prod.
   - name: Deprecated
     description: Deprecated enpoints
 components:
@@ -947,6 +1017,13 @@ components:
     PathProgramId:
       name: programId
       description: Short Name of the program (ex. ABCD-EF)
+      in: path
+      required: true
+      schema:
+        type: string
+    PathDonorId:
+      name: donorId
+      description: DonorId (ex. DO1234)
       in: path
       required: true
       schema:

--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -815,6 +815,31 @@ paths:
                 type: string
                 format: binary
         '400':
+          description: Invalid programId or entityType provided
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /clinical/program/{programId}/tsv/{entityType}:
+    parameters:
+      - $ref: '#/components/parameters/PathProgramId'
+      - $ref: '#/components/parameters/PathEntityType'
+    get:
+      tags:
+        - Clinical Data
+      summary: Get all commited clinical data for a program
+      description: Returns a zip file with all commited clinical and sample_registration data in tsvs. Exported data may not be valid with current dictionary.
+      responses:
+        '200':
+          description: 'A zip file with tsv file(s) inside'
+          content:
+            text/tab-separated-value:
+              schema:
+                type: string
+
+        '400':
           description: Invalid programId provided
         '401':
           $ref: '#/components/responses/UnauthorizedError'
@@ -1011,6 +1036,13 @@ components:
       name: submitterId
       description: Submitter Id of the entity
       in: query
+      required: true
+      schema:
+        type: string
+    PathEntityType:
+      name: entityType
+      description: Clinical Entity Type name
+      in: path
       required: true
       schema:
         type: string

--- a/src/routes/data.ts
+++ b/src/routes/data.ts
@@ -24,16 +24,25 @@ import clinicalApi from '../clinical/clinical-api';
 
 const router = express.Router();
 
-router.get('/donors', wrapAsync(clinicalApi.findDonors));
-router.delete('/donors', wrapAsync(clinicalApi.deleteDonors));
+// Get and Delete all
+router.get('/donors', wrapAsync(clinicalApi.findDonors)); //  DEPRECATED
+router.delete('/donors', wrapAsync(clinicalApi.deleteDonors)); // TEST ONLY
+
+// Get IDs
 router.get('/donors/id', wrapAsync(clinicalApi.findDonorId));
 router.get('/specimens/id', wrapAsync(clinicalApi.findSpecimenId));
 router.get('/samples/id', wrapAsync(clinicalApi.findSampleId));
 
+// Get Donor Data
+router.get('/program/:programId/donor/:donorId', wrapAsync(clinicalApi.getDonorById));
+router.get('/program/:programId/donors', wrapAsync(clinicalApi.streamProgramDonors));
+
+// Get TSV Data
 router.get(
   '/program/:programId/tsv-export',
   wrapAsync(clinicalApi.getProgramClinicalDataAsTsvsInZip),
-);
+); // DEPRECATED
+router.get('/program/:programId/tsv/all', wrapAsync(clinicalApi.getProgramClinicalDataAsTsvsInZip));
 
 router.patch('/donor/:donorId/completion-stats', wrapAsync(clinicalApi.patchDonorCompletionStats));
 

--- a/src/routes/data.ts
+++ b/src/routes/data.ts
@@ -43,6 +43,10 @@ router.get(
   wrapAsync(clinicalApi.getProgramClinicalDataAsTsvsInZip),
 ); // DEPRECATED
 router.get('/program/:programId/tsv/all', wrapAsync(clinicalApi.getProgramClinicalDataAsTsvsInZip));
+router.get(
+  '/program/:programId/tsv/:entityType',
+  wrapAsync(clinicalApi.getProgramClinicalDataAsTsv),
+);
 
 router.patch('/donor/:donorId/completion-stats', wrapAsync(clinicalApi.patchDonorCompletionStats));
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -145,6 +145,20 @@ export namespace ControllerUtils {
   };
 }
 
+export namespace DonorUtils {
+  export const donorIdPrefix = 'DO';
+  export const specimenIdPrefix = 'SP';
+  export const sampleIdPrefix = 'SA';
+
+  export const parseDonorId = (stringId: string): number =>
+    Number(stringId.replace(donorIdPrefix, ''));
+  export const prefixDonorId = (donorId: number): string => `${donorIdPrefix}${donorId}`;
+
+  export const prefixSpecimenId = (specimenId: number): string =>
+    `${specimenIdPrefix}${specimenId}`;
+  export const prefixSampleId = (sampleId: number): string => `${sampleIdPrefix}${sampleId}`;
+}
+
 export namespace Checks {
   export const checkNotNull = (argName: string, arg: any) => {
     if (!arg) {


### PR DESCRIPTION
**Description of changes**

Added endpoints (with auth) that will let a consuming application:
1. get a donor by donorID
2. stream response of all donors for a program
3. Renamed Download TSV endpoint `/clinical/program/{programId}/tsv/all`
4. Get TSV for single entity type `/clinical/program/{programId}/tsv/{entityType}`

Deprecated two endpoints:
1. get all donors for program that returned all donors as a single array. This is still available, and usable, but is discouraged for potential long response time due to content size.
2. download TSV at `/clinical/program/{programId}/tsv-export`


## ID Prefixing
The original donor entity included `getters` in mongoose to prefix the donor, specimen, and sample IDs. These were not actually being used in any response in my testing. I would like to have used these, but it was a significant data type refactor since the data types `Donor` and `Specimen` were being used for legacy import with these IDs as numbers, and with the prefix getters these would have to be string type. Seprating both the input and output Donor and Specimen types would be a lot of confusing work when we only actually want the string values when these values are being output by the clinical API. 

Therefore: I removed the mongoose getters and moved them to the clinical-api as a "santize output" method, which was needed to remove mongo specific properties from these objects.


<!-- Please add a brief description of the changes here. -->

**Type of Change**

- [ ] Bug
- [x] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Check copyrights for new files
- [x] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
