### PR TITLE
Creating Missing Entity Exception should trigger recalculation of core completion for the requested donors

### DIFF
--- a/src/exception/missing-entity-exceptions/api.ts
+++ b/src/exception/missing-entity-exceptions/api.ts
@@ -34,7 +34,7 @@ class MissingEntityExceptionController {
 			const { message, errors } = result;
 			return res.status(500).send({ message, errors });
 		} else {
-			return res.status(200).send(result.exception);
+			return res.status(200).send(result.data);
 		}
 	}
 
@@ -45,7 +45,7 @@ class MissingEntityExceptionController {
 			const { message, errors } = result;
 			return res.status(500).send({ message, errors });
 		} else {
-			return res.status(200).send(result.exception);
+			return res.status(200).send(result.data);
 		}
 	}
 
@@ -73,7 +73,7 @@ class MissingEntityExceptionController {
 			const { message, errors } = result;
 			return res.status(500).send({ message, errors });
 		} else {
-			return res.status(200).send(result.exception);
+			return res.status(200).send(result.data);
 		}
 	}
 
@@ -101,7 +101,7 @@ class MissingEntityExceptionController {
 			const { message, errors } = result;
 			return res.status(500).send({ message, errors });
 		} else {
-			return res.status(200).send(result.exception);
+			return res.status(200).send(result.data);
 		}
 	}
 }

--- a/src/exception/missing-entity-exceptions/missing-entity-exception-cache.ts
+++ b/src/exception/missing-entity-exceptions/missing-entity-exception-cache.ts
@@ -57,7 +57,7 @@ export const createMissingEntityExceptionCache = () => {
 
 		const programExceptionResult = await missingEntityExceptionRepo.getByProgramId(programId);
 		const programException = programExceptionResult.success
-			? programExceptionResult.exception.donorSubmitterIds
+			? programExceptionResult.data.donorSubmitterIds
 			: [];
 
 		programExceptionData.set(programId, programException);

--- a/src/exception/missing-entity-exceptions/service.ts
+++ b/src/exception/missing-entity-exceptions/service.ts
@@ -17,12 +17,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { DeepReadonly } from 'deep-freeze';
+import deepFreeze, { DeepReadonly } from 'deep-freeze';
 import { Donor } from '../../clinical/clinical-entities';
 import { donorDao as donorRepo } from '../../clinical/donor-repo';
 import { loggerFor } from '../../logger';
 import { updateDonorsCompletionStats } from '../../submission/submission-to-clinical/stat-calculator';
-import { F } from '../../utils';
 import { Result, failure, success } from '../../utils/results';
 import { createOrUpdate, getByProgramId } from './repo';
 
@@ -153,7 +152,7 @@ const recalculateAndUpdateDonors = async (props: {
 		const updatedDonors = await updateDonorsCompletionStats(
 			(donorDocuments || []) as DeepReadonly<Donor>[],
 		);
-		const savedDonors = await donorRepo.updateAll(updatedDonors.map((dto) => F(dto)));
+		const savedDonors = await donorRepo.updateAll(updatedDonors.map((dto) => deepFreeze(dto)));
 		return success(savedDonors);
 	} catch (error) {
 		const message = 'Error thrown while updating donor core completion data';

--- a/src/exception/missing-entity-exceptions/service.ts
+++ b/src/exception/missing-entity-exceptions/service.ts
@@ -55,7 +55,7 @@ export const create = async ({
 	const missingEntityExceptionResult = await getByProgramId(programId);
 
 	if (missingEntityExceptionResult.success) {
-		const currentDonorIds = missingEntityExceptionResult.exception.donorSubmitterIds;
+		const currentDonorIds = missingEntityExceptionResult.data.donorSubmitterIds;
 
 		// return unique donor ids
 		const donorSubmitterIds = [...new Set([...currentDonorIds, ...newDonorIds])];
@@ -98,7 +98,7 @@ export const deleteIdsByProgramId = async ({
 }): Promise<Result<DeleteResult>> => {
 	const missingEntityExceptionResult = await getByProgramId(programId);
 	if (missingEntityExceptionResult.success) {
-		const currentDonorIds = missingEntityExceptionResult.exception.donorSubmitterIds;
+		const currentDonorIds = missingEntityExceptionResult.data.donorSubmitterIds;
 		const updatedDonorIds = currentDonorIds.filter((id) => !donorSubmitterIds.includes(id));
 
 		// calc deleted and unchanged ids

--- a/src/submission/submission-to-clinical/stat-calculator.ts
+++ b/src/submission/submission-to-clinical/stat-calculator.ts
@@ -198,6 +198,8 @@ export const updateSingleDonorCompletionStats = async (
  * Re-calculate core-completion stats for each provided donor. Will return a new array with an updated
  * copy of each donor which includes the latest completion stats.
  *
+ * Does not save to DB.
+ *
  * This function retrieves missing-entity exception data in order to use this exception information when
  * calculating core completion stats.
  * @param donors

--- a/src/utils/results.ts
+++ b/src/utils/results.ts
@@ -1,10 +1,10 @@
 // types
-export type Success<T> = { success: true; exception: T };
+export type Success<T> = { success: true; data: T };
 export type Failure = { success: false; message: string; errors?: any };
 export type Result<T> = Success<T> | Failure;
 
 // helpers
-export const success = <T>(exception: T): Success<T> => ({ success: true, exception });
+export const success = <T>(data: T): Success<T> => ({ success: true, data });
 export const failure = (message: string, errors?: any): Failure => ({
 	success: false,
 	message,

--- a/test/unit/exception/missing-entity-exception/service.spec.ts
+++ b/test/unit/exception/missing-entity-exception/service.spec.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import chai from 'chai';
+import sinon from 'sinon';
+import { donorDao as donorRepo } from '../../../../src/clinical/donor-repo';
+import { create } from '../../../../src/exception/missing-entity-exceptions/service';
+import * as missingEntityExceptionsRepo from '../../../../src/exception/missing-entity-exceptions/repo';
+import { success } from '../../../../src/utils/results';
+import * as statCalculator from '../../../../src/submission/submission-to-clinical/stat-calculator';
+
+describe('missing entity exception service', () => {
+	const sandbox = sinon.createSandbox();
+	afterEach(() => {
+		// Restore the default sandbox here
+		sandbox.restore();
+	});
+
+	describe('create', () => {
+		let getByProgramStub: sinon.SinonStub<
+			Parameters<typeof missingEntityExceptionsRepo.getByProgramId>,
+			ReturnType<typeof missingEntityExceptionsRepo.getByProgramId>
+		>;
+		let createOrUpdateStub: sinon.SinonStub<
+			Parameters<typeof missingEntityExceptionsRepo.createOrUpdate>,
+			ReturnType<typeof missingEntityExceptionsRepo.createOrUpdate>
+		>;
+		let findDonorBySubmitterIdsStub: sinon.SinonStub<
+			Parameters<typeof donorRepo.findByProgramAndSubmitterIds>,
+			ReturnType<typeof donorRepo.findByProgramAndSubmitterIds>
+		>;
+		let saveDonorsStub: sinon.SinonStub<
+			Parameters<typeof donorRepo.updateAll>,
+			ReturnType<typeof donorRepo.updateAll>
+		>;
+		let updateCompletStatsStub: sinon.SinonStub<
+			Parameters<typeof statCalculator.updateDonorsCompletionStats>,
+			ReturnType<typeof statCalculator.updateDonorsCompletionStats>
+		>;
+
+		beforeEach(() => {
+			getByProgramStub = sandbox.stub(missingEntityExceptionsRepo, 'getByProgramId');
+			createOrUpdateStub = sandbox.stub(missingEntityExceptionsRepo, 'createOrUpdate');
+			findDonorBySubmitterIdsStub = sandbox.stub(donorRepo, 'findByProgramAndSubmitterIds');
+			saveDonorsStub = sandbox.stub(donorRepo, 'updateAll');
+			updateCompletStatsStub = sandbox.stub(statCalculator, 'updateDonorsCompletionStats');
+		});
+		it('triggers core calculation update for all donors', async () => {
+			const inputs: Parameters<typeof create>[0] = {
+				isDryRun: false,
+				newDonorIds: ['asdf', 'qwerty'],
+				programId: 'EXAMPLE-CA',
+			};
+
+			// set return data for getByProgramId stub, one existing donor
+			getByProgramStub.returns(
+				Promise.resolve(
+					success({
+						donorSubmitterIds: [inputs.newDonorIds[0]],
+						programId: inputs.programId,
+					}),
+				),
+			);
+
+			// createOrUpdate stub returns missingEntityException with all donor IDs from inputs
+			createOrUpdateStub.returns(
+				Promise.resolve(
+					success({
+						donorSubmitterIds: inputs.newDonorIds,
+						programId: inputs.programId,
+					}),
+				),
+			);
+
+			// create missing entity exception
+			await create(inputs);
+
+			// ensure that the update stats method is called as a consequence of creating an exception
+			chai.expect(updateCompletStatsStub.calledOnce).to.be.true;
+		});
+	});
+});

--- a/test/unit/submission/submission-to-clinical.spec.ts
+++ b/test/unit/submission/submission-to-clinical.spec.ts
@@ -296,7 +296,7 @@ describe('submission-to-clinical', () => {
 			missingEntityRepoGetByProgramStub.returns(
 				Promise.resolve({
 					success: true,
-					exception: { donorSubmitterIds: [], programId: 'ABCD-EF' },
+					data: { donorSubmitterIds: [], programId: 'ABCD-EF' },
 				}),
 			);
 


### PR DESCRIPTION
## Description

When missing-entity exceptions are added for a donor we should immediately trigger a recalculation of the core completion stats for that donor.

## Checklist

### Type of Change

- [ ] Bug
- [ ] Refactor
- [x] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Check copyrights for new files
- [ ] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
- [x] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
