### PR TITLE
Bug/invalid tsv

### DIFF
--- a/src/exception/types.ts
+++ b/src/exception/types.ts
@@ -135,8 +135,7 @@ export const isEntityExceptionRecord = (input: any): input is EntityExceptionRec
     // remove based exception record fields to validate specific entity
     const entityFields = _.omit(input, baseEntityExceptionFields);
     // can't have more than one identifying field eg. submitter_specimen_id AND submitter_followup_id
-    if (Object.keys(entityFields).length > 1) return false;
-    return isSpecimenExceptionRecord(entityFields) || isFollowupExceptionRecord(entityFields);
+    return Object.keys(entityFields).length === 1;
   }
   return false;
 };
@@ -148,9 +147,6 @@ const isExceptionRecord = (input: any): input is ExceptionRecord => isExceptionR
  * keeping it defined seperately reads more cleanly and is trivial to alter
  */
 export const isProgramExceptionRecord = isExceptionRecord;
-
-export const isArrayOfEntityExceptionRecord = (input: any): input is EntityExceptionRecords =>
-  input.every((i: any) => isEntityExceptionRecord(i));
 
 // array helpers
 export const isArrayOf = <T>(

--- a/src/exception/types.ts
+++ b/src/exception/types.ts
@@ -17,6 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import _ from 'lodash';
+
 export type ObjectValues<T> = T[keyof T];
 
 // base
@@ -81,6 +83,14 @@ export const ExceptionValue = {
 
 export type ExceptionValueType = ObjectValues<typeof ExceptionValue>;
 
+const baseEntityExceptionFields = [
+  'program_name',
+  'schema',
+  'requested_core_field',
+  'requested_exception_value',
+  'submitter_donor_id',
+];
+
 // type guard helpers
 const isExceptionRecordCheck = (input: any) => {
   return (
@@ -118,10 +128,17 @@ export const isFollowupExceptionRecord = (input: any): input is FollowUpExceptio
 
 // type guards
 export const isEntityExceptionRecord = (input: any): input is EntityExceptionRecord => {
-  return (
-    isExceptionRecordCheck(input) &&
-    (isSpecimenExceptionRecord(input) || isFollowupExceptionRecord(input))
-  );
+  const hasDonorIdField =
+    'submitter_donor_id' in input && typeof input.submitter_donor_id === 'string';
+
+  if (hasDonorIdField && isExceptionRecord(input)) {
+    // remove based exception record fields to validate specific entity
+    const entityFields = _.omit(input, baseEntityExceptionFields);
+    // can't have more than one identifying field eg. submitter_specimen_id AND submitter_followup_id
+    if (Object.keys(entityFields).length > 1) return false;
+    return isSpecimenExceptionRecord(entityFields) || isFollowupExceptionRecord(entityFields);
+  }
+  return false;
 };
 
 const isExceptionRecord = (input: any): input is ExceptionRecord => isExceptionRecordCheck(input);

--- a/src/exception/validation.ts
+++ b/src/exception/validation.ts
@@ -173,7 +173,11 @@ export const checkForEmptyField: Validator<ExceptionRecord> = ({
   };
 };
 
-export const checkIsValidSchema: Validator<ExceptionRecord> = async ({ fieldValue }) => {
+/**
+ * checks if schema is valid dictionary schema
+ * does not check if schema is valid to rest of record
+ */
+export const checkIsValidDictionarySchema: Validator<ExceptionRecord> = async ({ fieldValue }) => {
   const errorMessage = 'field is empty';
   if (!fieldValue) {
     return {
@@ -194,7 +198,7 @@ export const checkIsValidSchema: Validator<ExceptionRecord> = async ({ fieldValu
 
   return {
     result: isValid ? ValidationResultType.VALID : ValidationResultType.INVALID,
-    message: isValid ? '' : `Record schema of '${fieldValue}' is invalid`,
+    message: isValid ? '' : `Record schema of '${fieldValue}' is invalid.`,
   };
 };
 
@@ -226,6 +230,12 @@ const getValidator = <RecordT extends Object>(
   }
 };
 
+/**
+ * iterates through each record and runs provided validators
+ * @param programId
+ * @param records
+ * @param fieldValidators
+ */
 export const validateRecords = async <RecordT extends Object>(
   programId: string,
   records: ReadonlyArray<RecordT>,
@@ -275,7 +285,7 @@ export const validateRecords = async <RecordT extends Object>(
 
 export const commonValidators: FieldValidators<ExceptionRecord> = {
   program_name: checkProgramId,
-  schema: checkIsValidSchema,
+  schema: checkIsValidDictionarySchema,
   requested_core_field: checkCoreField,
   requested_exception_value: checkRequestedValue,
 };


### PR DESCRIPTION
**Description of changes**

Adds additional validation for the "schema" column value of uploaded entity exception.
gets the upload exception type early (specimen, follow up) as `schema` and passes it down to an additional validator function

Previously this would pass: 
```javascript
{
  follow_up: [
    {
      _id: '.',
      program_name: 'CIA-IE',
      submitter_donor_id: 'DO-1',
      submitter_followup_id: 'FO1-1',
      schema: 'Donor',
      requested_core_field: 'primary_site',
      requested_exception_value: 'Unknown',
    },
  ],
};
```

"donor" is not valid for "follow_up" exception



**Type of Change**

- [ ] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
  