### PR TITLE
remove no null rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -36,7 +36,6 @@
     ],
     "no-internal-module": true,
     "no-trailing-whitespace": true,
-    "no-null-keyword": true,
     "prefer-const": true,
     "jsdoc-format": true
   }


### PR DESCRIPTION
**Description of changes**

currently only "undefined" is allowed, not "null"

I think "null" should be allowed
this is the rule i'm suggesting we remove https://palantir.github.io/tslint/rules/no-null-keyword/

use case: https://github.com/icgc-argo/argo-clinical/pull/890/files#diff-b3e63aecd11562b14d8eafc010c5aa655a6818a2ae737260971fc881e6289be4R43

returning nulls for db queries  and returning nulls for api responses, eg. `error: null` for no error, `error: undefined` implies it's left to be defined.



**Type of Change**

- [ ] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
