### PR TITLE
Clinical Exceptions do not cause validation issues

### DIFF
--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -881,7 +881,7 @@ export namespace operations {
              */
             const { filteredErrors, normalizedRecord } = await checkForProgramAndEntityExceptions({
               programId: command.programId,
-              record,
+              record: schemaResult.processedRecord,
               schemaName,
               schemaValidationErrors: [...schemaResult.validationErrors],
             });


### PR DESCRIPTION
**Description of changes**

<!-- Please add a brief description of the changes here. -->

Applying exception rules was causing a loss of type information in records with exception values. In particular, fields that were being made into arrays were being converted back to single strings.

This change preserves the processed type information of the record when applying the clinical exception rules.

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [x] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
