### PR TITLE
donorIDs are always type `number[]` for clinical routes

### DIFF
--- a/src/clinical/api/types.ts
+++ b/src/clinical/api/types.ts
@@ -19,7 +19,7 @@ export type ClinicalDataApiBody = zod.infer<typeof ClinicalDataApiBody>;
  * Clinical Error API Body
  */
 export const ClinicalErrorsApiBody = zod.object({
-  donorIds: zod.array(zod.number().positive()).default([]),
+  donorIds: zod.array(zod.number().positive()).optional(),
 });
 export type ClinicalErrorsApiBody = zod.infer<typeof ClinicalErrorsApiBody>;
 
@@ -30,7 +30,7 @@ export type ClinicalErrorsApiBody = zod.infer<typeof ClinicalErrorsApiBody>;
 export const ClinicalSearchApiBody = zod.object({
   completionState: CompletionState.default(CompletionState.Values.all),
   entityTypes: zod.array(EntityAlias).default([]),
-  donorIds: zod.array(zod.string().nonempty()).default([]),
+  donorIds: zod.array(zod.number()).default([]),
   submitterDonorIds: zod.array(zod.string().nonempty()).default([]),
 });
 export type ClinicalSearchApiBody = zod.infer<typeof ClinicalSearchApiBody>;

--- a/src/clinical/clinical-service.ts
+++ b/src/clinical/clinical-service.ts
@@ -57,7 +57,7 @@ export type ClinicalQuery = {
 
 export type ClinicalSearchQuery = {
   programShortName: string;
-  donorIds: string[];
+  donorIds: number[];
   submitterDonorIds: string[];
   entityTypes: EntityAlias[];
   completionState?: {};
@@ -254,7 +254,7 @@ interface DonorMigration extends Omit<DictionaryMigration, 'invalidDonorsErrors'
  */
 export const getClinicalEntityMigrationErrors = async (
   programId: string,
-  query: number[],
+  queryDonorIds?: number[],
 ): Promise<{
   migration: DeepReadonly<DonorMigration | undefined>;
   clinicalMigrationErrors: ClinicalErrorsResponseRecord[];
@@ -271,7 +271,11 @@ export const getClinicalEntityMigrationErrors = async (
   if (migration) {
     const { invalidDonorsErrors } = migration;
     invalidDonorsErrors
-      .filter(donor => donor.programId.toString() === programId && query.includes(donor.donorId))
+      .filter(donor =>
+        Array.isArray(queryDonorIds)
+          ? donor.programId.toString() === programId && queryDonorIds.includes(donor.donorId)
+          : true,
+      )
       .forEach(donor => {
         const { donorId, submitterDonorId, errors } = donor;
         // Overwrite donor.errors + flatten entityName to simplify query

--- a/src/clinical/service-worker-thread/tasks.ts
+++ b/src/clinical/service-worker-thread/tasks.ts
@@ -172,7 +172,7 @@ function FilterDonorIdDataFromSearch(donors: Donor[], query: ClinicalSearchQuery
         // Enables Search by DonorId using partial terms, i.e. searching '262' returns all Donors where DonorId includes 262
         const { donorId, submitterId } = donor;
         const stringId = `${donorId}`;
-        const donorMatch = donorIds?.some(id => stringId.includes(id));
+        const donorMatch = donorIds?.some(id => stringId.includes(`${id}`));
         const submitterMatch = submitterDonorIds?.some(id => submitterId.includes(id));
         return donorMatch || submitterMatch;
       }


### PR DESCRIPTION
**Description of changes**

Fix API request parameters to match expected usage from UI/API. The `ClinicalSearchQuery` should accept donorIds as type `number[]` instead of `string[]`. Changes to other files are made to adhere to this type update.

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [x] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
