### PR TITLE
Allow exceptions for arrays with a single value

### DIFF
--- a/test/unit/exception/applyException.spec.ts
+++ b/test/unit/exception/applyException.spec.ts
@@ -86,6 +86,40 @@ describe('submission service apply exceptions', () => {
       chai.expect(result.filteredErrors).to.be.an('array').that.is.empty;
     });
 
+    it('array field, single value - should return zero validation errors if valid program exception exists', async () => {
+      const record = {
+        program_id: TEST_PROGRAM_ID,
+        submitter_donor_id: 'DO-1',
+        specimen_acquisition_interval: ['unknown'],
+      };
+
+      const result = await checkForProgramAndEntityExceptions({
+        programId: TEST_PROGRAM_ID,
+        schemaValidationErrors,
+        record,
+        schemaName: ClinicalEntitySchemaNames.SPECIMEN,
+      });
+
+      chai.expect(result.filteredErrors).to.be.an('array').that.is.empty;
+    });
+
+    it('array field, multiple values - should return validation errors, even if one value matches an exception', async () => {
+      const record = {
+        program_id: TEST_PROGRAM_ID,
+        submitter_donor_id: 'DO-1',
+        specimen_acquisition_interval: ['unknown', 'another value'],
+      };
+
+      const result = await checkForProgramAndEntityExceptions({
+        programId: TEST_PROGRAM_ID,
+        schemaValidationErrors,
+        record,
+        schemaName: ClinicalEntitySchemaNames.SPECIMEN,
+      });
+
+      chai.expect(result.filteredErrors).deep.equal(schemaValidationErrors);
+    });
+
     it('should return validation errors if there are no valid program exceptions ', async () => {
       const record = {
         program_id: TEST_PROGRAM_ID,


### PR DESCRIPTION
**Description of changes**

We want to allow exceptions for submission values of fields that are arrays. These exceptions will only be valid when the field value has exactly one value that is a string.

**Type of Change**

- [ ] Bug
- [ ] Refactor
- [x] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Check copyrights for new files
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
- [x] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
