### PR TITLE
🏷️ 1141 Add Exception Manifest to Donor tsv

### DIFF
--- a/src/clinical/api/clinical-api.ts
+++ b/src/clinical/api/clinical-api.ts
@@ -207,7 +207,12 @@ class ClinicalController {
 						(record) =>
 							typeof record.donor_id === 'number' && record.program_id === programShortName,
 					)
-					.map((record) => Number(record.donor_id));
+					.map((record) => Number(record.donor_id))
+					.filter(
+						(donorId, index, array) =>
+							// Remove duplicate donorIds
+							array.indexOf(donorId) === index,
+					);
 
 				const programExceptions =
 					(await getExceptionManifestRecords(programShortName, {

--- a/src/clinical/api/clinical-api.ts
+++ b/src/clinical/api/clinical-api.ts
@@ -186,6 +186,12 @@ class ClinicalController {
 		const date = currentDateFormatted();
 		const fileName = `filename=Donor_Clinical_Data_${date}.zip`;
 
+		// const exceptions =
+		// 	(await getExceptionManifestRecords(programShortName, {
+		// 		donorIds,
+		// 		submitterDonorIds,
+		// 	})) || [];
+
 		res
 			.status(200)
 			.contentType('application/zip')

--- a/src/clinical/api/clinical-api.ts
+++ b/src/clinical/api/clinical-api.ts
@@ -30,7 +30,7 @@ import {
 } from '../../decorators';
 import { ControllerUtils, DonorUtils, TsvUtils } from '../../utils';
 import AdmZip from 'adm-zip';
-import { ClinicalEntityData, Donor } from '../clinical-entities';
+import { ClinicalEntityData, ClinicalInfo, Donor } from '../clinical-entities';
 import { omit } from 'lodash';
 import { DeepReadonly } from 'deep-freeze';
 import {
@@ -204,10 +204,10 @@ class ClinicalController {
 				// Get Donor Ids + Exceptions for each program
 				const programDonors = entityRecords
 					.filter(
-						(record) =>
+						(record): record is ClinicalInfo & { donor_id: number; program_id: string } =>
 							typeof record.donor_id === 'number' && record.program_id === programShortName,
 					)
-					.map((record) => Number(record.donor_id))
+					.map((record) => record.donor_id)
 					.filter(
 						(donorId, index, array) =>
 							// Remove duplicate donorIds

--- a/src/clinical/clinical-service.ts
+++ b/src/clinical/clinical-service.ts
@@ -48,7 +48,7 @@ import {
 import { migrationRepo } from '../submission/migration/migration-repo';
 import { prepareForSchemaReProcessing } from '../submission/submission-service';
 import { Errors, notEmpty } from '../utils';
-import { ClinicalEntityData, ClinicalInfo, Donor, Sample } from './clinical-entities';
+import { ClinicalEntityData, Donor, Sample } from './clinical-entities';
 import { DONOR_DOCUMENT_FIELDS, donorDao } from './donor-repo';
 import { runTaskInWorkerThread } from './service-worker-thread/runner';
 import { WorkerTasks } from './service-worker-thread/tasks';


### PR DESCRIPTION
## Link to Issue

[#1141](https://app.zenhub.com/workspaces/icgc-argo-platform-dk-production-board-5e542d38415f5034e9fed89d/issues/gh/icgc-argo/roadmap/1141)

## Description

- Adds Exception Manifest to `getDonorDataByIdAsTsvsInZip` at `/donors/tsv`

- Allows downloading exceptions from multiple programs if files from multiple programs are selected (which is possible, tested in QA)
Example output in ticket

## Checklist

### Type of Change

- [ ] Bug
- [ ] Refactor
- [x] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
