### PR TITLE
🧾 Feat/1160 Treatment Detail records added to Exception Manifest

### DIFF
--- a/src/exception/exception-manifest/index.ts
+++ b/src/exception/exception-manifest/index.ts
@@ -42,7 +42,7 @@ export const createExceptionManifest = (
 	donors: DeepReadonly<Donor>[],
 	programExceptions: ReadonlyArray<ProgramExceptionRecord>,
 	entityPropertyException: EntityException | null,
-	missingEntitySubmitterIds: string[],
+	missingEntitySubmitterIds: MissingEntityException['donorSubmitterIds'],
 ) => {
 	// Exceptions only store submitterIds, so all submitterIds have to be collected before we can filter exceptions
 	const submitterDonorIds = donors.map((donor) => donor.submitterId);

--- a/src/exception/exception-manifest/index.ts
+++ b/src/exception/exception-manifest/index.ts
@@ -41,7 +41,7 @@ import {
 	sortExceptionRecordsByEntityId,
 } from './util';
 
-export const createExceptionManifest = async (
+export const createExceptionManifest = (
 	programId: string,
 	donors: DeepReadonly<Donor>[],
 	exceptions: {

--- a/src/exception/exception-manifest/index.ts
+++ b/src/exception/exception-manifest/index.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { DeepReadonly } from 'deep-freeze';
+import { Donor } from '../../clinical/clinical-entities';
+import { EntityException, ProgramExceptionRecord } from '../property-exceptions/types';
+import { MissingEntityException } from '../missing-entity-exceptions/model';
+
+import {
+	MissingEntityExceptionRecord,
+	ProgramPropertyExceptionRecord,
+	EntityPropertyExceptionRecord,
+	ExceptionManifestRecord,
+	ExceptionTypes,
+} from './types';
+
+import {
+	createProgramExceptions,
+	mapEntityExceptionRecords,
+	sortExceptionRecordsBySubmitterId,
+	sortExceptionRecordsByEntityId,
+} from './util';
+
+export const createExceptionManifest = (
+	programId: string,
+	donors: DeepReadonly<Donor>[],
+	programExceptions: ReadonlyArray<ProgramExceptionRecord>,
+	entityPropertyException: EntityException | null,
+	missingEntitySubmitterIds: string[],
+) => {
+	// Exceptions only store submitterIds, so all submitterIds have to be collected before we can filter exceptions
+	const submitterDonorIds = donors.map((donor) => donor.submitterId);
+
+	const programExceptionRecords: ProgramPropertyExceptionRecord[] = programExceptions.map(
+		createProgramExceptions(programId),
+	);
+
+	const sortedFollowUpExceptions =
+		entityPropertyException?.follow_up.sort(sortExceptionRecordsBySubmitterId) || [];
+
+	const sortedSpecimenExceptions =
+		entityPropertyException?.specimen.sort(sortExceptionRecordsBySubmitterId) || [];
+
+	const sortedTreatmentExceptions =
+		entityPropertyException?.treatment.sort(sortExceptionRecordsBySubmitterId) || [];
+
+	const entityPropertyRecords: EntityPropertyExceptionRecord[] = [
+		...sortedFollowUpExceptions,
+		...sortedSpecimenExceptions,
+		...sortedTreatmentExceptions,
+	]
+		.filter((exceptionRecord) => submitterDonorIds.includes(exceptionRecord.submitter_donor_id))
+		.map(mapEntityExceptionRecords(programId, donors))
+		.sort(sortExceptionRecordsByEntityId);
+
+	const missingEntityRecords: MissingEntityExceptionRecord[] = missingEntitySubmitterIds
+		.filter((submitterDonorId) => submitterDonorIds.includes(submitterDonorId))
+		.map((submitterDonorId) => {
+			const exceptionType = ExceptionTypes.missingEntity;
+			const { donorId } = donors.find((donor) => donor.submitterId === submitterDonorId) || {};
+			return { programId, exceptionType, submitterDonorId, donorId };
+		});
+
+	const exceptionManifest: ExceptionManifestRecord[] = [
+		...programExceptionRecords,
+		...entityPropertyRecords,
+		...missingEntityRecords,
+	];
+
+	return exceptionManifest;
+};

--- a/src/exception/exception-manifest/index.ts
+++ b/src/exception/exception-manifest/index.ts
@@ -36,7 +36,8 @@ import {
 import {
 	createProgramExceptions,
 	mapEntityExceptionRecords,
-	sortExceptionRecordsBySubmitterId,
+	sortDonorExceptionRecordsBySubmitterId,
+	sortEntityExceptionRecordsBySubmitterId,
 	sortExceptionRecordsByEntityId,
 } from './util';
 
@@ -65,13 +66,13 @@ export const createExceptionManifest = async (
 	);
 
 	const sortedFollowUpExceptions =
-		entityException?.follow_up.sort(sortExceptionRecordsBySubmitterId) || [];
+		entityException?.follow_up.sort(sortEntityExceptionRecordsBySubmitterId) || [];
 
 	const sortedSpecimenExceptions =
-		entityException?.specimen.sort(sortExceptionRecordsBySubmitterId) || [];
+		entityException?.specimen.sort(sortEntityExceptionRecordsBySubmitterId) || [];
 
 	const sortedTreatmentExceptions =
-		entityException?.treatment.sort(sortExceptionRecordsBySubmitterId) || [];
+		entityException?.treatment.sort(sortEntityExceptionRecordsBySubmitterId) || [];
 
 	const entityPropertyRecords: EntityPropertyExceptionRecord[] = [
 		...sortedFollowUpExceptions,
@@ -92,7 +93,8 @@ export const createExceptionManifest = async (
 			const exceptionType = ExceptionTypes.missingEntity;
 			const { donorId } = donors.find((donor) => donor.submitterId === submitterDonorId) || {};
 			return { programId, exceptionType, submitterDonorId, donorId };
-		});
+		})
+		.sort(sortDonorExceptionRecordsBySubmitterId);
 
 	const treatmentDetailSubmitterIds = treatmentDetailException?.success
 		? treatmentDetailException.data.donorSubmitterIds
@@ -104,7 +106,8 @@ export const createExceptionManifest = async (
 			const exceptionType = ExceptionTypes.treatmentDetail;
 			const { donorId } = donors.find((donor) => donor.submitterId === submitterDonorId) || {};
 			return { programId, exceptionType, submitterDonorId, donorId };
-		});
+		})
+		.sort(sortDonorExceptionRecordsBySubmitterId);
 
 	const exceptionManifest: ExceptionManifestRecord[] = [
 		...programExceptionRecords,

--- a/src/exception/exception-manifest/types.ts
+++ b/src/exception/exception-manifest/types.ts
@@ -24,6 +24,7 @@ export const ExceptionTypes = {
 	programProperty: 'ProgramProperty',
 	entityProperty: 'EntityProperty',
 	missingEntity: 'MissingEntity',
+	treatmentDetail: 'TreatmentDetail',
 } as const;
 
 export type EntityRecord =
@@ -33,6 +34,13 @@ export type EntityRecord =
 
 export type MissingEntityExceptionRecord = {
 	exceptionType: typeof ExceptionTypes.missingEntity;
+	programId: string;
+	donorId?: number;
+	submitterDonorId: string;
+};
+
+export type TreatmentDetailExceptionRecord = {
+	exceptionType: typeof ExceptionTypes.treatmentDetail;
 	programId: string;
 	donorId?: number;
 	submitterDonorId: string;
@@ -59,6 +67,7 @@ export type EntityPropertyExceptionRecord = {
 };
 
 export type ExceptionManifestRecord =
+	| TreatmentDetailExceptionRecord
 	| MissingEntityExceptionRecord
 	| ProgramPropertyExceptionRecord
 	| EntityPropertyExceptionRecord;

--- a/src/exception/exception-manifest/util.ts
+++ b/src/exception/exception-manifest/util.ts
@@ -159,7 +159,7 @@ export const mapEntityExceptionRecords = (programId: string, donors: DeepReadonl
 	return entityRecord;
 };
 
-export const baseExceptionSort = <Exception>(
+const baseExceptionSort = <Exception>(
 	first: Exception,
 	next: Exception,
 	key: keyof Exception,

--- a/src/exception/exception-manifest/util.ts
+++ b/src/exception/exception-manifest/util.ts
@@ -159,13 +159,13 @@ export const mapEntityExceptionRecords = (programId: string, donors: DeepReadonl
 	return entityRecord;
 };
 
-function baseExceptionSort<Exception>(
+export const baseExceptionSort = <Exception>(
 	first: Exception,
 	next: Exception,
 	key: keyof Exception,
-): number {
+): number => {
 	return first[key] === next[key] ? 0 : first[key] > next[key] ? 1 : -1;
-}
+};
 
 export const sortEntityExceptionRecordsBySubmitterId = (
 	first: EntityExceptionRecord,

--- a/src/exception/exception-manifest/util.ts
+++ b/src/exception/exception-manifest/util.ts
@@ -33,6 +33,8 @@ import {
 	ExceptionTypes,
 	ProgramPropertyExceptionRecord,
 	EntityPropertyExceptionRecord,
+	MissingEntityExceptionRecord,
+	TreatmentDetailExceptionRecord,
 } from './types';
 
 const idKeys = {
@@ -157,13 +159,24 @@ export const mapEntityExceptionRecords = (programId: string, donors: DeepReadonl
 	return entityRecord;
 };
 
-export const sortExceptionRecordsBySubmitterId = (
+export const sortEntityExceptionRecordsBySubmitterId = (
 	first: EntityExceptionRecord,
 	next: EntityExceptionRecord,
 ): number => {
 	return first.submitter_donor_id === next.submitter_donor_id
 		? 0
 		: first.submitter_donor_id > next.submitter_donor_id
+		? 1
+		: -1;
+};
+
+export const sortDonorExceptionRecordsBySubmitterId = (
+	first: MissingEntityExceptionRecord | TreatmentDetailExceptionRecord,
+	next: MissingEntityExceptionRecord | TreatmentDetailExceptionRecord,
+): number => {
+	return first.submitterDonorId === next.submitterDonorId
+		? 0
+		: first.submitterDonorId > next.submitterDonorId
 		? 1
 		: -1;
 };

--- a/src/exception/exception-manifest/util.ts
+++ b/src/exception/exception-manifest/util.ts
@@ -159,26 +159,26 @@ export const mapEntityExceptionRecords = (programId: string, donors: DeepReadonl
 	return entityRecord;
 };
 
+function baseExceptionSort<Exception>(
+	first: Exception,
+	next: Exception,
+	key: keyof Exception,
+): number {
+	return first[key] === next[key] ? 0 : first[key] > next[key] ? 1 : -1;
+}
+
 export const sortEntityExceptionRecordsBySubmitterId = (
 	first: EntityExceptionRecord,
 	next: EntityExceptionRecord,
 ): number => {
-	return first.submitter_donor_id === next.submitter_donor_id
-		? 0
-		: first.submitter_donor_id > next.submitter_donor_id
-		? 1
-		: -1;
+	return baseExceptionSort(first, next, 'submitter_donor_id');
 };
 
 export const sortDonorExceptionRecordsBySubmitterId = (
 	first: MissingEntityExceptionRecord | TreatmentDetailExceptionRecord,
 	next: MissingEntityExceptionRecord | TreatmentDetailExceptionRecord,
 ): number => {
-	return first.submitterDonorId === next.submitterDonorId
-		? 0
-		: first.submitterDonorId > next.submitterDonorId
-		? 1
-		: -1;
+	return baseExceptionSort(first, next, 'submitterDonorId');
 };
 
 export const sortExceptionRecordsByEntityId = (

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -302,15 +302,35 @@ export async function getExceptionManifestRecords(
 
 	const programExceptions = programException?.exceptions || [];
 
+	const {
+		specimen: specimenExceptions,
+		follow_up: followUpExceptions,
+		treatment: treatmentExceptions,
+	} = entityException || {
+		specimen: [],
+		follow_up: [],
+		treatment: [],
+	};
+
 	const missingEntityException = await getMissingEntityExceptionByProgram(programId);
+
+	const missingEntitySubmitterIds = missingEntityException?.success
+		? missingEntityException.data.donorSubmitterIds
+		: [];
 
 	const treatmentDetailException = await getTreatmentDetailExceptionByProgram(programId);
 
+	const treatmentDetailSubmitterIds = treatmentDetailException?.success
+		? treatmentDetailException.data.donorSubmitterIds
+		: [];
+
 	const exceptionManifest = createExceptionManifest(programId, donors, {
 		programExceptions,
-		entityException,
-		missingEntityException,
-		treatmentDetailException,
+		specimenExceptions,
+		followUpExceptions,
+		treatmentExceptions,
+		missingEntitySubmitterIds,
+		treatmentDetailSubmitterIds,
 	});
 
 	return exceptionManifest;

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -306,7 +306,7 @@ export async function getExceptionManifestRecords(
 
 	const treatmentDetailException = await getTreatmentDetailExceptionByProgram(programId);
 
-	const exceptionManifest = await createExceptionManifest(programId, donors, {
+	const exceptionManifest = createExceptionManifest(programId, donors, {
 		programExceptions,
 		entityException,
 		missingEntityException,

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -34,7 +34,7 @@ import {
 	ProgramException,
 } from '../../exception/property-exceptions/types';
 import { fieldFilter } from '../../exception/property-exceptions/validation';
-import { getByProgramId as getMissinEntityExceptionByProgram } from '../../exception/missing-entity-exceptions/repo';
+import { getByProgramId as getMissingEntityExceptionByProgram } from '../../exception/missing-entity-exceptions/repo';
 import { getByProgramId as getTreatmentDetailExceptionByProgram } from '../../exception/treatment-detail-exceptions/repo';
 import { createExceptionManifest } from '../../exception/exception-manifest/index';
 import { ExceptionManifestRecord } from '../../exception/exception-manifest/types';
@@ -302,7 +302,7 @@ export async function getExceptionManifestRecords(
 
 	const programExceptions = programException?.exceptions || [];
 
-	const missingEntityException = await getMissinEntityExceptionByProgram(programId);
+	const missingEntityException = await getMissingEntityExceptionByProgram(programId);
 
 	const treatmentDetailException = await getTreatmentDetailExceptionByProgram(programId);
 

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -34,7 +34,6 @@ import {
 	ProgramException,
 } from '../../exception/property-exceptions/types';
 import { fieldFilter } from '../../exception/property-exceptions/validation';
-import { MissingEntityException } from '../../exception/missing-entity-exceptions/model';
 import { getByProgramId as getMissinEntityExceptionByProgram } from '../../exception/missing-entity-exceptions/repo';
 import { getByProgramId as getTreatmentDetailExceptionByProgram } from '../../exception/treatment-detail-exceptions/repo';
 import { createExceptionManifest } from '../../exception/exception-manifest/index';
@@ -45,7 +44,6 @@ import {
 	findDonorsBySubmitterIds,
 } from '../../clinical/clinical-service';
 import { notEmpty } from '../../utils';
-import { Result } from '../../utils/results';
 
 /**
  * query db for program or entity exceptions
@@ -308,7 +306,7 @@ export async function getExceptionManifestRecords(
 
 	const treatmentDetailException = await getTreatmentDetailExceptionByProgram(programId);
 
-	const exceptionManifest = createExceptionManifest(programId, donors, {
+	const exceptionManifest = await createExceptionManifest(programId, donors, {
 		programExceptions,
 		entityException,
 		missingEntityException,

--- a/test/unit/exception/manifest/exceptionManifest.spec.ts
+++ b/test/unit/exception/manifest/exceptionManifest.spec.ts
@@ -217,7 +217,9 @@ describe('Exception Manifest', () => {
 			//  - Schema
 			//  - Submitter Entity ID
 			// Missing Entity Exceptions
+			//  - Submitter Donor ID
 			// Treatment Details Exceptions
+			//  - Submitter Donor ID
 
 			chai
 				.expect(result)

--- a/test/unit/exception/manifest/exceptionManifest.spec.ts
+++ b/test/unit/exception/manifest/exceptionManifest.spec.ts
@@ -27,6 +27,7 @@ import {
 import entityExceptionRepository from '../../../../src/exception/property-exceptions/repo/entity';
 import programExceptionRepository from '../../../../src/exception/property-exceptions/repo/program';
 import * as missingEntityExceptionsRepo from '../../../../src/exception/missing-entity-exceptions/repo';
+import * as treatmentDetailExceptionsRepo from '../../../../src/exception/treatment-detail-exceptions/repo';
 import { getExceptionManifestRecords } from '../../../../src/submission/exceptions/exceptions';
 import { success } from '../../../../src/utils/results';
 import {
@@ -44,6 +45,7 @@ import {
 	emptyEntitiesStub,
 	emptyProgramExceptionStub,
 	emptyMissingEntityStub,
+	emptyTreatmentDetailStub,
 } from './stubs';
 
 const stubDonors = [existingDonor01, existingDonor02, existingDonor03, existingDonor04];
@@ -114,6 +116,9 @@ describe('Exception Manifest', () => {
 			sinon
 				.stub(missingEntityExceptionsRepo, 'getByProgramId')
 				.returns(Promise.resolve(success(missingEntityStub)));
+			sinon
+				.stub(treatmentDetailExceptionsRepo, 'getByProgramId')
+				.returns(Promise.resolve(success(emptyTreatmentDetailStub)));
 			sinon.stub(clinicalService, 'getDonors').returns(Promise.resolve(stubDonors));
 			sinon.stub(clinicalService, 'getDonorsByIds').returns(Promise.resolve([]));
 			sinon
@@ -148,6 +153,9 @@ describe('Exception Manifest', () => {
 			sinon
 				.stub(missingEntityExceptionsRepo, 'getByProgramId')
 				.returns(Promise.resolve(success(missingEntityStub)));
+			sinon
+				.stub(treatmentDetailExceptionsRepo, 'getByProgramId')
+				.returns(Promise.resolve(success(emptyTreatmentDetailStub)));
 			sinon.stub(clinicalService, 'getDonors').returns(Promise.resolve(stubDonors));
 			sinon.stub(clinicalService, 'getDonorsByIds').returns(Promise.resolve([]));
 			sinon
@@ -241,6 +249,9 @@ describe('Exception Manifest', () => {
 			sinon
 				.stub(missingEntityExceptionsRepo, 'getByProgramId')
 				.returns(Promise.resolve(success(emptyMissingEntityStub)));
+			sinon
+				.stub(treatmentDetailExceptionsRepo, 'getByProgramId')
+				.returns(Promise.resolve(success(emptyTreatmentDetailStub)));
 			sinon.stub(clinicalService, 'getDonors').returns(Promise.resolve([]));
 			sinon.stub(clinicalService, 'getDonorsByIds').returns(Promise.resolve(stubFilteredDonors));
 			sinon.stub(clinicalService, 'findDonorsBySubmitterIds').returns(Promise.resolve([]));
@@ -273,6 +284,9 @@ describe('Exception Manifest', () => {
 			sinon
 				.stub(missingEntityExceptionsRepo, 'getByProgramId')
 				.returns(Promise.resolve(success(missingEntityStub)));
+			sinon
+				.stub(treatmentDetailExceptionsRepo, 'getByProgramId')
+				.returns(Promise.resolve(success(emptyTreatmentDetailStub)));
 			sinon.stub(clinicalService, 'getDonorsByIds').returns(Promise.resolve(stubDonors));
 			sinon
 				.stub(clinicalService, 'findDonorsBySubmitterIds')
@@ -304,6 +318,9 @@ describe('Exception Manifest', () => {
 			sinon
 				.stub(missingEntityExceptionsRepo, 'getByProgramId')
 				.returns(Promise.resolve(success(emptyMissingEntityStub)));
+			sinon
+				.stub(treatmentDetailExceptionsRepo, 'getByProgramId')
+				.returns(Promise.resolve(success(emptyTreatmentDetailStub)));
 			sinon.stub(clinicalService, 'getDonors').returns(Promise.resolve([]));
 			sinon.stub(clinicalService, 'getDonorsByIds').returns(Promise.resolve([]));
 			sinon.stub(clinicalService, 'findDonorsBySubmitterIds').returns(Promise.resolve(undefined));

--- a/test/unit/exception/manifest/exceptionManifest.spec.ts
+++ b/test/unit/exception/manifest/exceptionManifest.spec.ts
@@ -40,6 +40,7 @@ import {
 	missingEntityStub,
 	allEntitiesStub,
 	sortingEntitiesStub,
+	treatmentDetailStub,
 	donorIdEntitiesStub,
 	submitterIdEntitiesStub,
 	emptyEntitiesStub,
@@ -103,6 +104,13 @@ const missingEntityTestResult = {
 	donorId: 4,
 };
 
+const treatmentDetailTestResult = {
+	programId: 'TEST-IE',
+	exceptionType: 'TreatmentDetail',
+	submitterDonorId: 'DO-2',
+	donorId: 2,
+};
+
 describe('Exception Manifest', () => {
 	afterEach(() => {
 		// Restore the default sandbox here
@@ -118,7 +126,7 @@ describe('Exception Manifest', () => {
 				.returns(Promise.resolve(success(missingEntityStub)));
 			sinon
 				.stub(treatmentDetailExceptionsRepo, 'getByProgramId')
-				.returns(Promise.resolve(success(emptyTreatmentDetailStub)));
+				.returns(Promise.resolve(success(treatmentDetailStub)));
 			sinon.stub(clinicalService, 'getDonors').returns(Promise.resolve(stubDonors));
 			sinon.stub(clinicalService, 'getDonorsByIds').returns(Promise.resolve([]));
 			sinon
@@ -136,13 +144,14 @@ describe('Exception Manifest', () => {
 			chai
 				.expect(result)
 				.to.be.an('array')
-				.with.lengthOf(5);
+				.with.lengthOf(6);
 
 			chai.expect(result).to.deep.include(programTestResult);
 			chai.expect(result).to.deep.include(entityTestResultA);
 			chai.expect(result).to.deep.include(entityTestResultB);
 			chai.expect(result).to.deep.include(entityTestResultC);
 			chai.expect(result).to.deep.include(missingEntityTestResult);
+			chai.expect(result).to.deep.include(treatmentDetailTestResult);
 		});
 	});
 

--- a/test/unit/exception/manifest/exceptionManifest.spec.ts
+++ b/test/unit/exception/manifest/exceptionManifest.spec.ts
@@ -97,14 +97,42 @@ const entityTestResultC = {
 	entityId: 30,
 };
 
-const missingEntityTestResult = {
+const missingEntityTestResultA = {
+	programId: 'TEST-IE',
+	exceptionType: 'MissingEntity',
+	submitterDonorId: 'AB3',
+	donorId: 3,
+};
+
+const missingEntityTestResultB = {
 	programId: 'TEST-IE',
 	exceptionType: 'MissingEntity',
 	submitterDonorId: 'AB4',
 	donorId: 4,
 };
 
-const treatmentDetailTestResult = {
+const missingEntityTestResultC = {
+	programId: 'TEST-IE',
+	exceptionType: 'MissingEntity',
+	submitterDonorId: 'DO-0',
+	donorId: 0,
+};
+
+const treatmentDetailTestResultA = {
+	programId: 'TEST-IE',
+	exceptionType: 'TreatmentDetail',
+	submitterDonorId: 'AB3',
+	donorId: 3,
+};
+
+const treatmentDetailTestResultB = {
+	programId: 'TEST-IE',
+	exceptionType: 'TreatmentDetail',
+	submitterDonorId: 'DO-0',
+	donorId: 0,
+};
+
+const treatmentDetailTestResultC = {
 	programId: 'TEST-IE',
 	exceptionType: 'TreatmentDetail',
 	submitterDonorId: 'DO-2',
@@ -144,14 +172,18 @@ describe('Exception Manifest', () => {
 			chai
 				.expect(result)
 				.to.be.an('array')
-				.with.lengthOf(6);
+				.with.lengthOf(10);
 
 			chai.expect(result).to.deep.include(programTestResult);
 			chai.expect(result).to.deep.include(entityTestResultA);
 			chai.expect(result).to.deep.include(entityTestResultB);
 			chai.expect(result).to.deep.include(entityTestResultC);
-			chai.expect(result).to.deep.include(missingEntityTestResult);
-			chai.expect(result).to.deep.include(treatmentDetailTestResult);
+			chai.expect(result).to.deep.include(missingEntityTestResultA);
+			chai.expect(result).to.deep.include(missingEntityTestResultB);
+			chai.expect(result).to.deep.include(missingEntityTestResultC);
+			chai.expect(result).to.deep.include(treatmentDetailTestResultA);
+			chai.expect(result).to.deep.include(treatmentDetailTestResultB);
+			chai.expect(result).to.deep.include(treatmentDetailTestResultC);
 		});
 	});
 
@@ -190,7 +222,7 @@ describe('Exception Manifest', () => {
 			chai
 				.expect(result)
 				.to.be.an('array')
-				.with.lengthOf(11);
+				.with.lengthOf(15);
 
 			// Expect Program Exceptions sorted first
 			chai
@@ -204,9 +236,14 @@ describe('Exception Manifest', () => {
 
 			// Expect Treatment Detail Exceptions sorted last
 			chai
-				.expect(result.findIndex((exception) => exception.exceptionType === 'TreatmentDetail'))
+				.expect(
+					result.findIndex(
+						(exception) =>
+							exception.exceptionType === 'TreatmentDetail' &&
+							exception.submitterDonorId === treatmentDetailTestResultC.submitterDonorId,
+					),
+				)
 				.equals(result.length - 1);
-
 			// Test Entities
 			const entityResults = result.filter((exception) =>
 				isEntityManifestRecord(exception),
@@ -325,10 +362,10 @@ describe('Exception Manifest', () => {
 			chai
 				.expect(result)
 				.to.be.an('array')
-				.with.lengthOf(2);
+				.with.lengthOf(4);
 
 			chai.expect(result).to.deep.include(entityTestResultC);
-			chai.expect(result).to.deep.include(missingEntityTestResult);
+			chai.expect(result).to.deep.include(missingEntityTestResultA);
 		});
 	});
 

--- a/test/unit/exception/manifest/stubs.ts
+++ b/test/unit/exception/manifest/stubs.ts
@@ -294,6 +294,11 @@ export const missingEntityStub: MissingEntityException = {
 	donorSubmitterIds: ['AB4'],
 };
 
+export const emptyTreatmentDetailStub: MissingEntityException = {
+	programId: TEST_PROGRAM_ID,
+	donorSubmitterIds: [],
+};
+
 export const allEntitiesStub: EntityException = {
 	programId: TEST_PROGRAM_ID,
 	specimen: [specimenExceptionStub],

--- a/test/unit/exception/manifest/stubs.ts
+++ b/test/unit/exception/manifest/stubs.ts
@@ -20,6 +20,7 @@
 import { Donor } from '../../../../src/clinical/clinical-entities';
 import { FollowupFieldsEnum, TreatmentFieldsEnum } from '../../../../src/common-model/entities';
 import { MissingEntityException } from '../../../../src/exception/missing-entity-exceptions/model';
+import { TreatmentDetailException } from '../../../../src/exception/treatment-detail-exceptions/model';
 import {
 	FollowUpExceptionRecord,
 	ProgramException,
@@ -294,9 +295,9 @@ export const missingEntityStub: MissingEntityException = {
 	donorSubmitterIds: ['AB4'],
 };
 
-export const emptyTreatmentDetailStub: MissingEntityException = {
+export const treatmentDetailStub: MissingEntityException = {
 	programId: TEST_PROGRAM_ID,
-	donorSubmitterIds: [],
+	donorSubmitterIds: ['DO-2'],
 };
 
 export const allEntitiesStub: EntityException = {
@@ -345,6 +346,11 @@ export const emptyProgramExceptionStub: ProgramException = {
 };
 
 export const emptyMissingEntityStub: MissingEntityException = {
+	programId: TEST_PROGRAM_ID,
+	donorSubmitterIds: [],
+};
+
+export const emptyTreatmentDetailStub: TreatmentDetailException = {
 	programId: TEST_PROGRAM_ID,
 	donorSubmitterIds: [],
 };

--- a/test/unit/exception/manifest/stubs.ts
+++ b/test/unit/exception/manifest/stubs.ts
@@ -292,12 +292,12 @@ export const treatmentExceptionStub4: TreatmentExceptionRecord = {
 
 export const missingEntityStub: MissingEntityException = {
 	programId: TEST_PROGRAM_ID,
-	donorSubmitterIds: ['AB4'],
+	donorSubmitterIds: ['AB4', 'AB3', 'DO-0'],
 };
 
 export const treatmentDetailStub: MissingEntityException = {
 	programId: TEST_PROGRAM_ID,
-	donorSubmitterIds: ['DO-2'],
+	donorSubmitterIds: ['DO-2', 'AB3', 'DO-0'],
 };
 
 export const allEntitiesStub: EntityException = {


### PR DESCRIPTION
## Link to Issue
Unit test & TSV output in ticket
[#1160](https://app.zenhub.com/workspaces/icgc-argo-platform-dk-production-board-5e542d38415f5034e9fed89d/issues/gh/icgc-argo/argo-clinical/1160)
## Description
- Adds Treatment Detail Exception Records to Manifest
- Moves main exception manifest code to own file
- Updates Sorting for Missing Entity & Treatment Detail exception records
- Updates Unit Tests

## Checklist

### Type of Change

- [ ] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
