### PR TITLE
🪰 Core Complete is 0 when missing Specimen Submissions

### DIFF
--- a/src/common-model/functions.ts
+++ b/src/common-model/functions.ts
@@ -259,7 +259,10 @@ export const calculateSpecimenCompletionStats = (
       ? 0
       : tumourSubmissions / tumourRegistrations;
 
-  const coreCompletionPercentage = (normalSpecimensPercentage + tumourSpecimensPercentage) / 2;
+  const coreCompletionPercentage =
+    normalSubmissions === 0 || tumourSubmissions === 0
+      ? 0
+      : (normalSpecimensPercentage + tumourSpecimensPercentage) / 2;
 
   const completionValues = {
     coreCompletionPercentage,


### PR DESCRIPTION
**Description of changes**

When either category of Specimen is missing Submitted Clinical Info, the Specimen CoreCompletionPercentage must be 0

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
