### PR TITLE
Add page size query param handling to clinical-data api

### DIFF
--- a/src/clinical/api/clinical-api.ts
+++ b/src/clinical/api/clinical-api.ts
@@ -99,7 +99,8 @@ class ClinicalController {
       return ControllerUtils.badRequest(res, 'Invalid programId provided');
     }
     const sort: string = 'donorId';
-    const page: number = 0;
+    const page: number = req.query.page;
+    const pageSize: number = req.query.pageSize;
 
     const bodyParseResult = ClinicalDataApiBody.safeParse(req.body);
     if (!bodyParseResult.success) {
@@ -121,6 +122,7 @@ class ClinicalController {
       sort,
       entityTypes,
       page,
+      pageSize,
       donorIds,
       submitterDonorIds,
       completionState,
@@ -150,7 +152,8 @@ class ClinicalController {
       return ControllerUtils.badRequest(res, 'Invalid programId provided');
     }
     const sort: string = req.query.sort || 'donorId';
-    const page: number = parseInt(req.query.page);
+    const page: number = parseInt(req.query.page) || 0;
+    const pageSize: number = parseInt(req.query.pageSize) || 20;
 
     const bodyParseResult = ClinicalDataApiBody.safeParse(req.body);
     if (!bodyParseResult.success) {
@@ -172,6 +175,7 @@ class ClinicalController {
       sort,
       entityTypes,
       page,
+      pageSize,
       donorIds,
       submitterDonorIds,
       completionState,


### PR DESCRIPTION
**Description of changes**

Handling for `pageSize` query parameter was missed in refactor, adding that in.

**Type of Change**

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
