### PR TITLE
#1082 Numeric Exceptions

### DIFF
--- a/src/exception/exception-api.ts
+++ b/src/exception/exception-api.ts
@@ -40,7 +40,6 @@ const L = loggerFor(__filename);
 type ValidateRecords<T> = (records: ReadonlyArray<TsvUtils.TsvRecordAsJsonObj>) => ReadonlyArray<T>;
 
 const validateProgramExceptionRecords: ValidateRecords<ProgramExceptionRecord> = records => {
-  // temporary
   const normalizedRecords = records.map(exceptionRecord => ({
     ...exceptionRecord,
     requested_exception_value:

--- a/src/exception/exception-api.ts
+++ b/src/exception/exception-api.ts
@@ -40,19 +40,11 @@ const L = loggerFor(__filename);
 type ValidateRecords<T> = (records: ReadonlyArray<TsvUtils.TsvRecordAsJsonObj>) => ReadonlyArray<T>;
 
 const validateProgramExceptionRecords: ValidateRecords<ProgramExceptionRecord> = records => {
-  const normalizedRecords = records.map(exceptionRecord => ({
-    ...exceptionRecord,
-    requested_exception_value:
-      exceptionRecord.requested_exception_value === ''
-        ? undefined
-        : exceptionRecord.requested_exception_value,
-  }));
-
-  if (!isReadonlyArrayOf(normalizedRecords, isProgramExceptionRecord)) {
+  if (!isReadonlyArrayOf(records, isProgramExceptionRecord)) {
     L.debug(`Program Exception TSV_PARSING_FAILED`);
     throw new ExceptionTSVError('Invalid program exception tsv file');
   }
-  return normalizedRecords;
+  return records;
 };
 
 type ValidateEntityRecords<T> = (

--- a/src/exception/exception-api.ts
+++ b/src/exception/exception-api.ts
@@ -40,11 +40,20 @@ const L = loggerFor(__filename);
 type ValidateRecords<T> = (records: ReadonlyArray<TsvUtils.TsvRecordAsJsonObj>) => ReadonlyArray<T>;
 
 const validateProgramExceptionRecords: ValidateRecords<ProgramExceptionRecord> = records => {
-  if (!isReadonlyArrayOf(records, isProgramExceptionRecord)) {
+  // temporary
+  const normalizedRecords = records.map(exceptionRecord => ({
+    ...exceptionRecord,
+    requested_exception_value:
+      exceptionRecord.requested_exception_value === ''
+        ? undefined
+        : exceptionRecord.requested_exception_value,
+  }));
+
+  if (!isReadonlyArrayOf(normalizedRecords, isProgramExceptionRecord)) {
     L.debug(`Program Exception TSV_PARSING_FAILED`);
     throw new ExceptionTSVError('Invalid program exception tsv file');
   }
-  return records;
+  return normalizedRecords;
 };
 
 type ValidateEntityRecords<T> = (

--- a/src/exception/types.ts
+++ b/src/exception/types.ts
@@ -27,7 +27,7 @@ export type ExceptionRecord = {
   program_name: string;
   schema: string;
   requested_core_field: string;
-  requested_exception_value: string | undefined;
+  requested_exception_value: string;
 };
 
 // program exception
@@ -112,8 +112,9 @@ const isExceptionRecordCheck = (input: any) => {
     // requested_core_field must exist and be string
     'requested_core_field' in input &&
     typeof input.requested_core_field === 'string' &&
-    // requested_exception_value must exist
-    'requested_exception_value' in input
+    // requested_exception_value must exist and be string
+    'requested_exception_value' in input &&
+    typeof input.requested_exception_value === 'string'
   );
 };
 

--- a/src/exception/types.ts
+++ b/src/exception/types.ts
@@ -27,7 +27,7 @@ export type ExceptionRecord = {
   program_name: string;
   schema: string;
   requested_core_field: string;
-  requested_exception_value: string;
+  requested_exception_value: string | undefined;
 };
 
 // program exception
@@ -113,8 +113,7 @@ const isExceptionRecordCheck = (input: any) => {
     'requested_core_field' in input &&
     typeof input.requested_core_field === 'string' &&
     // requested_exception_value must exist and be string and be in enum list
-    'requested_exception_value' in input &&
-    typeof input.requested_exception_value === 'string'
+    'requested_exception_value' in input
   );
 };
 

--- a/src/exception/types.ts
+++ b/src/exception/types.ts
@@ -85,7 +85,6 @@ export type EntityExceptionSchemaNames = Extract<
 export const ExceptionValue = {
   Unknown: 'Unknown',
   NotApplicable: 'Not applicable',
-  Empty: '',
 } as const;
 
 export type ExceptionValueType = ObjectValues<typeof ExceptionValue>;

--- a/src/exception/types.ts
+++ b/src/exception/types.ts
@@ -85,6 +85,7 @@ export type EntityExceptionSchemaNames = Extract<
 export const ExceptionValue = {
   Unknown: 'Unknown',
   NotApplicable: 'Not applicable',
+  Empty: '',
 } as const;
 
 export type ExceptionValueType = ObjectValues<typeof ExceptionValue>;
@@ -112,7 +113,7 @@ const isExceptionRecordCheck = (input: any) => {
     // requested_core_field must exist and be string
     'requested_core_field' in input &&
     typeof input.requested_core_field === 'string' &&
-    // requested_exception_value must exist and be string and be in enum list
+    // requested_exception_value must exist
     'requested_exception_value' in input
   );
 };

--- a/src/exception/validation.ts
+++ b/src/exception/validation.ts
@@ -149,24 +149,24 @@ export const checkRequestedValue: Validator<ExceptionRecord> = async ({ record, 
 
   const exceptionFieldDefinition = schemaDefinition?.fields.find(fieldFilter);
 
-  if (exceptionFieldDefinition) {
-    const { valueType } = exceptionFieldDefinition;
-
-    if ((valueType === 'number' || valueType === 'integer') && requested_exception_value !== '') {
-      return {
-        result: ValidationResultType.INVALID,
-        message: `Requested value '${requested_exception_value}' is not valid. Only blank values are allowed for numeric fields.`,
-      };
-    } else if (valueType === 'string' && !validRequests.includes(requested_exception_value)) {
-      return {
-        result: ValidationResultType.INVALID,
-        message: `'${fieldName}' value is not valid. Must be one of [${validRequests.join(', ')}]`,
-      };
-    }
-  } else {
+  if (!exceptionFieldDefinition) {
     return {
       result: ValidationResultType.INVALID,
       message: `The requested core field '${record.requested_core_field}' does not match schema '${record.schema}'. Please update your exception request form.`,
+    };
+  }
+
+  const { valueType } = exceptionFieldDefinition;
+
+  if (valueType === 'number' || valueType === 'integer' || valueType === 'string') {
+    return {
+      result: ValidationResultType.TYPE_ERROR,
+      message: `The requested core field '${record.requested_core_field}' is invalid. Exceptions must be a text or number field.`,
+    };
+  } else if (!validRequests.includes(requested_exception_value)) {
+    return {
+      result: ValidationResultType.INVALID,
+      message: `'${fieldName}' value is not valid. Must be one of [${validRequests.join(', ')}]`,
     };
   }
 

--- a/src/exception/validation.ts
+++ b/src/exception/validation.ts
@@ -166,7 +166,7 @@ export const checkRequestedValue: Validator<ExceptionRecord> = async ({ record, 
   } else {
     return {
       result: ValidationResultType.INVALID,
-      message: `The requested_core_field '${record.requested_core_field}' does not match schema '${record.schema}'. Please update your exception request form.`,
+      message: `The requested core field '${record.requested_core_field}' does not match schema '${record.schema}'. Please update your exception request form.`,
     };
   }
 

--- a/src/exception/validation.ts
+++ b/src/exception/validation.ts
@@ -140,17 +140,7 @@ export const checkRequestedValue: Validator<ExceptionRecord> = ({ record, fieldN
   const validRequests: string[] = Object.values(ExceptionValue);
   const requestedExceptionValue = record.requested_exception_value;
 
-  if (requestedExceptionValue === undefined) {
-    return {
-      result: ValidationResultType.UNDEFINED,
-      message: `${fieldName} value is not defined`,
-    };
-  } else if (typeof requestedExceptionValue !== 'string') {
-    return {
-      result: ValidationResultType.TYPE_ERROR,
-      message: `${fieldName} value is not a string`,
-    };
-  } else if (!validRequests.includes(requestedExceptionValue)) {
+  if (requestedExceptionValue !== undefined && !validRequests.includes(requestedExceptionValue)) {
     return {
       result: ValidationResultType.INVALID,
       message: `'${fieldName}' value is not valid. Must be one of [${validRequests.join(', ')}]`,

--- a/src/exception/validation.ts
+++ b/src/exception/validation.ts
@@ -152,16 +152,16 @@ export const checkRequestedValue: Validator<ExceptionRecord> = async ({ record, 
   if (!exceptionFieldDefinition) {
     return {
       result: ValidationResultType.INVALID,
-      message: `The requested core field '${record.requested_core_field}' does not match schema '${record.schema}'. Please update your exception request form.`,
+      message: `The requested core field '${requested_core_field}' does not match schema '${schemaName}'. Please update your exception request form.`,
     };
   }
 
   const { valueType } = exceptionFieldDefinition;
 
-  if (valueType === 'number' || valueType === 'integer' || valueType === 'string') {
+  if (!(valueType === 'number' || valueType === 'integer' || valueType === 'string')) {
     return {
       result: ValidationResultType.TYPE_ERROR,
-      message: `The requested core field '${record.requested_core_field}' is invalid. Exceptions must be a text or number field.`,
+      message: `The requested core field '${requested_core_field}' is invalid. Exceptions must be a text or number field.`,
     };
   } else if (!validRequests.includes(requested_exception_value)) {
     return {

--- a/src/exception/validation.ts
+++ b/src/exception/validation.ts
@@ -85,6 +85,10 @@ export type FieldValidators<RecordT extends Object> = Partial<
   }
 >;
 
+const schemaFilter = (schemaName: string) => (
+  schema: dictionaryEntities.SchemaDefinition,
+): boolean => schema.name === schemaName;
+
 export const checkCoreField: Validator<ExceptionRecord> = async ({ record, fieldName }) => {
   const currentDictionary = await dictionaryManager.instance();
 
@@ -99,11 +103,9 @@ export const checkCoreField: Validator<ExceptionRecord> = async ({ record, field
 
   const coreFieldFilter = (field: dictionaryEntities.FieldDefinition): boolean =>
     field.name === requestedCoreField && !!field.meta?.core;
-  const schemaFilter = (schema: dictionaryEntities.SchemaDefinition): boolean =>
-    schema.name === record.schema;
 
   const existingDictionarySchema = await currentDictionary.getSchemasWithFields(
-    schemaFilter,
+    schemaFilter(record.schema),
     coreFieldFilter,
   );
 
@@ -142,10 +144,9 @@ export const checkRequestedValue: Validator<ExceptionRecord> = async ({ record, 
   const fieldFilter = (field: dictionaryEntities.FieldDefinition): boolean =>
     field.name === requested_core_field;
 
-  const schemaFilter = (schemaDefintion: dictionaryEntities.SchemaDefinition): boolean =>
-    schemaDefintion.name === schemaName;
-
-  const schemaDefinition = (await currentDictionary.getCurrent()).schemas.find(schemaFilter);
+  const schemaDefinition = (await currentDictionary.getCurrent()).schemas.find(
+    schemaFilter(schemaName),
+  );
 
   const exceptionFieldDefinition = schemaDefinition?.fields.find(fieldFilter);
 
@@ -201,10 +202,9 @@ export const checkIsValidDictionarySchema: Validator<ExceptionRecord> = async ({
 
   const currentDictionary = await dictionaryManager.instance();
 
-  const schemaFilter = (schema: dictionaryEntities.SchemaDefinition): boolean =>
-    schema.name === fieldValue;
-
-  const existingDictionarySchema = await currentDictionary.getSchemasWithFields(schemaFilter);
+  const existingDictionarySchema = await currentDictionary.getSchemasWithFields(
+    schemaFilter(fieldValue),
+  );
 
   const isValid = existingDictionarySchema[0];
 

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -65,7 +65,7 @@ const validateFieldValueWithExceptions = ({
   fieldValue: string;
   validationErrorFieldName: string;
 }): boolean => {
-  const allowedValues: Set<string> = new Set();
+  const allowedValues: Set<string | undefined> = new Set();
 
   // program level is applicable to ALL donors
   if (programException) {

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -204,7 +204,7 @@ export const checkForProgramAndEntityExceptions = async ({
       // ensure value is normalized exception value
       const normalizedExceptionRecord = {
         ...record,
-        [validationErrorFieldName]: normalizedValue, // normalized value keeps this as array for array fields, or string for string fields,
+        [validationErrorFieldName]: normalizedValue, // normalized value keeps this as array for array fields, or string for string fields
       };
       normalizedRecord = normalizedExceptionRecord;
     } else {

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -206,9 +206,7 @@ export const checkForProgramAndEntityExceptions = async ({
       // ensure value is normalized exception value
       // normalized value keeps this as array for array fields, string for string fields, or undefined
       const normalizedValue =
-        typeof normalizedString === 'undefined'
-          ? normalizedString
-          : isSingleString(fieldValue)
+        typeof normalizedString !== 'undefined' && isSingleString(fieldValue)
           ? [normalizedString]
           : normalizedString;
 

--- a/test/unit/exception/validateExceptionUpload.spec.ts
+++ b/test/unit/exception/validateExceptionUpload.spec.ts
@@ -70,6 +70,13 @@ const mockDictionary = {
 };
 
 describe('program exception service', () => {
+  beforeEach(() => {
+    sinon.stub(dictionaryManager, 'instance').returns(
+      // @ts-ignore
+      mockDictionary,
+    );
+  });
+
   afterEach(() => {
     // Restore the default sandbox here
     sinon.restore();
@@ -77,10 +84,6 @@ describe('program exception service', () => {
 
   describe('req param should match submitted program_name in tsv', () => {
     it('[positive] should succeed if req param program id matches program_name in records', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
       const record = createRecord({
         program_name: 'TEST-IE',
       });
@@ -89,11 +92,6 @@ describe('program exception service', () => {
     });
 
     it('[negative] should error if req param program id does not match program_name in records', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
-
       const record = createRecord({
         program_name: 'NOT-TEST-IE',
       });
@@ -105,11 +103,6 @@ describe('program exception service', () => {
 
   describe('check for empty fields', () => {
     it('[positive] should succeed if no empty fields', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
-
       const record = createRecord({ schema: '' });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectToHaveNumberOfErrors(result, 2);
@@ -117,14 +110,8 @@ describe('program exception service', () => {
     });
 
     it('[negative] should error if there are empty fields', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
-
       const record = createRecord({ schema: '' });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
-
       expectToHaveNumberOfErrors(result, 2);
       expectValidationError(result[0], 1, ValidationResultType.EMPTY_FIELD);
     });
@@ -132,25 +119,14 @@ describe('program exception service', () => {
 
   describe('schema', () => {
     it('[positive] should return success when submitted schema is valid schema', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
-
       const record = createRecord();
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectZeroValidationErrors(result);
     });
 
     it('[negative] should return errors when submitted schema is not valid schema', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
-
       const record = createRecord({ schema: 'not_a_valid_schema' });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
-
       expectToHaveNumberOfErrors(result);
       expectValidationError(result[0], 1, ValidationResultType.INVALID);
     });
@@ -158,24 +134,14 @@ describe('program exception service', () => {
 
   describe('requested core field', () => {
     it('[positive] should return successfully if core field is valid dictionary field', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
-
       const record = createRecord();
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectZeroValidationErrors(result);
     });
 
     it('[negative] should return errors if requested core field is not a valid dictionary field', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
       const record = createRecord({ schema: 'not_a_valid_schema' });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
-
       expectToHaveNumberOfErrors(result);
       expectValidationError(result[0], 1, ValidationResultType.INVALID);
     });
@@ -183,30 +149,18 @@ describe('program exception service', () => {
 
   describe('exception value', () => {
     it('[positive] should return successfully if exception value is valid', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
       const record = createRecord({ requested_exception_value: ExceptionValue.NotApplicable });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectZeroValidationErrors(result);
     });
 
     it('[positive] should return successfully if exception value is undefined', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
       const record = createRecord({ requested_exception_value: undefined });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectZeroValidationErrors(result);
     });
 
     it('[negative] should return errors if exception value is invalid', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
       const record = createRecord({ requested_exception_value: 'invalid!' });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectToHaveNumberOfErrors(result);
@@ -216,11 +170,6 @@ describe('program exception service', () => {
 
   describe('duplicate rows', () => {
     it('[positive] should return successfully if there are no duplicate rows', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
-
       const records = [
         createRecord(),
         createRecord({ requested_exception_value: ExceptionValue.NotApplicable }),
@@ -230,14 +179,8 @@ describe('program exception service', () => {
     });
 
     it('[negative] should return errors if duplicate rows found', async () => {
-      sinon.stub(dictionaryManager, 'instance').returns(
-        // @ts-ignore
-        mockDictionary,
-      );
-
       const records = new Array(2).fill(undefined).map(() => createRecord());
       const result = await validateRecords(DEFAULT_PROGRAM_ID, records, commonValidators);
-
       expectToHaveNumberOfErrors(result);
       expectValidationError(result[0], 2, ValidationResultType.INVALID);
     });

--- a/test/unit/exception/validateExceptionUpload.spec.ts
+++ b/test/unit/exception/validateExceptionUpload.spec.ts
@@ -60,7 +60,10 @@ function createRecord(
 const mockSchema = [
   {
     name: 'treatment',
-    fields: [{ name: 'is_primary_treatment', meta: { core: true } }],
+    fields: [
+      { name: 'is_primary_treatment', valueType: 'string', meta: { core: true } },
+      { name: 'treatment_duration', valueType: 'number', meta: { core: true } },
+    ],
   },
 ];
 
@@ -103,10 +106,9 @@ describe('program exception service', () => {
 
   describe('check for empty fields', () => {
     it('[positive] should succeed if no empty fields', async () => {
-      const record = createRecord({ schema: '' });
+      const record = createRecord();
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
-      expectToHaveNumberOfErrors(result, 2);
-      expectValidationError(result[0], 1, ValidationResultType.EMPTY_FIELD);
+      expectZeroValidationErrors(result);
     });
 
     it('[negative] should error if there are empty fields', async () => {
@@ -114,6 +116,7 @@ describe('program exception service', () => {
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectToHaveNumberOfErrors(result, 2);
       expectValidationError(result[0], 1, ValidationResultType.EMPTY_FIELD);
+      expectValidationError(result[1], 1, ValidationResultType.INVALID);
     });
   });
 
@@ -155,7 +158,10 @@ describe('program exception service', () => {
     });
 
     it('[positive] should return successfully if exception value is undefined', async () => {
-      const record = createRecord({ requested_exception_value: undefined });
+      const record = createRecord({
+        requested_core_field: 'treatment_duration',
+        requested_exception_value: '',
+      });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectZeroValidationErrors(result);
     });

--- a/test/unit/exception/validateExceptionUpload.spec.ts
+++ b/test/unit/exception/validateExceptionUpload.spec.ts
@@ -157,26 +157,27 @@ describe('program exception service', () => {
       expectZeroValidationErrors(result);
     });
 
-    it('[positive] should return successfully if exception value is blank for numeric field', async () => {
+    it('[positive] should return successfully if exception value is valid and a numeric field', async () => {
       const record = createRecord({
         requested_core_field: 'treatment_duration',
-        requested_exception_value: '',
+        requested_exception_value: ExceptionValue.Unknown,
       });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectZeroValidationErrors(result);
     });
 
-    it('[negative] should return errors if exception value is string for numeric field', async () => {
-      const record = createRecord({
-        requested_core_field: 'treatment_duration',
-      });
+    it('[negative] should return errors if exception value is invalid', async () => {
+      const record = createRecord({ requested_exception_value: 'invalid!' });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectToHaveNumberOfErrors(result);
       expectValidationError(result[0], 1, ValidationResultType.INVALID);
     });
 
-    it('[negative] should return errors if exception value is invalid', async () => {
-      const record = createRecord({ requested_exception_value: 'invalid!' });
+    it('[negative] should return errors if exception field is numeric and value is an invalid string', async () => {
+      const record = createRecord({
+        requested_core_field: 'treatment_duration',
+        requested_exception_value: 'invalid!',
+      });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectToHaveNumberOfErrors(result);
       expectValidationError(result[0], 1, ValidationResultType.INVALID);

--- a/test/unit/exception/validateExceptionUpload.spec.ts
+++ b/test/unit/exception/validateExceptionUpload.spec.ts
@@ -157,13 +157,23 @@ describe('program exception service', () => {
       expectZeroValidationErrors(result);
     });
 
-    it('[positive] should return successfully if exception value is undefined', async () => {
+    it('[positive] should return successfully if exception value is blank for numeric field', async () => {
       const record = createRecord({
         requested_core_field: 'treatment_duration',
         requested_exception_value: '',
       });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectZeroValidationErrors(result);
+    });
+
+    it('[negative] should return errors if exception value is string for numeric field', async () => {
+      const record = createRecord({
+        requested_core_field: 'treatment_duration',
+      });
+      const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
+      expectToHaveNumberOfErrors(result);
+      console.log('\nresult', result);
+      expectValidationError(result[0], 1, ValidationResultType.INVALID);
     });
 
     it('[negative] should return errors if exception value is invalid', async () => {

--- a/test/unit/exception/validateExceptionUpload.spec.ts
+++ b/test/unit/exception/validateExceptionUpload.spec.ts
@@ -173,10 +173,10 @@ describe('program exception service', () => {
       expectValidationError(result[0], 1, ValidationResultType.INVALID);
     });
 
-    it('[negative] should return errors if exception field is numeric and value is an invalid string', async () => {
+    it('[negative] should return errors if exception field is numeric and value is an empty string', async () => {
       const record = createRecord({
         requested_core_field: 'treatment_duration',
-        requested_exception_value: 'invalid!',
+        requested_exception_value: '',
       });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectToHaveNumberOfErrors(result);

--- a/test/unit/exception/validateExceptionUpload.spec.ts
+++ b/test/unit/exception/validateExceptionUpload.spec.ts
@@ -172,7 +172,6 @@ describe('program exception service', () => {
       });
       const result = await validateRecords(DEFAULT_PROGRAM_ID, [record], commonValidators);
       expectToHaveNumberOfErrors(result);
-      console.log('\nresult', result);
       expectValidationError(result[0], 1, ValidationResultType.INVALID);
     });
 


### PR DESCRIPTION
**Description of changes**

[Issue 1082](https://app.zenhub.com/workspaces/icgc-argo-platform-dk-production-board-5e542d38415f5034e9fed89d/issues/gh/icgc-argo/roadmap/1082)

Allows submitting Exceptions on numeric fields so records can include `undefined` as a field value

**Type of Change**

- [ ] Bug
- [ ] Refactor
- [x] New Feature
- [ ] Release Candidate

**Checklist before requesting review:**

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
