### PR TITLE
Allow entities for multiple schemas to be set for the same program

### DIFF
--- a/src/exception/property-exceptions/property-exception-api.ts
+++ b/src/exception/property-exceptions/property-exception-api.ts
@@ -121,7 +121,7 @@ class ExceptionController {
 		// validate tsv structure using cols, does not validate field data
 		const { records: entityExceptionRecords, schema } = validateEntityExceptionRecords(records);
 
-		const result = await exceptionService.createEntityException({
+		const result = await exceptionService.setEntityExceptions({
 			programId,
 			records: entityExceptionRecords,
 			schema,

--- a/src/exception/property-exceptions/property-exception-service.ts
+++ b/src/exception/property-exceptions/property-exception-service.ts
@@ -99,7 +99,7 @@ export const createProgramException = async ({
 };
 
 // entity exceptions
-export const createEntityException = async ({
+export const setEntityExceptions = async ({
 	programId,
 	records,
 	schema,

--- a/src/exception/property-exceptions/repo/entity.ts
+++ b/src/exception/property-exceptions/repo/entity.ts
@@ -67,17 +67,28 @@ const EntityExceptionModel =
 	mongoose.model<EntityException>('EntityException', entityExceptionSchema);
 
 const entityExceptionRepository = {
+	/**
+	 * Create or Update the entity exceptions for this program, setting the exceptions for the specified entity to the list of records provided.
+	 * @param programId
+	 * @param records
+	 * @param entity
+	 * @returns
+	 */
 	async save(
 		programId: string,
 		records: ReadonlyArray<EntityExceptionRecord>,
 		entity: ClinicalEntitySchemaNames,
 	): Promise<EntityException> {
+		// Get the stored entity exceptions for the program. We will replace the records for the entity type specified in the funciton arguments.
+		const existingExceptions = await entityExceptionRepository.find(programId);
+
 		const entities: Record<Entity, typeof records> = {
-			follow_up: [],
-			treatment: [],
-			specimen: [],
+			follow_up: existingExceptions?.follow_up || [],
+			treatment: existingExceptions?.treatment || [],
+			specimen: existingExceptions?.specimen || [],
 		};
-		const update = { ...entities, ...{ [entity]: records } };
+
+		const update = { ...entities, [entity]: records };
 
 		L.debug(`Creating new donor exception for program: ${programId}, entity: ${entity}`);
 

--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -805,7 +805,7 @@ paths:
                 exceptionFile:
                   type: string
                   format: binary
-        description: 'The tsv exception file. There is no required format for the filename. <br/><br/> The "schema" field must use snake case eg. follow_up <br/><br/> __Important__ Only "specimen" and "follow_up" are currently accepted schemas. <br/><br/> __Important:__ Be careful when you submit request form, every new submission will override existing entity level exceptions, please check the current exceptions using the GET endpoint before posting new submission.'
+        description: 'The tsv exception file. There is no required format for the filename. <br/><br/> The "schema" field must use snake case eg. follow_up <br/><br/> __Important__ Currently we can set entity excpetions for "specimen", "follow_up", are "treatment" schemas. <br/><br/> __Important:__ Be careful when you submit request form, every new submission will override existing entity level exceptions, please check the current exceptions using the GET endpoint before posting new submission.'
         required: true
       responses:
         '200':


### PR DESCRIPTION
## Description

Discovered a bug from the recent refactor where setting entity exceptions for one schema would remove entity types of all other schemas on the same program. This updates the behaviour when setting entity exceptions to replace all exceptions for one schema (based on the file headers) while leaving the existing entity exceptions for all other schemas.

## Checklist

### Type of Change

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Check copyrights for new files
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
- [x] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
