### PR TITLE
API Endpoint to Download TSV Files for donors by Donor ID

### DIFF
--- a/src/clinical/api/types.ts
+++ b/src/clinical/api/types.ts
@@ -34,3 +34,11 @@ export const ClinicalSearchApiBody = zod.object({
   submitterDonorIds: zod.array(zod.string().nonempty()).default([]),
 });
 export type ClinicalSearchApiBody = zod.infer<typeof ClinicalSearchApiBody>;
+
+/**
+ * Download Donor Data by ID
+ */
+export const DonorDataApiBody = zod.object({
+  donorIds: zod.array(zod.number().positive()).min(1),
+});
+export type DonorDataApiBody = zod.infer<typeof ClinicalDataApiBody>;

--- a/src/clinical/donor-repo.ts
+++ b/src/clinical/donor-repo.ts
@@ -91,6 +91,7 @@ export interface DonorRepository {
     programId: string,
     query: ClinicalDonorEntityQuery,
   ): Promise<DeepReadonly<{ donors: Donor[] }>>;
+  findByDonorIds(donorIds: number[]): Promise<DeepReadonly<Donor[]>>;
   deleteByProgramId(programId: string): Promise<void>;
   deleteByProgramIdAndDonorIds(programId: string, donorIds: number[]): Promise<void>;
   findByProgramAndSubmitterId(
@@ -392,7 +393,17 @@ export const donorDao: DonorRepository = {
       submitterId: { $in: submitterIds },
       programId: programId,
     });
-    const mapped = result.map((d: DonorDocument) => {
+    const mapped = result.map(d => {
+      return MongooseUtils.toPojo(d) as Donor;
+    });
+    return F(mapped);
+  },
+
+  async findByDonorIds(donorIds: number[]): Promise<DeepReadonly<Donor[]>> {
+    const result = await DonorModel.find({
+      donorId: { $in: donorIds },
+    });
+    const mapped = result.map(d => {
       return MongooseUtils.toPojo(d) as Donor;
     });
     return F(mapped);

--- a/src/common-model/entities.ts
+++ b/src/common-model/entities.ts
@@ -80,7 +80,7 @@ export const aliasEntityNames: Record<ClinicalEntitySchemaNames, EntityAlias> = 
   biomarker: 'biomarker',
 };
 
-export const queryEntityNames = Object.values(aliasEntityNames);
+export const allEntityNames = Object.values(aliasEntityNames);
 
 export interface ClinicalEntityErrorRecord extends dictionaryEntities.SchemaValidationError {
   entityName: ClinicalEntitySchemaNames;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -40,13 +40,10 @@ export interface Logger {
 }
 
 const winstonLogger = winston.createLogger(logConfiguration);
-if (process.env.LOG_LEVEL == 'debug') {
+if (process.env.LOG_LEVEL === 'debug') {
   console.log('logger configured: ', winstonLogger);
 }
 export const loggerFor = (fileName: string): Logger => {
-  if (process.env.LOG_LEVEL == 'debug') {
-    console.debug('creating logger for', fileName);
-  }
   const source = fileName.substring(fileName.indexOf('argo-clinical'));
   return {
     error: (msg: string, err: Error): void => {

--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -842,44 +842,43 @@ paths:
         '200':
           description: 'returns new entity exception after deletion'
 
-  /clinical/donors:
-    get:
-      deprecated: true
+  /clinical/donors/tsv:
+    post:
       tags:
-        - Deprecated
-      summary: Get all program donors from db
-      parameters:
-        - $ref: '#/components/parameters/QueryProgramId'
+        - Clinical Data
+      summary: Download TSVs for donors by ID.
+      description: This request downloads all clinical data for donors rquested by ID. The response is a zip containing all clinical data as TSVs. Requires full system read permission to access.
+      requestBody:
+        description: JSON object with list of donor IDs
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                donorIds:
+                  description: List of donor IDs, as numbers, to be included in request. At least one Donor ID minimum is required.
+                  type: array
+                  items:
+                    type: numbers
+                  default: []
       responses:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/ForbiddenError'
+        '400':
+          description: 'User input error. Either the request body was invalid, or some of the requested Donor IDs were not found.'
         '500':
           $ref: '#/components/responses/ServerError'
         '200':
-          description: 'List of donors for the given program'
+          description: 'Zip file with clinical data for requested donors.'
           content:
-            application/json:
+            application/zip:
               schema:
-                type: array
-                items:
-                  type: object
-    delete:
-      tags:
-        - Test
-      summary: Test endpoint to delete program donors in db (disabled in prod)
-      parameters:
-        - $ref: '#/components/parameters/QueryProgramId'
-      responses:
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '403':
-          $ref: '#/components/responses/ForbiddenError'
-        '500':
-          $ref: '#/components/responses/ServerError'
-        '200':
-          description: 'all donors deleted'
+                type: string
+                format: binary
+
   /clinical/program/{programId}/donor/{donorId}:
     get:
       tags:
@@ -1068,6 +1067,16 @@ paths:
       description: Returns a zip file with commited clinical entity data in tsvs, filtered by request query. Exported data may not be valid with current dictionary.
       parameters:
         - $ref: '#/components/parameters/PathProgramId'
+        - in: query
+          name: page
+          schema:
+            type: integer
+          description: Paginated Results page number to return
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+          description: Number of paginated results per page
       requestBody:
         description: JSON object containing search filters
         required: true
@@ -1359,8 +1368,6 @@ tags:
     description: APIs to do the icgc import
   - name: Admin
     description: Admin operations collected for convenience
-  - name: Test
-    description: Protected endpoints that run in dev only, not in prod.
   - name: Deprecated
     description: Deprecated enpoints
 components:

--- a/src/routes/data.ts
+++ b/src/routes/data.ts
@@ -45,10 +45,10 @@ router.post(
   wrapAsync(clinicalApi.getProgramClinicalSearchResults),
 );
 router.post('/program/:programId/clinical-errors', wrapAsync(clinicalApi.getProgramClinicalErrors));
-router.post(
-  '/program/:programId/clinical-tsv',
-  wrapAsync(clinicalApi.getSpecificClinicalDataAsTsvsInZip),
-);
+router.post('/program/:programId/clinical-tsv', wrapAsync(clinicalApi.getDonorDataByIdAsTsvsInZip));
+
+// Download TSVs for Donors by Donor ID
+router.post('/donors/tsv', wrapAsync(clinicalApi.getDonorDataByIdAsTsvsInZip));
 
 // Get TSV Data
 router.get(


### PR DESCRIPTION
**Description of changes**

This adds a new API endpoint at `POST /clinical/donors/tsv` which accepts in the request body an array of donor IDs. It will collect all entity data for the requested donors and return that data in a Zip file with TSVs of each clinical entity.

This endpoint is restricted to Full Read Access only, requiring service level read access.

This will be used by the UI/API for users to request Clinical Data for files/donors that they have embargo level access to. Additional authorization restrictions for this request are managed by the Platform API Gateway.

**Type of Change**

- [ ] Bug
- [ ] Refactor
- [x] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Check copyrights for new files
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
