### PR TITLE
Endpoints Not Accepting ProgramId

### DIFF
--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -806,7 +806,7 @@ paths:
           $ref: '#/components/responses/ServerError'
         '200':
           description: 'Stream of newline `\n` delimited JSON objects'
-  /clinical/program/:programId/clinical-data:
+  /clinical/program/{programId}/clinical-data:
     get:
       tags:
         - Clinical Data
@@ -865,7 +865,7 @@ paths:
           $ref: '#/components/responses/ServerError'
         '200':
           description: 'Array of Clinical Entity objects'
-  /clinical/program/:programId/clinical-errors:
+  /clinical/program/{programId}/clinical-errors:
     get:
       tags:
         - Clinical Data
@@ -891,7 +891,7 @@ paths:
         '200':
           description: 'Array of Clinical Error objects'
 
-  /clinical/program/:programId/clinical-search-results:
+  /clinical/program/{programId}/clinical-search-results:
     get:
       tags:
         - Clinical Data


### PR DESCRIPTION
**Description of changes**

<!-- Found inconsistency with newly created path in url. The path being :programId, which cause end point to not be accepted in Swagger UI. Solution: replaced `:programId` with `{programId}`, which is consistent with the rest of the path. -->

**Type of Change**

- [x] Bug

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [x] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
