### PR TITLE
fix inconsitent name of clinical schema names and exception schema names

### DIFF
--- a/src/exception/types.ts
+++ b/src/exception/types.ts
@@ -18,6 +18,7 @@
  */
 
 import _ from 'lodash';
+import { ClinicalEntitySchemaNames } from '../common-model/entities';
 
 export type ObjectValues<T> = T[keyof T];
 
@@ -75,6 +76,11 @@ export type EntityException = {
   specimen: SpecimenExceptionRecord[];
   follow_up: FollowUpExceptionRecord[];
 };
+
+export type EntityExceptionSchemaNames = Extract<
+  ClinicalEntitySchemaNames,
+  ClinicalEntitySchemaNames.SPECIMEN | ClinicalEntitySchemaNames.FOLLOW_UP
+>;
 
 export const ExceptionValue = {
   Unknown: 'Unknown',

--- a/src/exception/util.ts
+++ b/src/exception/util.ts
@@ -27,9 +27,8 @@ export function isProgramException(result: ProgramException | null): result is P
 
 export function isEntityException(result: EntityException | null): result is EntityException {
   return (
-    result !== null &&
-    (result as EntityException).programId !== undefined &&
-    (result as EntityException).specimen !== undefined
+    result?.programId !== undefined &&
+    (result?.specimen !== undefined || result?.follow_up !== undefined)
   );
 }
 

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -20,10 +20,14 @@
 import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
 import { DataRecord } from '@overturebio-stack/lectern-client/lib/schema-entities';
 import _ from 'lodash';
-import { ClinicalEntitySchemaNames } from '../../common-model/entities';
 import entityExceptionRepository from '../../exception/repo/entity';
 import programExceptionRepository from '../../exception/repo/program';
-import { EntityException, ExceptionRecord, ProgramException } from '../../exception/types';
+import {
+  EntityException,
+  EntityExceptionSchemaNames,
+  ExceptionRecord,
+  ProgramException,
+} from '../../exception/types';
 import { isEntityException, isProgramException } from '../../exception/util';
 
 /**
@@ -55,7 +59,7 @@ const validateFieldValueWithExceptions = ({
 }: {
   programException: ProgramException | null;
   entityException: EntityException | null;
-  schemaName: ClinicalEntitySchemaNames;
+  schemaName: EntityExceptionSchemaNames;
   fieldValue: string;
   validationErrorFieldName: string;
 }): boolean => {
@@ -66,15 +70,10 @@ const validateFieldValueWithExceptions = ({
       exception => exception.requested_core_field === validationErrorFieldName,
     )?.requested_exception_value;
   } else if (isEntityException(entityException)) {
-    const exceptionSchemaName = mapClinicalEntityNameToExceptionName(schemaName);
-    if (exceptionSchemaName) {
-      const exceptions: Array<ExceptionRecord> = entityException[exceptionSchemaName];
-      exceptionValue = exceptions.find(
-        exception => exception.requested_core_field === validationErrorFieldName,
-      )?.requested_exception_value;
-    } else {
-      return false;
-    }
+    const exceptions: Array<ExceptionRecord> = entityException[schemaName];
+    exceptionValue = exceptions.find(
+      exception => exception.requested_core_field === validationErrorFieldName,
+    )?.requested_exception_value;
   }
 
   // check submitted exception value matches record validation error field value
@@ -89,37 +88,6 @@ const validateFieldValueWithExceptions = ({
  * @returns normalized string
  */
 const normalizeExceptionValue = (value: string) => _.upperFirst(value.trim().toLowerCase());
-
-/**
- * map uploaded clinical type schema name with underscores to exception schema name camel cased
- * eg. follow_up: 'followUp',
- * Partial<> until all donor entities are accounted for
- * @param schemaName
- */
-
-const clinicalEntities: Partial<Record<
-  ClinicalEntitySchemaNames,
-  Exclude<keyof EntityException, 'programId'>
->> = {
-  // donor: 'donor',
-  specimen: 'specimen',
-  //   primary_diagnosis: 'primaryDiagnoses',
-  //   family_history: 'familyHistory',
-  //   treatment: 'treatment',
-  //   chemotherapy: 'chemotherapy',
-  //   immunotherapy: 'immunotherapy',
-  //   surgery: 'surgery',
-  //   radiation: 'radiation',
-  //   follow_up: 'followUps',
-  //   hormone_therapy: 'hormoneTherapy',
-  //   exposure: 'exposure',
-  //   comorbidity: 'comorbidity',
-  //   biomarker: 'biomarker',
-  //   sample_registration: 'sampleRegistration',
-};
-
-const mapClinicalEntityNameToExceptionName = (schemaName: ClinicalEntitySchemaNames) =>
-  clinicalEntities[schemaName];
 
 /**
  * Check if a valid exception exists and the record value matches it.
@@ -140,7 +108,7 @@ export const checkForProgramAndEntityExceptions = async ({
 }: {
   programId: string;
   record: DataRecord;
-  schemaName: ClinicalEntitySchemaNames;
+  schemaName: EntityExceptionSchemaNames;
   schemaValidationErrors: dictionaryEntities.SchemaValidationError[];
 }) => {
   const filteredErrors: dictionaryEntities.SchemaValidationError[] = [];


### PR DESCRIPTION
**Description of changes**

bug where schema names from clinical record types did not match exception schema name values
remove unused name mapping functionality

**Type of Change**

- [ ] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
