### PR TITLE
🕷️ Remove unused Create Zip argument

### DIFF
--- a/src/clinical/api/clinical-api.ts
+++ b/src/clinical/api/clinical-api.ts
@@ -108,7 +108,7 @@ class ClinicalController {
 			.contentType('application/zip')
 			.attachment(`${programId}_Clinical_Data_${todaysDate}.zip`);
 
-		const zip = createClinicalZipFile(data, { programShortName: programId, exceptions });
+		const zip = createClinicalZipFile(data, exceptions);
 
 		res.send(zip.toBuffer());
 	}


### PR DESCRIPTION
## Link to Issue

## Description

- Remove 'programShortName' from `create zip file` usage

## Checklist

### Type of Change

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
