### PR TITLE
Revert "🗑️ Disable lost to follow up (#1037)"

### DIFF
--- a/src/common-model/entities.ts
+++ b/src/common-model/entities.ts
@@ -130,6 +130,7 @@ export enum DonorFieldsEnum {
   vital_status = 'vital_status',
   survival_time = 'survival_time',
   cause_of_death = 'cause_of_death',
+  lost_to_followup_after_clinical_event_id = 'lost_to_followup_after_clinical_event_id',
 }
 
 export enum SpecimenFieldsEnum {

--- a/src/submission/validation-clinical/donor.ts
+++ b/src/submission/validation-clinical/donor.ts
@@ -47,7 +47,10 @@ export const validate = async (
     mergedDonor,
   );
 
-  return { errors: [...timeConflictErrors] };
+  // Validation across all submissions and entities
+  const crossFileErrors = await crossFileValidator(submittedDonorClinicalRecord, mergedDonor);
+
+  return { errors: [...timeConflictErrors, ...crossFileErrors] };
 };
 
 function checkTimeConflictWithSpecimens(
@@ -92,3 +95,127 @@ function checkTimeConflictWithSpecimens(
       ]
     : [];
 }
+
+const crossFileValidator = async (
+  submittedDonorRecord: DeepReadonly<SubmittedClinicalRecord>,
+  mergedDonor: DeepReadonly<Donor>,
+) => {
+  const { lost_to_followup_after_clinical_event_id } = submittedDonorRecord;
+  const { primaryDiagnoses = [], treatments = [], followUps = [] } = mergedDonor;
+  const errors: SubmissionValidationError[] = [];
+
+  if (lost_to_followup_after_clinical_event_id) {
+    const treatmentMatch = treatments?.find(
+      treatmentRecord =>
+        treatmentRecord.clinicalInfo?.submitter_treatment_id ===
+        lost_to_followup_after_clinical_event_id,
+    );
+
+    const primaryDiagnosisMatch = primaryDiagnoses?.find(
+      primaryDiagnosisRecord =>
+        primaryDiagnosisRecord?.clinicalInfo?.submitter_primary_diagnosis_id ===
+        lost_to_followup_after_clinical_event_id,
+    );
+
+    const followUpMatch = followUps?.find(
+      followUpRecord =>
+        followUpRecord.clinicalInfo?.submitter_follow_up_id ===
+        lost_to_followup_after_clinical_event_id,
+    );
+
+    // Find if Lost to Follow Up ID matches a previous Treatment ID
+    const donorClinicalEventIdMatch = treatmentMatch || primaryDiagnosisMatch || followUpMatch;
+
+    if (!donorClinicalEventIdMatch) {
+      errors.push(
+        utils.buildSubmissionError(
+          submittedDonorRecord,
+          DataValidationErrors.INVALID_LOST_TO_FOLLOW_UP_ID,
+          DonorFieldsEnum.lost_to_followup_after_clinical_event_id,
+          {
+            lost_to_followup_after_clinical_event_id,
+          },
+        ),
+      );
+    } else {
+      const lostToFollowUpDiagnosisId =
+        donorClinicalEventIdMatch?.clinicalInfo?.submitter_primary_diagnosis_id;
+
+      const lostToFollowUpInterval =
+        (typeof donorClinicalEventIdMatch?.clinicalInfo?.interval_of_followup === 'number' &&
+          donorClinicalEventIdMatch.clinicalInfo.interval_of_followup) ||
+        0;
+
+      const invalidTreatmentIntervals = treatments.filter(treatment => {
+        const treatmentRecord = treatment.clinicalInfo;
+
+        const { treatment_start_interval, treatment_duration } = treatmentRecord;
+
+        const treatmentStartInterval =
+          typeof treatment_start_interval === 'number' ? treatment_start_interval : 0;
+
+        const treatmentDuration = typeof treatment_duration === 'number' ? treatment_duration : 0;
+
+        const totalTreatmentTime = treatmentStartInterval + treatmentDuration;
+
+        return totalTreatmentTime > lostToFollowUpInterval;
+      });
+
+      const invalidFollowUpIntervals = followUps.filter(followUp => {
+        const followUpRecord = followUp.clinicalInfo;
+
+        const { interval_of_followup } = followUpRecord;
+
+        const intervalOfFollowUp =
+          typeof interval_of_followup === 'number' ? interval_of_followup : 0;
+
+        return intervalOfFollowUp > lostToFollowUpInterval;
+      });
+
+      const invalidRecords = [...invalidTreatmentIntervals, ...invalidFollowUpIntervals];
+
+      if (invalidRecords.length) {
+        const firstInvalidTreatmentMatch = invalidRecords[0].clinicalInfo;
+        const invalidTreatmentDiagnosisId =
+          firstInvalidTreatmentMatch?.submitter_primary_diagnosis_id;
+
+        const lostToFollowUpPrimaryDiagnosisMatch = primaryDiagnoses?.find(
+          primaryDiagnosisRecord =>
+            primaryDiagnosisRecord?.clinicalInfo?.submitter_primary_diagnosis_id ===
+            lostToFollowUpDiagnosisId,
+        )?.clinicalInfo;
+
+        const invalidPrimaryDiagnosisMatch = primaryDiagnoses?.find(
+          primaryDiagnosisRecord =>
+            primaryDiagnosisRecord?.clinicalInfo?.submitter_primary_diagnosis_id ===
+            invalidTreatmentDiagnosisId,
+        )?.clinicalInfo;
+
+        const lostToFollowUpAge = Number(lostToFollowUpPrimaryDiagnosisMatch?.age_at_diagnosis);
+
+        const invalidRecordAge = Number(invalidPrimaryDiagnosisMatch?.age_at_diagnosis);
+
+        const isPreviousPrimaryDiagnosis = lostToFollowUpAge >= invalidRecordAge;
+
+        if (firstInvalidTreatmentMatch && isPreviousPrimaryDiagnosis) {
+          const { submitter_treatment_id } = firstInvalidTreatmentMatch;
+
+          errors.push(
+            utils.buildSubmissionError(
+              submittedDonorRecord,
+              DataValidationErrors.INVALID_SUBMISSION_AFTER_LOST_TO_FOLLOW_UP,
+              DonorFieldsEnum.lost_to_followup_after_clinical_event_id,
+              {
+                lost_to_followup_after_clinical_event_id,
+                interval_of_followup: lostToFollowUpInterval,
+                submitter_treatment_id,
+              },
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  return errors;
+};

--- a/test/unit/submission/validation.spec.ts
+++ b/test/unit/submission/validation.spec.ts
@@ -1500,6 +1500,158 @@ describe('data-validator', () => {
       chai.expect(result[ClinicalEntitySchemaNames.SPECIMEN].dataErrors.length).to.eq(0);
     });
 
+    it('should detect submitted Lost to Follow Up After Clinical Event ID exists', async () => {
+      const existingDonorAB1Mock: Donor = stubs.validation.existingDonor01();
+      const submittedAB1Records = {};
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.DONOR,
+        submittedAB1Records,
+        {
+          [SampleRegistrationFieldsEnum.submitter_donor_id]: 'DN190',
+          [SampleRegistrationFieldsEnum.program_id]: 'TEST-CA',
+          [DonorFieldsEnum.vital_status]: 'alive',
+          lost_to_followup_after_clinical_event_id: 'FL-23',
+          index: 0,
+        },
+      );
+
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.FOLLOW_UP,
+        submittedAB1Records,
+        {
+          [FollowupFieldsEnum.submitter_donor_id]: 'DN190',
+          [FollowupFieldsEnum.program_id]: 'TEST-CA',
+          [FollowupFieldsEnum.submitter_follow_up_id]: 'FL-21',
+          [FollowupFieldsEnum.interval_of_followup]: 230,
+          index: 0,
+        },
+      );
+
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.TREATMENT,
+        submittedAB1Records,
+        {
+          [FollowupFieldsEnum.submitter_donor_id]: 'DN190',
+          [FollowupFieldsEnum.program_id]: 'TEST-CA',
+          [FollowupFieldsEnum.submitter_follow_up_id]: 'FL-33',
+          [FollowupFieldsEnum.interval_of_followup]: 300,
+          index: 0,
+        },
+      );
+
+      const donorIdConflictErr: SubmissionValidationError = {
+        type: DataValidationErrors['INVALID_LOST_TO_FOLLOW_UP_ID'],
+        fieldName: DonorFieldsEnum.lost_to_followup_after_clinical_event_id,
+        index: 0,
+        info: {
+          lost_to_followup_after_clinical_event_id: 'FL-23',
+          donorSubmitterId: 'DN190',
+          value: 'FL-23',
+        },
+        message: `The identifier 'FL-23' submitted in the 'lost_to_followup_after_clinical_event_id' field does not exist in your clinical submission.`,
+      };
+
+      const result = await dv
+        .validateSubmissionData({ AB1: submittedAB1Records }, { AB1: existingDonorAB1Mock })
+        .catch(err => fail(err));
+
+      chai.expect(result[ClinicalEntitySchemaNames.DONOR].dataErrors.length).to.eq(1);
+      chai
+        .expect(result[ClinicalEntitySchemaNames.DONOR].dataErrors)
+        .to.deep.include(donorIdConflictErr);
+    });
+
+    it('should detect there are no further clinical events submitted after a Lost to Follow Up clinical event', async () => {
+      const existingDonorAB1Mock: Donor = stubs.validation.existingDonor01();
+      const submittedAB1Records = {};
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.DONOR,
+        submittedAB1Records,
+        {
+          [SampleRegistrationFieldsEnum.submitter_donor_id]: 'DN190',
+          [SampleRegistrationFieldsEnum.program_id]: 'TEST-CA',
+          [DonorFieldsEnum.vital_status]: 'alive',
+          lost_to_followup_after_clinical_event_id: 'FL-23',
+          index: 0,
+        },
+      );
+
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.PRIMARY_DIAGNOSIS,
+        submittedAB1Records,
+        {
+          [PrimaryDiagnosisFieldsEnum.submitter_donor_id]: 'DN190',
+          [PrimaryDiagnosisFieldsEnum.program_id]: 'TEST-CA',
+          [PrimaryDiagnosisFieldsEnum.submitter_primary_diagnosis_id]: 'PP-1',
+          [PrimaryDiagnosisFieldsEnum.age_at_diagnosis]: 30,
+          index: 0,
+        },
+      );
+
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.SPECIMEN,
+        submittedAB1Records,
+        {
+          [SampleRegistrationFieldsEnum.submitter_donor_id]: 'DN190',
+          [SampleRegistrationFieldsEnum.program_id]: 'TEST-CA',
+          [SampleRegistrationFieldsEnum.submitter_specimen_id]: 'SP1',
+          [SpecimenFieldsEnum.specimen_acquisition_interval]: 5020,
+          index: 0,
+        },
+      );
+
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.FOLLOW_UP,
+        submittedAB1Records,
+        {
+          [FollowupFieldsEnum.submitter_donor_id]: 'DN190',
+          [FollowupFieldsEnum.program_id]: 'TEST-CA',
+          [PrimaryDiagnosisFieldsEnum.submitter_primary_diagnosis_id]: 'PP-1',
+          [FollowupFieldsEnum.submitter_follow_up_id]: 'FL-23',
+          [FollowupFieldsEnum.interval_of_followup]: 230,
+          index: 0,
+        },
+      );
+
+      ClinicalSubmissionRecordsOperations.addRecord(
+        ClinicalEntitySchemaNames.TREATMENT,
+        submittedAB1Records,
+        {
+          [TreatmentFieldsEnum.submitter_donor_id]: 'DN190',
+          [TreatmentFieldsEnum.program_id]: 'TEST-CA',
+          [TreatmentFieldsEnum.submitter_treatment_id]: 'TR-33',
+          [PrimaryDiagnosisFieldsEnum.submitter_primary_diagnosis_id]: 'PP-1',
+          [TreatmentFieldsEnum.treatment_start_interval]: 250,
+          [TreatmentFieldsEnum.treatment_duration]: 50,
+          index: 0,
+        },
+      );
+
+      const submissionConflictErr: SubmissionValidationError = {
+        type: DataValidationErrors['INVALID_SUBMISSION_AFTER_LOST_TO_FOLLOW_UP'],
+        fieldName: DonorFieldsEnum.lost_to_followup_after_clinical_event_id,
+        index: 0,
+        info: {
+          lost_to_followup_after_clinical_event_id: 'FL-23',
+          donorSubmitterId: 'DN190',
+          interval_of_followup: 230,
+          submitter_treatment_id: 'TR-33',
+          value: 'FL-23',
+        },
+        message:
+          'A clinical event that occurs after the donor was lost to follow up cannot be submitted. The donor was indicated to be lost to follow up 230 days after their primary diagnosis ("lost_to_followup_after_clinical_event_id" = "FL-23"), but a new treatment ("TR-33") that started after the donor was lost to follow up has been submitted. If the donor was found later on, then update the "lost_to_followup_after_clinical_event_id" field to be empty.',
+      };
+
+      const result = await dv
+        .validateSubmissionData({ AB1: submittedAB1Records }, { AB1: existingDonorAB1Mock })
+        .catch(err => fail(err));
+
+      chai.expect(result[ClinicalEntitySchemaNames.DONOR].dataErrors.length).to.eq(1);
+      chai
+        .expect(result[ClinicalEntitySchemaNames.DONOR].dataErrors)
+        .to.deep.include(submissionConflictErr);
+    });
+
     it('should allow submission of a new Primary Diagnosis after a Lost to Follow Up After clinical event', async () => {
       const existingDonorAB1Mock: Donor = stubs.validation.existingDonor01();
       const submittedAB1Records = {};


### PR DESCRIPTION
This reverts commit f2f86e3c72f249d4fd28bdb4fb5ffcf8d8d52ca9.

Enables cross-file Lost to Follow Up validation
https://app.zenhub.com/workspaces/icgc-argo-platform-dk-production-board-5e542d38415f5034e9fed89d/issues/gh/icgc-argo/roadmap/1013

**Type of Change**

- [ ] Bug
- [ ] Refactor
- [x] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
