### PR TITLE
❌ Sort Invalid Clinical Records first

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@apollo/server": "4.0.0",
 				"@apollo/subgraph": "2.5.2",
 				"@icgc-argo/ego-token-utils": "^8.2.0",
-				"@overturebio-stack/lectern-client": "1.4.0",
+				"@overturebio-stack/lectern-client": "^1.5.0",
 				"@types/mongoose-paginate-v2": "^1.3.11",
 				"adm-zip": "^0.4.16",
 				"apollo-server-core": "^3.12.0",
@@ -1025,9 +1025,9 @@
 			}
 		},
 		"node_modules/@overturebio-stack/lectern-client": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@overturebio-stack/lectern-client/-/lectern-client-1.4.0.tgz",
-			"integrity": "sha512-+T16UkGEOvAkt/QwfQwjO1C/kUzA71r9pjBfn/yymCBmpA5rabflMAYB8HjcVsCltoqamClMQiNAV1K+iaJOLA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@overturebio-stack/lectern-client/-/lectern-client-1.5.0.tgz",
+			"integrity": "sha512-WYLwlWE09yR/SG6FqhAbbFynY3+ViclVbGJO0PO6Uspe5Pe7YKOfzWO9udlO4f40y+ZnwDlzkaJgMsk/AocyhQ==",
 			"dependencies": {
 				"cd": "^0.3.3",
 				"deep-freeze": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -97,13 +97,13 @@
 		"typescript": "^5.0.0"
 	},
 	"dependencies": {
-		"@apollo/subgraph": "2.5.2",
-		"apollo-server-core": "^3.12.0",
 		"@apollo/server": "4.0.0",
-		"@overturebio-stack/lectern-client": "1.4.0",
-		"@types/mongoose-paginate-v2": "^1.3.11",
+		"@apollo/subgraph": "2.5.2",
 		"@icgc-argo/ego-token-utils": "^8.2.0",
+		"@overturebio-stack/lectern-client": "^1.5.0",
+		"@types/mongoose-paginate-v2": "^1.3.11",
 		"adm-zip": "^0.4.16",
+		"apollo-server-core": "^3.12.0",
 		"async": "^3.0.1",
 		"bcrypt-nodejs": "^0.0.3",
 		"bluebird": "^3.5.5",

--- a/src/clinical/clinical-service.ts
+++ b/src/clinical/clinical-service.ts
@@ -24,6 +24,7 @@ import {
 import { DeepReadonly } from 'deep-freeze';
 import _ from 'lodash';
 import {
+	ClinicalDataSortTypes,
 	ClinicalEntityErrorRecord,
 	ClinicalEntitySchemaNames,
 	ClinicalErrorsResponseRecord,
@@ -69,7 +70,7 @@ export type PaginationQuery = {
 	sort: string;
 };
 
-type ClinicalDataPaginatedQuery = ClinicalDonorEntityQuery & PaginationQuery;
+export type ClinicalDataPaginatedQuery = ClinicalDonorEntityQuery & PaginationQuery;
 
 export type ClinicalDataQuery = ClinicalDataPaginatedQuery & {
 	completionState?: {};
@@ -231,8 +232,31 @@ export const getPaginatedClinicalData = async (programId: string, query: Clinica
 	// Get all donors + records for given entity
 	const { donors, totalDonors } = await donorDao.findByPaginatedProgramId(programId, query);
 
+	const donorIds = donors.map((donor) => donor.donorId);
+
+	const isDefaultDonorSort = query.sort.includes('completionStats.coreCompletionPercentage');
+	const isInvalidSort = query.sort.includes('schemaMetadata.isValid');
+
+	const clinicalErrors = isInvalidSort
+		? (await getClinicalErrors(programId, donorIds)).clinicalErrors
+		: [];
+
+	const sortType = isDefaultDonorSort
+		? ClinicalDataSortTypes.defaultDonor
+		: isInvalidSort
+		? ClinicalDataSortTypes.invalidEntity
+		: ClinicalDataSortTypes.columnSort;
+
 	const taskToRun = WorkerTasks.ExtractEntityDataFromDonors;
-	const taskArgs = [donors as Donor[], totalDonors, allSchemasWithFields, query.entityTypes, query];
+	const taskArgs = [
+		donors as Donor[],
+		totalDonors,
+		allSchemasWithFields,
+		query.entityTypes,
+		query,
+		sortType,
+		clinicalErrors,
+	];
 
 	// Return paginated data
 	const data = await runTaskInWorkerThread<{ clinicalEntities: ClinicalEntityData[] }>(

--- a/src/clinical/clinical-service.ts
+++ b/src/clinical/clinical-service.ts
@@ -24,6 +24,7 @@ import {
 import { DeepReadonly } from 'deep-freeze';
 import _ from 'lodash';
 import {
+	ClinicalDataSortType,
 	ClinicalDataSortTypes,
 	ClinicalEntityErrorRecord,
 	ClinicalEntitySchemaNames,
@@ -241,7 +242,7 @@ export const getPaginatedClinicalData = async (programId: string, query: Clinica
 		? (await getClinicalErrors(programId, donorIds)).clinicalErrors
 		: [];
 
-	const sortType = isDefaultDonorSort
+	const sortType: ClinicalDataSortType = isDefaultDonorSort
 		? ClinicalDataSortTypes.defaultDonor
 		: isInvalidSort
 		? ClinicalDataSortTypes.invalidEntity

--- a/src/clinical/service-worker-thread/tasks.ts
+++ b/src/clinical/service-worker-thread/tasks.ts
@@ -180,8 +180,10 @@ const mapEntityDocuments = (
 	switch (sortType) {
 		case ClinicalDataSortTypes.defaultDonor:
 			records = results.sort(sortDocs(sort, completionStats, sortDonorRecordsByCompletion));
+			break;
 		case ClinicalDataSortTypes.invalidEntity:
 			records = sortInvalidRecords(errors, results, entityName);
+			break;
 		case ClinicalDataSortTypes.columnSort:
 		default:
 			const sortKey = sort[0] === '-' ? sort.split('-')[1] : sort;

--- a/src/clinical/service-worker-thread/tasks.ts
+++ b/src/clinical/service-worker-thread/tasks.ts
@@ -156,10 +156,7 @@ const mapEntityDocuments = (
 			records = results.sort(sortDocs(sort, completionStats, sortDonorRecordsByCompletion));
 		case ClinicalDataSortTypes.invalidEntity:
 			const entityErrors = errors.filter((errorRecord) => errorRecord.entityName === entityName);
-			const donorIdsWithErrors = entityErrors.reduce<Set<number>>(
-				(acc, error) => acc.add(error.donorId),
-				new Set(),
-			);
+			const donorIdsWithErrors = new Set(entityErrors.map((error) => error.donorId));
 			records = results.sort(sortDocs(sort, donorIdsWithErrors, sortInvalidRecords));
 		case ClinicalDataSortTypes.columnSort:
 		default:

--- a/src/clinical/service-worker-thread/tasks.ts
+++ b/src/clinical/service-worker-thread/tasks.ts
@@ -20,7 +20,9 @@
 import { DeepReadonly } from 'deep-freeze';
 import _, { isEmpty } from 'lodash';
 import {
+	ClinicalDataSortTypes,
 	ClinicalEntitySchemaNames,
+	ClinicalErrorsResponseRecord,
 	EntityAlias,
 	aliasEntityNames,
 } from '../../common-model/entities';
@@ -58,21 +60,21 @@ const isEntityInQuery = (entityName: ClinicalEntitySchemaNames, entityTypes: str
 // Main Sort Function
 const sortDocs = (
 	sortQuery: string,
-	entityName: string,
 	completionStats: CompletionDisplayRecord[],
+	sortType: keyof typeof ClinicalDataSortTypes,
+	errors: ClinicalErrorsResponseRecord[],
 ) => (currentRecord: ClinicalInfo, nextRecord: ClinicalInfo) => {
 	// Sort Value: 0 order is Unchanged, -1 Current lower index than Next, +1 Current higher index than Next
 	let order = 0;
 	const isDescending = sortQuery.startsWith('-');
-	const isDefaultSort =
-		entityName === ClinicalEntitySchemaNames.DONOR &&
-		sortQuery.includes('completionStats.coreCompletionPercentage');
 
 	const queryKey = isDescending ? sortQuery.split('-')[1] : sortQuery;
-	const key = queryKey === 'donorId' ? 'donor_id' : queryKey;
+	const key = queryKey === 'donorId' ? DONOR_ID_FIELD : queryKey;
 
-	if (isDefaultSort) {
+	if (sortType === ClinicalDataSortTypes.defaultDonor) {
 		order = sortDonorRecordsByCompletion(currentRecord, nextRecord, completionStats);
+	} else if (sortType === ClinicalDataSortTypes.invalidEntity) {
+		order = sortInvalidRecords(currentRecord, nextRecord, errors);
 	} else {
 		order = sortRecordsByColumn(currentRecord, nextRecord, key);
 	}
@@ -116,6 +118,20 @@ const sortRecordsByColumn = (
 	return valueSort;
 };
 
+// Sort Invalid Records to Top
+const sortInvalidRecords = (
+	currentRecord: ClinicalInfo,
+	nextRecord: ClinicalInfo,
+	errors: ClinicalErrorsResponseRecord[],
+) => {
+	const currentRecordIsInvalid = errors.some((record) => record.donorId === currentRecord.donor_id);
+	const nextRecordIsInvalid = errors.some((record) => record.donorId === nextRecord.donor_id);
+	const invalidSort =
+		currentRecordIsInvalid === nextRecordIsInvalid ? 0 : currentRecordIsInvalid ? -1 : 1;
+
+	return invalidSort;
+};
+
 // Formats + Organizes Clinical Data
 const mapEntityDocuments = (
 	entity: EntityClinicalInfo,
@@ -124,6 +140,8 @@ const mapEntityDocuments = (
 	entityTypes: EntityAlias[],
 	paginationQuery: PaginationQuery,
 	completionStats: CompletionDisplayRecord[],
+	sortType: keyof typeof ClinicalDataSortTypes,
+	errors: ClinicalErrorsResponseRecord[],
 ): ClinicalEntityData | undefined => {
 	const { entityName, results } = entity;
 
@@ -131,13 +149,14 @@ const mapEntityDocuments = (
 	const { page, pageSize = results.length, sort } = paginationQuery;
 	const relevantSchemaWithFields = schemas.find((s: any) => s.name === entityName);
 	const entityInQuery = isEntityInQuery(entityName, entityTypes);
+	const entityErrors = errors.filter((errorRecord) => errorRecord.entityName === entityName);
 
 	if (!relevantSchemaWithFields || !entityInQuery || isEmpty(results)) {
 		return undefined;
 	}
 
 	const totalDocs = entityName === ClinicalEntitySchemaNames.DONOR ? donorCount : results.length;
-	let records = results.sort(sortDocs(sort, entityName, completionStats));
+	let records = results.sort(sortDocs(sort, completionStats, sortType, entityErrors));
 
 	if (records.length > pageSize) {
 		// Manual Pagination
@@ -254,6 +273,8 @@ function extractEntityDataFromDonors(
 	schemasWithFields: any,
 	entityTypes: EntityAlias[],
 	paginationQuery: PaginationQuery,
+	sortType: keyof typeof ClinicalDataSortTypes,
+	errors: ClinicalErrorsResponseRecord[],
 ) {
 	let clinicalEntityData: EntityClinicalInfo[] = [];
 
@@ -312,6 +333,8 @@ function extractEntityDataFromDonors(
 				entityTypes,
 				paginationQuery,
 				completionStats,
+				sortType,
+				errors,
 			),
 		)
 		.filter(notEmpty);

--- a/src/clinical/service-worker-thread/tasks.ts
+++ b/src/clinical/service-worker-thread/tasks.ts
@@ -165,7 +165,7 @@ const mapEntityDocuments = (
 		default:
 			const sortKey = sort[0] === '-' ? sort.split('-')[1] : sort;
 			const key = sortKey === 'donorId' ? DONOR_ID_FIELD : sortKey;
-			sortDocs(sort, key, sortRecordsByColumn);
+			records = results.sort(sortDocs(sort, key, sortRecordsByColumn));
 	}
 
 	if (records.length > pageSize) {

--- a/src/clinical/service-worker-thread/tasks.ts
+++ b/src/clinical/service-worker-thread/tasks.ts
@@ -61,7 +61,7 @@ const isEntityInQuery = (entityName: ClinicalEntitySchemaNames, entityTypes: str
 const sortDocs = (
 	sortQuery: string,
 	sortFunction: (currentRecord: ClinicalInfo, nextRecord: ClinicalInfo, rest: any) => number,
-	sortArgs: any,
+	sortArgs: CompletionDisplayRecord[] | Set<number> | string,
 ) => (currentRecord: ClinicalInfo, nextRecord: ClinicalInfo) => {
 	// Sort Value: 0 order is Unchanged, -1 Current lower index than Next, +1 Current higher index than Next
 	let order = 0;

--- a/src/clinical/service-worker-thread/tasks.ts
+++ b/src/clinical/service-worker-thread/tasks.ts
@@ -20,6 +20,7 @@
 import { DeepReadonly } from 'deep-freeze';
 import _, { isEmpty } from 'lodash';
 import {
+	ClinicalDataSortType,
 	ClinicalDataSortTypes,
 	ClinicalEntitySchemaNames,
 	ClinicalErrorsResponseRecord,
@@ -132,7 +133,7 @@ const mapEntityDocuments = (
 	entityTypes: EntityAlias[],
 	paginationQuery: PaginationQuery,
 	completionStats: CompletionDisplayRecord[],
-	sortType: keyof typeof ClinicalDataSortTypes,
+	sortType: ClinicalDataSortType,
 	errors: ClinicalErrorsResponseRecord[],
 ): ClinicalEntityData | undefined => {
 	const { entityName, results } = entity;
@@ -282,7 +283,7 @@ function extractEntityDataFromDonors(
 	schemasWithFields: any,
 	entityTypes: EntityAlias[],
 	paginationQuery: PaginationQuery,
-	sortType: keyof typeof ClinicalDataSortTypes,
+	sortType: ClinicalDataSortType,
 	errors: ClinicalErrorsResponseRecord[],
 ) {
 	let clinicalEntityData: EntityClinicalInfo[] = [];

--- a/src/common-model/entities.ts
+++ b/src/common-model/entities.ts
@@ -19,6 +19,7 @@
 
 import { z as zod } from 'zod';
 import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { Values } from '../utils/objectTypes';
 
 // this is temporary to keep code compiling until surgery is ready in dictionary, to be removed in favor of
 // the surgery in ClinicalEntitySchemaNames
@@ -99,6 +100,8 @@ export const ClinicalDataSortTypes = {
 	invalidEntity: 'invalidEntity',
 	columnSort: 'columnSort',
 };
+
+export type ClinicalDataSortType = Values<typeof ClinicalDataSortTypes>;
 
 export type ClinicalFields =
 	| DonorFieldsEnum

--- a/src/common-model/entities.ts
+++ b/src/common-model/entities.ts
@@ -94,6 +94,12 @@ export interface ClinicalErrorsResponseRecord {
 	errors: ClinicalEntityErrorRecord[];
 }
 
+export const ClinicalDataSortTypes = {
+	defaultDonor: 'defaultDonor',
+	invalidEntity: 'invalidEntity',
+	columnSort: 'columnSort',
+};
+
 export type ClinicalFields =
 	| DonorFieldsEnum
 	| SpecimenFieldsEnum

--- a/test/integration/stub-schema.json
+++ b/test/integration/stub-schema.json
@@ -1,5172 +1,5173 @@
 {
-  "dictionaries": [
-    {
-      "schemas": [
-        {
-          "name": "sample_registration",
-          "description": "The collection of data elements required to register the required Donor-Specimen-Sample data to the ARGO Data Platform. Registration of samples is required before molecular and clinical data submission can proceed.",
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "examples": "TEST-CA",
-                "notes": "This is the unique id that is assigned to your program.  If you have logged into the platform, this is the Program Id that you see in the Program Services area. For example, TEST-CA is a Program ID.",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "examples": "90234,BLD_donor_89,AML-90",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "gender",
-              "valueType": "string",
-              "description": "Description of the donor self-reported gender. Gender is described as the assemblage of properties that distinguish people on the basis of their societal roles.",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "displayName": "Gender"
-              },
-              "restrictions": {
-                "required": true,
-                "codeList": ["Female", "Male", "Other"]
-              }
-            },
-            {
-              "name": "submitter_specimen_id",
-              "valueType": "string",
-              "description": "Unique identifier of the specimen, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "examples": "LAML_PO,00445,THY_099-tumour",
-                "displayName": "Submitter Specimen ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "specimen_tissue_source",
-              "valueType": "string",
-              "description": "Tissue source of the biospecimen.",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "displayName": "Specimen Tissue Source"
-              },
-              "restrictions": {
-                "required": true,
-                "codeList": [
-                  "Blood derived - bone marrow",
-                  "Blood derived - peripheral blood",
-                  "Blood derived",
-                  "Bone marrow",
-                  "Bone",
-                  "Buccal cell",
-                  "Buffy coat",
-                  "Cerebellum",
-                  "Cerebrospinal fluid",
-                  "Endometrium",
-                  "Esophagus",
-                  "Intestine",
-                  "Lymph node",
-                  "Mononuclear cells from bone marrow",
-                  "Other",
-                  "Plasma",
-                  "Pleural effusion",
-                  "Saliva",
-                  "Serum",
-                  "Skin",
-                  "Solid tissue",
-                  "Spleen",
-                  "Sputum",
-                  "Stomach",
-                  "Tonsil",
-                  "Urine"
-                ]
-              }
-            },
-            {
-              "name": "tumour_normal_designation",
-              "valueType": "string",
-              "description": "Description of specimens tumour/normal status for data processing.",
-              "restrictions": {
-                "required": true,
-                "codeList": ["Normal", "Tumour"]
-              },
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "displayName": "Tumour Normal Designation"
-              }
-            },
-            {
-              "name": "specimen_type",
-              "valueType": "string",
-              "description": "Description of the kind of specimen that was collected with respect to tumour/normal tissue origin.",
-              "restrictions": {
-                "required": true,
-                "codeList": [
-                  "Cell line - derived from normal",
-                  "Cell line - derived from tumour",
-                  "Cell line - derived from xenograft tumour",
-                  "Metastatic tumour - additional metastatic",
-                  "Metastatic tumour - metastasis local to lymph node",
-                  "Metastatic tumour - metastasis to distant location",
-                  "Metastatic tumour",
-                  "Normal - tissue adjacent to primary tumour",
-                  "Normal",
-                  "Primary tumour - additional new primary",
-                  "Primary tumour - adjacent to normal",
-                  "Primary tumour",
-                  "Recurrent tumour",
-                  "Xenograft - derived from primary tumour",
-                  "Xenograft - derived from tumour cell line"
-                ],
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      const row = $row;\n      let result = {valid: true, message: \"Ok\"};\n      \n      const designation = row.tumour_normal_designation.trim().toLowerCase();\n      const specimen_type = $field.trim().toLowerCase();\n      \n      if (designation === \"normal\"){\n          const validTypes = [\"normal\", \"normal - tissue adjacent to primary tumour\", \"cell line - derived from normal\"];\n          if (!validTypes.includes(specimen_type)){\n              result = {valid: false, message: \"Invalid specimen_type. Specimen_type can only be set to a normal type value (Normal, Normal - tissue adjacent to primary tumour, or Cell line - derived from normal) when tumour_normal_designation is set to Normal.\"};\n          }\n      }\n      else if (designation === \"tumour\") {\n          const invalidTypes = [\"normal\", \"cell line - derived from normal\"];\n          if (invalidTypes.includes(specimen_type)){\n              result = {valid: false, message: \"Invalid specimen_type. Specimen_type cannot be set to normal type value (Normal or Cell line - derived from normal) when tumour_normal_designation is set to Tumour.\"};\n          }\n      }\n      return result;\n    })"
-                ]
-              },
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "displayName": "Specimen Type"
-              }
-            },
-            {
-              "name": "submitter_sample_id",
-              "valueType": "string",
-              "description": "Unique identifier of the sample, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "examples": "hnc_12,CCG_34_94583,BRCA47832-3239",
-                "displayName": "Submitter Sample ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "sample_type",
-              "valueType": "string",
-              "description": "Description of the type of molecular sample used for testing.",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "displayName": "Sample Type"
-              },
-              "restrictions": {
-                "required": true,
-                "codeList": [
-                  "Amplified DNA",
-                  "ctDNA",
-                  "Other DNA enrichments",
-                  "Other RNA fractions",
-                  "polyA+ RNA",
-                  "Ribo-Zero RNA",
-                  "Total DNA",
-                  "Total RNA"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "donor",
-          "description": "The collection of data elements related to a specific donor in an ARGO program.",
-          "meta": {
-            "parent": "specimen"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "description": "Donor's last known state of living or deceased.",
-              "name": "vital_status",
-              "restrictions": {
-                "codeList": ["Alive", "Deceased", "Unknown"],
-                "required": true
-              },
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "displayName": "Vital Status"
-              }
-            },
-            {
-              "description": "Indicate the cause of a donor's death.",
-              "name": "cause_of_death",
-              "restrictions": {
-                "codeList": ["Died of cancer", "Died of other reasons", "Unknown"],
-                "script": [
-                  "(function validate(inputs) {\n        const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n        const vitalStatus = $row.vital_status.trim().toLowerCase();\n    \n        if (!currField && vitalStatus === \"deceased\"){\n            result = {valid: false, message: `${$name} must be provided when the donor's vital_status is deceased.`}\n        }\n        else if (currField && vitalStatus != \"deceased\"){\n            result = {valid: false, message: `${$name} cannot be provided if the donor's vital_status is not deceased.`}\n        }\n        return result;\n    })"
-                ]
-              },
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "donor.vital_status",
-                "notes": "Cause of death is only required to be submitted if the donor's vital_status is Deceased.",
-                "displayName": "Cause of Death"
-              }
-            },
-            {
-              "description": "Interval of how long the donor has survived since primary diagnosis, in days.",
-              "name": "survival_time",
-              "valueType": "integer",
-              "meta": {
-                "dependsOn": "donor.vital_status",
-                "notes": "Survival_time is only required to be submitted if the donor's vital_status is Deceased.",
-                "validationDependency": true,
-                "units": "days",
-                "core": "true",
-                "displayName": "Survival Time"
-              },
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n        const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n        const vitalStatus = $row.vital_status.trim().toLowerCase();\n    \n        if (!currField && vitalStatus === \"deceased\"){\n            result = {valid: false, message: `${$name} must be provided when the donor's vital_status is deceased.`}\n        }\n        else if (currField && vitalStatus != \"deceased\"){\n            result = {valid: false, message: `${$name} cannot be provided if the donor's vital_status is not deceased.`}\n        }\n        return result;\n    })"
-                ]
-              }
-            },
-            {
-              "name": "primary_site",
-              "valueType": "string",
-              "description": "The text term used to describe the primary site of disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O). This categorization groups cases into general categories.",
-              "meta": {
-                "displayName": "Primary Site",
-                "core": true
-              },
-              "restrictions": {
-                "required": true,
-                "codeList": [
-                  "Accessory sinuses",
-                  "Adrenal gland",
-                  "Anus and anal canal",
-                  "Base of tongue",
-                  "Bladder",
-                  "Bones, joints and articular cartilage of limbs",
-                  "Bones, joints and articular cartilage of other and unspecified sites",
-                  "Brain",
-                  "Breast",
-                  "Bronchus and lung",
-                  "Cervix uteri",
-                  "Colon",
-                  "Connective, subcutaneous and other soft tissues",
-                  "Corpus uteri",
-                  "Esophagus",
-                  "Eye and adnexa",
-                  "Floor of mouth",
-                  "Gallbladder",
-                  "Gum",
-                  "Heart, mediastinum, and pleura",
-                  "Hematopoietic and reticuloendothelial systems",
-                  "Hypopharynx",
-                  "Kidney",
-                  "Larynx",
-                  "Lip",
-                  "Liver and intrahepatic bile ducts",
-                  "Lymph nodes",
-                  "Meninges",
-                  "Nasal cavity and middle ear",
-                  "Nasopharynx",
-                  "Not Reported",
-                  "Oropharynx",
-                  "Other and ill-defined digestive organs",
-                  "Other and ill-defined sites",
-                  "Other and ill-defined sites in lip, oral cavity and pharynx",
-                  "Other and ill-defined sites within respiratory system and intrathoracic organs",
-                  "Other and unspecified female genital organs",
-                  "Other and unspecified major salivary glands",
-                  "Other and unspecified male genital organs",
-                  "Other and unspecified parts of biliary tract",
-                  "Other and unspecified parts of mouth",
-                  "Other and unspecified parts of tongue",
-                  "Other and unspecified urinary organs",
-                  "Other endocrine glands and related structures",
-                  "Ovary",
-                  "Palate",
-                  "Pancreas",
-                  "Parotid gland",
-                  "Penis",
-                  "Peripheral nerves and autonomic nervous system",
-                  "Placenta",
-                  "Prostate gland",
-                  "Pyriform sinus",
-                  "Rectosigmoid junction",
-                  "Rectum",
-                  "Renal pelvis",
-                  "Retroperitoneum and peritoneum",
-                  "Skin",
-                  "Small intestine",
-                  "Spinal cord, cranial nerves, and other parts of central nervous system",
-                  "Stomach",
-                  "Testis",
-                  "Thymus",
-                  "Thyroid gland",
-                  "Tonsil",
-                  "Trachea",
-                  "Ureter",
-                  "Uterus, NOS",
-                  "Vagina",
-                  "Vulva",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "description": "Indicate the donor's height, in centimeters (cm).",
-              "name": "height",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Height"
-              }
-            },
-            {
-              "description": "Indicate the donor's weight, in kilograms (kg).",
-              "name": "weight",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Weight"
-              }
-            },
-            {
-              "description": "Indicate the donor's Body Mass Index (BMI) in kg/m².",
-              "name": "bmi",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "BMI"
-              }
-            },
-            {
-              "description": "Indicate the donor's menopause status at the time of primary diagnosis. (Reference: caDSR CDE ID 2434914)",
-              "name": "menopause_status",
-              "restrictions": {
-                "codeList": [
-                  "Indeterminate or unknown",
-                  "Not applicable",
-                  "Perimenopausal",
-                  "Postmenopausal",
-                  "Premenopausal"
-                ]
-              },
-              "valueType": "string",
-              "meta": {
-                "displayName": "Menopause Status"
-              }
-            },
-            {
-              "description": "Indicate the donor's age of menarche, the first occurrence of menstruation.",
-              "name": "age_at_menarche",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Age at Menarche"
-              }
-            },
-            {
-              "description": "Indicate the number of pregnancies a donor has had.",
-              "name": "number_of_pregnancies",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Number of Pregnancies"
-              }
-            },
-            {
-              "description": "Indicate the number of children the donor has birthed.",
-              "name": "number_of_children",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Number of Children"
-              }
-            },
-            {
-              "description": "If the donor became lost to follow up, indicate the identifier of the clinical event (eg. submitter_primary_diagnosis_id, submitter_treatment_id or submitter_follow_up_id) after which the donor became lost to follow up.",
-              "name": "lost_to_followup_after_clinical_event_id",
-              "valueType": "string",
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n       const {$row, $name, $field} = inputs;\n       let result = {valid: true, message: \"Ok\"};\n       const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n       /* checks for a string just consisting of whitespace */\n       const checkforEmpty = (entry) => {return /^s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n       if (currField != null && !(checkforEmpty(currField))) {\n       const vitalStatus = $row.vital_status.trim().toLowerCase();\n       if (vitalStatus === \"deceased\") {\n       result = {valid: false, message: `${$name} cannot be submitted if the donor's vital_status is deceased.`}\n       }\n       }\n       return result;\n       });"
-                ]
-              },
-              "meta": {
-                "displayName": "Lost To Follow Up After Clinical Event",
-                "foreignKey": "primary_diagnosis.submitter_primary_diagnosis_id",
-                "validationDependency": true
-              }
-            }
-          ]
-        },
-        {
-          "name": "specimen",
-          "description": "The collection of data elements related to a donor's specimen. A specimen is any material sample taken for testing, diagnostic or research purposes.",
-          "meta": {
-            "parent": "sample_registration"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "submitter_donor_id",
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_specimen_id",
-              "description": "Unique identifier of the specimen, assigned by the data provider.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_specimen_id",
-                "displayName": "Submitter Specimen ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_primary_diagnosis_id",
-              "valueType": "string",
-              "description": "Indicate the primary diagnosis event in the clinical timeline that this specimen acquisition was related to.",
-              "meta": {
-                "primaryId": true,
-                "displayName": "Submitter Primary Diagnosis ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "pathological_tumour_staging_system",
-              "description": "Specify the tumour staging system used to assess the cancer at the time the tumour specimen was resected. Pathological classification is based on the clinical stage information (acquired before treatment) and supplemented/modified by operative findings and pathological evaluation of the resected specimen.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "dependsOn": "sample_registration.tumour_normal_designation",
-                "notes": "This field is only required if the specimen is a tumour.",
-                "displayName": "Pathological Tumour Staging System"
-              },
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    const arrayFormatter = arr => `\\n${arr.map(entry => `- \"${entry}\"`).join('\\n')}`;\n    /* This is not a required field, so first ensure that it exists */\n    if ($field) {\n      /* Contingent on the naming system for tumour staging systems to remain consistent */\n      const stagingName = $name\n        .trim()\n        .toLowerCase()\n        .split('_tumour_staging_system')[0];\n      const requiredFields = [\n        `${stagingName}_m_category`,\n        `${stagingName}_n_category`,\n        `${stagingName}_t_category`,\n      ];\n      const convertedRow = Object.fromEntries(\n        Object.entries($row).map(([fieldName, fieldVal]) => [fieldName.toLowerCase(), fieldVal]),\n      );\n      /* Check for contigous spaces wrapped with quotes (empty strings) */\n      const checkforEmpty = entry => {\n        return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'));\n      };\n\n      /* search for fields with falsy values*/\n      const emptyFields = requiredFields.filter(\n        field => !convertedRow[field] || checkforEmpty(convertedRow[field]),\n      );\n\n      /* The fields should be provided IF and ONLY IF the AJCC regex passes */\n      if (/^(AJCC)\\b/i.test($field) && emptyFields.length) {\n        result = {\n          valid: false,\n          message: `The following fields are required when ${$name} is set to an AJCC option: ${arrayFormatter(\n            emptyFields,\n          )}`,\n        };\n      } else if (!/^(AJCC)\\b/i.test($field) && emptyFields.length != requiredFields.length) {\n        const errorFields = requiredFields.filter(fieldName => !emptyFields.includes(fieldName));\n        result = {\n          valid: false,\n          message: `The following fields cannot be provided when ${$name} is not set to an AJCC option: ${arrayFormatter(\n            errorFields,\n          )}`,\n        };\n      }\n    }\n    return result;\n  })"
-                ],
-                "codeList": [
-                  "AJCC 8th edition",
-                  "AJCC 7th edition",
-                  "Ann Arbor staging system",
-                  "Binet staging system",
-                  "Durie-Salmon staging system",
-                  "FIGO staging system",
-                  "Lugano staging system",
-                  "Rai staging system",
-                  "Revised International staging system (RISS)",
-                  "St Jude staging system"
-                ]
-              }
-            },
-            {
-              "name": "pathological_t_category",
-              "description": "The code to represent the stage of cancer defined by the size or contiguous extension of the primary tumour (T), according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "specimen.pathological_tumour_staging_system",
-                "notes": "This field is required only if the selected pathological_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Pathological T Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "T0",
-                  "T1",
-                  "T1a",
-                  "T1a1",
-                  "T1a2",
-                  "T1b",
-                  "T1b1",
-                  "T1b2",
-                  "T1c",
-                  "T1d",
-                  "T1mi",
-                  "T2",
-                  "T2a",
-                  "T2a1",
-                  "T2a2",
-                  "T2b",
-                  "T2c",
-                  "T2d",
-                  "T3",
-                  "T3a",
-                  "T3b",
-                  "T3c",
-                  "T3d",
-                  "T3e",
-                  "T4",
-                  "T4a",
-                  "T4b",
-                  "T4c",
-                  "T4d",
-                  "T4e",
-                  "Ta",
-                  "Tis",
-                  "Tis(DCIS)",
-                  "Tis(LAMN)",
-                  "Tis(LCIS)",
-                  "Tis(Paget)",
-                  "Tis(Paget’s)",
-                  "Tis pd",
-                  "Tis pu",
-                  "TX"
-                ]
-              }
-            },
-            {
-              "name": "pathological_n_category",
-              "description": "The code to represent the stage of cancer defined by whether or not the cancer has reached nearby lymph nodes (N), according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "specimen.pathological_tumour_staging_system",
-                "notes": "This field is required only if the selected pathological_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Pathological N Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "N0",
-                  "N0a",
-                  "N0a (biopsy)",
-                  "N0b",
-                  "N0b (no biopsy)",
-                  "N0(i+)",
-                  "N0(i-)",
-                  "N0(mol+)",
-                  "N0(mol-)",
-                  "N1",
-                  "N1a",
-                  "N1a(sn)",
-                  "N1b",
-                  "N1c",
-                  "N1mi",
-                  "N2",
-                  "N2a",
-                  "N2b",
-                  "N2c",
-                  "N2mi",
-                  "N3",
-                  "N3a",
-                  "N3b",
-                  "N3c",
-                  "N4",
-                  "NX"
-                ]
-              }
-            },
-            {
-              "name": "pathological_m_category",
-              "description": "The code to represent the stage of cancer defined by whether there are distant metastases (M), meaning spread of cancer to other parts of the body, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "specimen.pathological_tumour_staging_system",
-                "notes": "This field is required only if the selected pathological_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Pathological M Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "M0",
-                  "M0(i+)",
-                  "M1",
-                  "M1a",
-                  "M1a(0)",
-                  "M1a(1)",
-                  "M1b",
-                  "M1b(0)",
-                  "M1b(1)",
-                  "M1c",
-                  "M1c(0)",
-                  "M1c(1)",
-                  "M1d",
-                  "M1d(0)",
-                  "M1d(1)",
-                  "M1e"
-                ]
-              }
-            },
-            {
-              "name": "pathological_stage_group",
-              "description": "Specify the tumour stage, based on pathological_tumour_staging_system, used to assess the cancer at the time the tumour specimen was resected.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "specimen.pathological_tumour_staging_system",
-                "notes": "This field depends on the selected pathological_tumour_staging_system, and is only required if the specimen is a tumour.\nPlease refer to the documentation for Tumour Staging Classifications: http://docs.icgc-argo.org/docs/submission/dictionary-overview#tumour-staging-classifications",
-                "displayName": "Pathological Stage Group"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Stage 0",
-                  "Stage 0a",
-                  "Stage 0is",
-                  "Stage I",
-                  "Stage IA",
-                  "Stage IA1",
-                  "Stage IA2",
-                  "Stage IA3",
-                  "Stage IB",
-                  "Stage IB1",
-                  "Stage IB2",
-                  "Stage IC",
-                  "Stage IS",
-                  "Stage IE",
-                  "Stage II",
-                  "Stage IIA",
-                  "Stage IIA1",
-                  "Stage IIA2",
-                  "Stage IIE",
-                  "Stage IIB",
-                  "Stage IIC",
-                  "Stage III",
-                  "Stage IIIA",
-                  "Stage IIIA1",
-                  "Stage IIIA2",
-                  "Stage IIIB",
-                  "Stage IIIC",
-                  "Stage IIIC1",
-                  "Stage IIIC2",
-                  "Stage IIID",
-                  "Stage IV",
-                  "Stage IVA",
-                  "Stage IVA1",
-                  "Stage IVA2",
-                  "Stage IVB",
-                  "Stage IVC",
-                  "Occult carcinoma",
-                  "Stage 1",
-                  "Stage 1A",
-                  "Stage 1B",
-                  "Stage ISA",
-                  "Stage ISB",
-                  "Stage IEA",
-                  "Stage IEB",
-                  "Stage IIEA",
-                  "Stage IIEB",
-                  "Stage IIES",
-                  "Stage IIESA",
-                  "Stage IIESB",
-                  "Stage IIS",
-                  "Stage IISA",
-                  "Stage IISB",
-                  "Stage IIIE",
-                  "Stage IIIEA",
-                  "Stage IIIEB",
-                  "Stage IIIES",
-                  "Stage IIIESA",
-                  "Stage IIIESB",
-                  "Stage IIIS",
-                  "Stage IIISA",
-                  "Stage IIISB",
-                  "Stage IAB",
-                  "Stage A",
-                  "Stage B",
-                  "Stage C"
-                ],
-                "script": [
-                  "(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    if ($row.pathological_tumour_staging_system && $field) {\n      let codeList = [];\n      switch ($row.pathological_tumour_staging_system && $row.pathological_tumour_staging_system.trim().toLowerCase()) {\n        case 'revised international staging system (riss)':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii'\n          ];\n          break;\n        case 'lugano staging system':\n          codeList = [\n             'stage i',\n             'stage ia',\n             'stage ib',\n             'stage ie',\n             'stage iea',\n             'stage ieb',\n             'stage ii',\n             'stage iia',\n             'stage iib',\n             'stage iie',\n             'stage iiea',\n             'stage iieb',\n             'stage iii',\n             'stage iiia',\n             'stage iiib',\n             'stage iv',\n             'stage iva',\n             'stage ivb'\n          ];\n          break;\n        case 'st jude staging system':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii',\n            'stage iv'\n          ];\n          break;\n        case 'ann arbor staging system':\n          codeList = [\n            'stage i',\n            'stage ia',\n            'stage ib',\n            'stage ie',\n            'stage is',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iie',\n            'stage iis',\n            'stage iii',\n            'stage iiia',\n            'stage iiib',\n            'stage iiie',\n            'stage iiis',\n            'stage iv',\n            'stage iva',\n            'stage ivb',\n            'stage ive',\n            'stage ivs'\n          ];\n          break;\n        case 'rai staging system':\n          codeList = [\n             'stage 0',\n             'stage i',\n             'stage ii',\n             'stage iii',\n             'stage iv'\n          ];\n          break;\n        case 'durie-salmon staging system':\n          codeList = [\n            'stage 1',\n            'stage 1a',\n            'stage 1b',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iii',\n            'stage iiia',\n            'stage iiib'\n          ];\n          break;\n        case 'figo staging system':\n          codeList = [\n            'stage ia',\n            'stage ia1',\n            'stage ia2',\n            'stage ib',\n            'stage ib1',\n            'stage ib2',\n            'stage iia',\n            'stage iab',\n            'stage iiia',\n            'stage iiib',\n            'stage iva',\n            'stage ivb'\n          ];\n          break;\n        case 'binet staging system':\n          codeList = [\n             'stage a',\n             'stage b',\n             'stage c'\n         ];\n          break;\n        case 'ajcc 8th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ia3','stage ib','stage ib1','stage ib2','stage ic','stage ie','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iie','stage iii','stage iiia','stage iiia1','stage iiia2','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iiid','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'];\n          break;\n        case 'ajcc 7th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ib','stage ib1','stage ib2','stage ic','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iii','stage iiia','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'\n];\n          break;\n        default:\n          codelist = [];\n      }\n\n      if (!codeList.includes($field.trim().toLowerCase()) && codeList.length) {\n        const msg = `'${$field}' is not a permissible value. When 'pathological_tumour_staging_system' is set to '${\n          $row.pathological_tumour_staging_system\n        }', 'pathological_stage_group' must be one of the following: \\n${codeList\n          .map(code => `- \"${code}\"`)\n          .join('\\n')}`;\n\n        result.valid = false;\n        result.message = msg;\n      }\n    }\n    return result;\n  })"
-                ]
-              }
-            },
-            {
-              "name": "specimen_acquisition_interval",
-              "description": "Interval between primary diagnosis and specimen acquisition, in days.",
-              "valueType": "integer",
-              "meta": {
-                "validationDependency": true,
-                "units": "days",
-                "core": true,
-                "notes": "The associated primary diagnosis is used as the reference point for this interval. To calculate this, find the number of days since the date of primary diagnosis.",
-                "displayName": "Specimen Acquisition Interval"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "tumour_histological_type",
-              "description": "The code to represent the histology (morphology) of neoplasms that is usually obtained from a pathology report, according to the International Classification of Diseases for Oncology, 3rd Edition (WHO ICD-O-3). Refer to the ICD-O-3 manual for guidelines at https://apps.who.int/iris/handle/10665/42344.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "dependsOn": "sample_registration.tumour_normal_designation",
-                "notes": "This field is only required if the specimen is a tumour.",
-                "examples": "8260/3,9691/36",
-                "displayName": "Tumour Histological Type"
-              },
-              "restrictions": {
-                "regex": "^[8,9]{1}[0-9]{3}/[0,1,2,3,6,9]{1}[1-9]{0,1}$"
-              }
-            },
-            {
-              "name": "specimen_anatomic_location",
-              "description": "Indicate the ICD-O-3 topography code for the anatomic location of a specimen when it was collected. Refer to the guidelines provided in the ICD-O-3 manual at https://apps.who.int/iris/handle/10665/42344.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "displayName": "Specimen Anatomic Location",
-                "examples": "C50.1,C18"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[C][0-9]{2}(.[0-9]{1})?$"
-              }
-            },
-            {
-              "name": "specimen_processing",
-              "description": "Indicate the technique used to process specimen.",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cryopreservation in liquid nitrogen (dead tissue)",
-                  "Cryopreservation in dry ice (dead tissue)",
-                  "Cryopreservation of live cells in liquid nitrogen",
-                  "Cryopreservation - other",
-                  "Formalin fixed & paraffin embedded",
-                  "Formalin fixed - buffered",
-                  "Formalin fixed - unbuffered",
-                  "Fresh",
-                  "Other"
-                ]
-              },
-              "meta": {
-                "displayName": "Specimen Processing"
-              }
-            },
-            {
-              "name": "specimen_storage",
-              "description": "Indicate the method of specimen storage for specimens that were not extracted freshly or immediately cultured.",
-              "valueType": "string",
-              "meta": {
-                "notes": "For specimens that were freshly extracted or immediately cultured, select Not Applicable.",
-                "displayName": "Specimen Storage"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Cut slide",
-                  "Frozen in -70 freezer",
-                  "Frozen in liquid nitrogen",
-                  "Frozen in vapour phase",
-                  "Not Applicable",
-                  "Other",
-                  "Paraffin block",
-                  "RNA later frozen"
-                ]
-              }
-            },
-            {
-              "name": "reference_pathology_confirmed",
-              "description": "Indicate whether the pathological diagnosis was confirmed by a (central) reference pathologist.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "dependsOn": "sample_registration.tumour_normal_designation",
-                "notes": "This field is only required if the specimen is a tumour.",
-                "displayName": "Reference Pathology Confirmed"
-              },
-              "restrictions": {
-                "codeList": ["Yes", "No", "Unknown"]
-              }
-            },
-            {
-              "name": "tumour_grading_system",
-              "description": "Specify the tumour staging system used to assess the description of a tumour based on how abnormal the tumour cells and the tumour tissue look under a microscope. Tumour grade is an indicator of how quickly a tumour is likely to grow.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "sample_registration.tumour_normal_designation",
-                "notes": "This field is only required if the specimen is a tumour.",
-                "displayName": "Tumour Grading System"
-              },
-              "restrictions": {
-                "codeList": [
-                  "FNCLCC grading system",
-                  "Four-tier grading system",
-                  "Gleason grade group system",
-                  "Grading system for GISTs",
-                  "Grading system for GNETs",
-                  "ISUP grading system",
-                  "Nuclear grading system for DCIS",
-                  "Scarff-Bloom-Richardson grading system",
-                  "Three-tier grading system",
-                  "Two-tier grading system",
-                  "WHO grading system for CNS tumours"
-                ]
-              }
-            },
-            {
-              "name": "tumour_grade",
-              "description": "Grade of the tumour as assigned by the reporting tumour_grading_system.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "specimen.tumour_grading_system",
-                "notes": "This field depends on the selected tumour_grading_system, and is only required if the specimen is a tumour.\nPlease refer to the documentation for Tumour Grading Classifications: http://docs.icgc-argo.org/docs/submission/dictionary-overview#tumour-grading-classifications",
-                "displayName": "Tumour Grade"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Low grade",
-                  "High grade",
-                  "GX",
-                  "G1",
-                  "G2",
-                  "G3",
-                  "G4",
-                  "Low",
-                  "High",
-                  "Grade I",
-                  "Grade II",
-                  "Grade III",
-                  "Grade IV",
-                  "Grade Group 1",
-                  "Grade Group 2",
-                  "Grade Group 3",
-                  "Grade Group 4",
-                  "Grade Group 5"
-                ],
-                "script": [
-                  "(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    if ($row.tumour_grading_system && $field) {\n      let codeList = [];\n      const tieredGradingList = ['gx','g1','g2','g3'];\n      const gradingSystems = ['two-tier grading system', 'three-tier grading system', 'four-tier grading system', 'grading system for gists', 'grading system for gnets', 'isup grading system', 'who grading system for cns tumours', 'fnclcc grading system', 'gleason grade group system', 'scarff-bloom-richardson grading system', 'nuclear grading system for dcis'];\n      switch ($row.tumour_grading_system && $row.tumour_grading_system.trim().toLowerCase()) {\n        case 'two-tier grading system':\n          codeList = [\n            'low grade',\n            'high grade',\n          ];\n          break;\n        case 'three-tier grading system':\n          codeList = tieredGradingList;\n          break;\n        case 'four-tier grading system':\n          codeList = [\n            'gx',\n            'g1',\n            'g2',\n            'g3',\n            'g4',\n          ];\n          break;\n        case 'grading system for gists':\n          codeList = [\n            'low',\n            'high',\n          ];\n          break;\n        case 'grading system for gnets':\n          codeList = tieredGradingList;\n          break;\n        case 'isup grading system':\n          codeList = [\n            'gx',\n            'g1',\n            'g2',\n            'g3',\n            'g4',\n          ];\n          break;\n        case 'who grading system for cns tumours':\n          codeList = [\n            'grade i',\n            'grade ii',\n            'grade iii',\n            'grade iv',\n          ];\n          break;\n        case 'fnclcc grading system':\n          codeList = tieredGradingList;\n          break;\n        case 'gleason grade group system':\n          codeList = [\n            'grade group 1',\n            'grade group 2',\n            'grade group 3',\n            'grade group 4',\n            'grade group 5',\n          ];\n          break;\n        case 'scarff-bloom-richardson grading system':\n          codeList = tieredGradingList;\n          break;\n        case 'nuclear grading system for dcis':\n          codeList = tieredGradingList;\n          break;\n      }\n\n      if (!codeList.includes($field.trim().toLowerCase())) {\n        const msg = `'${$field}' is not a permissible value. When 'tumour_grading_system' is set to '${\n          $row.tumour_grading_system\n        }', 'tumour_grade' must be one of the following: \\n${codeList\n          .map(code => `- \"${code}\"`)\n          .join('\\n')}`;\n        result.valid = false;\n        result.message = msg;\n      }\n      else if (!gradingSystems.includes($row.tumour_grading_system.trim().toLowerCase())) {\n         result.valid = false;\n         const msg = \"'${$row.tumour_grading_system}' is not a permissible value for 'tumour_grading_system'. If the tumour grading system you use is missing, please contact the DCC.\";\n         result.message = msg;\n      }\n    }\n    return result;\n  })"
-                ]
-              }
-            },
-            {
-              "name": "percent_tumour_cells",
-              "description": "Indicate a value, in decimals, that represents the percentage of infiltration by tumour cells in a specimen.",
-              "valueType": "number",
-              "meta": {
-                "core": true,
-                "dependsOn": "sample_registration.tumour_normal_designation",
-                "notes": "This field is only required if the specimen is a tumour.",
-                "displayName": "Percent Tumour Cells"
-              }
-            },
-            {
-              "name": "percent_tumour_cells_measurement_method",
-              "description": "Indicate method used to measure percent_tumour_cells.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "sample_registration.tumour_normal_designation",
-                "notes": "This field is only required if the specimen is a tumour.",
-                "displayName": "Percent Tumour Cells Measurement Method"
-              },
-              "restrictions": {
-                "codeList": ["Genomics", "Image analysis", "Pathology estimate by percent nuclei"]
-              }
-            },
-            {
-              "name": "percent_proliferating_cells",
-              "description": "Indicate a value, in decimals, that represents the count of proliferating cells determined during pathologic review of the specimen.",
-              "valueType": "number",
-              "meta": {
-                "dependsOn": "sample_registration.tumour_normal_designation",
-                "notes": "",
-                "displayName": "Percent Proliferating Cells"
-              }
-            },
-            {
-              "name": "percent_inflammatory_tissue",
-              "description": "Indicate a value, in decimals, that represents local response to cellular injury, marked by capillary dilatation, edema and leukocyte infiltration; clinically, inflammation is manifest by redness, heat, pain, swelling and loss of function, with the need to heal damaged tissue.",
-              "valueType": "number",
-              "meta": {
-                "dependsOn": "sample_registration.tumour_normal_designation",
-                "notes": "",
-                "displayName": "Percent Inflammatory Tissue"
-              }
-            },
-            {
-              "name": "percent_stromal_cells",
-              "description": "Indicate a value, in decimals, that represents the percentage of reactive cells that are present in a malignant tumour specimen but are not malignant such as fibroblasts, vascular structures, etc.",
-              "valueType": "number",
-              "meta": {
-                "dependsOn": "sample_registration.tumour_normal_designation",
-                "notes": "",
-                "displayName": "Percent Stromal Cells"
-              }
-            },
-            {
-              "name": "percent_necrosis",
-              "description": "Indicate a value, in decimals, that represents the percentage of cell death in a malignant tumour specimen.",
-              "valueType": "number",
-              "meta": {
-                "dependsOn": "sample_registration.tumour_normal_designation",
-                "notes": "",
-                "displayName": "Percent Necrosis"
-              }
-            }
-          ]
-        },
-        {
-          "name": "primary_diagnosis",
-          "description": "The collection of data elements related to a donor's primary diagnosis. The primary diagnosis is the first diagnosed case of cancer in a donor. To submit multiple primary diagnoses for a single donor, submit multiple rows in the primary diagnosis file for this donor.",
-          "meta": {
-            "parent": "donor"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_primary_diagnosis_id",
-              "valueType": "string",
-              "description": "Unique identifier of the primary diagnosis event, assigned by the data provider.",
-              "meta": {
-                "primaryId": true,
-                "displayName": "Submitter Primary Diagnosis ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "age_at_diagnosis",
-              "valueType": "integer",
-              "description": "Age that the donor was first diagnosed with cancer, in years. This should be based on the earliest diagnosis of cancer.",
-              "restrictions": {
-                "required": true
-              },
-              "meta": {
-                "units": "years",
-                "core": true,
-                "displayName": "Age at Diagnosis"
-              }
-            },
-            {
-              "name": "cancer_type_code",
-              "valueType": "string",
-              "description": "The code to represent the cancer type using the WHO ICD-10 code (https://icd.who.int/browse10/2019/en) classification.",
-              "restrictions": {
-                "required": true,
-                "regex": "^[C|D][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$"
-              },
-              "meta": {
-                "core": true,
-                "examples": "C41.1,C16.9,C00.5,D46.9",
-                "displayName": "Cancer Type Code"
-              }
-            },
-            {
-              "name": "cancer_type_additional_information",
-              "valueType": "string",
-              "description": "Additional details related to the cancer type that are not covered by the ICD-10 code provided in the cancer_type field.",
-              "meta": {
-                "displayName": "Cancer Type Additional Information"
-              }
-            },
-            {
-              "name": "basis_of_diagnosis",
-              "description": "Indicate the most valid basis of how the primary diagnosis was identified. If more than one diagnosis technique was used, select the term that has the highest code number (see notes). (Reference: IACR Standard for Basis of Diagnosis http://www.iacr.com.fr/images/doc/basis.pdf)",
-              "restrictions": {
-                "codeList": [
-                  "Clinical investigation",
-                  "Clinical",
-                  "Cytology",
-                  "Death certificate only",
-                  "Histology of a metastasis",
-                  "Histology of a primary tumour",
-                  "Specific tumour markers",
-                  "Unknown"
-                ]
-              },
-              "valueType": "string",
-              "meta": {
-                "notes": "0: Death certificate only: Information provided is from a death certificate.\n1: Clinical: Diagnosis made before death.\n2: Clinical investigation: All diagnostic techniques, including X-ray, endoscopy, imaging, ultrasound, exploratory surgery (such as laparotomy), and autopsy, without a tissue diagnosis.\n4: Specific tumour markers: Including biochemical and/or immunologic markers that are specific for a tumour site.\n5: Cytology: Examination of cells from a primary or secondary site, including fluids aspirated by endoscopy or needle; also includes the microscopic examination of peripheral blood and bone marrow aspirates.\n6: Histology of a metastasis: Histologic examination of tissue from a metastasis, including autopsy specimens.\n7: Histology of a primary tumour: Histologic examination of tissue from primary tumour, however obtained, including all cutting techniques and bone marrow biopsies; also includes autopsy specimens of primary tumour.\n9: Unknown: No information on how the diagnosis has been made.",
-                "displayName": "Basis of Diagnosis"
-              }
-            },
-            {
-              "name": "number_lymph_nodes_positive",
-              "description": "The number of regional lymph nodes reported as being positive for tumour metastases. (Reference: caDSR CDE ID 6113694)",
-              "valueType": "integer",
-              "restrictions": {
-                "required": true
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Number Of Lymph Nodes Positive"
-              }
-            },
-            {
-              "name": "number_lymph_nodes_examined",
-              "description": "The total number of lymph nodes tested for the presence of cancer. (Reference: caDSR CDE ID 3)",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Number Of Lymph Nodes Examined"
-              }
-            },
-            {
-              "name": "clinical_tumour_staging_system",
-              "valueType": "string",
-              "description": "Indicate the tumour staging system used to stage the cancer at the time of primary diagnosis (prior to treatment).",
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    const arrayFormatter = arr => `\\n${arr.map(entry => `- \"${entry}\"`).join('\\n')}`;\n    /* This is not a required field, so first ensure that it exists */\n    if ($field) {\n      /* Contingent on the naming system for tumour staging systems to remain consistent */\n      const stagingName = $name\n        .trim()\n        .toLowerCase()\n        .split('_tumour_staging_system')[0];\n      const requiredFields = [\n        `${stagingName}_m_category`,\n        `${stagingName}_n_category`,\n        `${stagingName}_t_category`,\n      ];\n      const convertedRow = Object.fromEntries(\n        Object.entries($row).map(([fieldName, fieldVal]) => [fieldName.toLowerCase(), fieldVal]),\n      );\n      /* Check for contigous spaces wrapped with quotes (empty strings) */\n      const checkforEmpty = entry => {\n        return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'));\n      };\n\n      /* search for fields with falsy values*/\n      const emptyFields = requiredFields.filter(\n        field => !convertedRow[field] || checkforEmpty(convertedRow[field]),\n      );\n\n      /* The fields should be provided IF and ONLY IF the AJCC regex passes */\n      if (/^(AJCC)\\b/i.test($field) && emptyFields.length) {\n        result = {\n          valid: false,\n          message: `The following fields are required when ${$name} is set to an AJCC option: ${arrayFormatter(\n            emptyFields,\n          )}`,\n        };\n      } else if (!/^(AJCC)\\b/i.test($field) && emptyFields.length != requiredFields.length) {\n        const errorFields = requiredFields.filter(fieldName => !emptyFields.includes(fieldName));\n        result = {\n          valid: false,\n          message: `The following fields cannot be provided when ${$name} is not set to an AJCC option: ${arrayFormatter(\n            errorFields,\n          )}`,\n        };\n      }\n    }\n    return result;\n  })"
-                ],
-                "codeList": [
-                  "AJCC 8th edition",
-                  "AJCC 7th edition",
-                  "Ann Arbor staging system",
-                  "Binet staging system",
-                  "Durie-Salmon staging system",
-                  "FIGO staging system",
-                  "Lugano staging system",
-                  "Rai staging system",
-                  "Revised International staging system (RISS)",
-                  "St Jude staging system"
-                ]
-              },
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "displayName": "Clinical Tumour Staging System"
-              }
-            },
-            {
-              "name": "clinical_stage_group",
-              "description": "Stage group of the tumour, as assigned by the reporting clinical_tumour_staging_system, that indicates the overall prognostic tumour stage (ie. Stage I, Stage II, Stage III etc.).",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Stage 0",
-                  "Stage 0a",
-                  "Stage 0is",
-                  "Stage I",
-                  "Stage IA",
-                  "Stage IA1",
-                  "Stage IA2",
-                  "Stage IA3",
-                  "Stage IB",
-                  "Stage IB1",
-                  "Stage IB2",
-                  "Stage IC",
-                  "Stage IS",
-                  "Stage IE",
-                  "Stage II",
-                  "Stage IIA",
-                  "Stage IIA1",
-                  "Stage IIA2",
-                  "Stage IIE",
-                  "Stage IIB",
-                  "Stage IIC",
-                  "Stage III",
-                  "Stage IIIA",
-                  "Stage IIIA1",
-                  "Stage IIIA2",
-                  "Stage IIIB",
-                  "Stage IIIC",
-                  "Stage IIIC1",
-                  "Stage IIIC2",
-                  "Stage IIID",
-                  "Stage IV",
-                  "Stage IVA",
-                  "Stage IVA1",
-                  "Stage IVA2",
-                  "Stage IVB",
-                  "Stage IVC",
-                  "Occult carcinoma",
-                  "Stage 1",
-                  "Stage 1A",
-                  "Stage 1B",
-                  "Stage ISA",
-                  "Stage ISB",
-                  "Stage IEA",
-                  "Stage IEB",
-                  "Stage IIEA",
-                  "Stage IIEB",
-                  "Stage IIES",
-                  "Stage IIESA",
-                  "Stage IIESB",
-                  "Stage IIS",
-                  "Stage IISA",
-                  "Stage IISB",
-                  "Stage IIIE",
-                  "Stage IIIEA",
-                  "Stage IIIEB",
-                  "Stage IIIES",
-                  "Stage IIIESA",
-                  "Stage IIIESB",
-                  "Stage IIIS",
-                  "Stage IIISA",
-                  "Stage IIISB",
-                  "Stage IAB",
-                  "Stage A",
-                  "Stage B",
-                  "Stage C"
-                ],
-                "script": [
-                  "(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    if ($row.clinical_tumour_staging_system && $field) {\n      let codeList = [];\n      switch ($row.clinical_tumour_staging_system && $row.clinical_tumour_staging_system.trim().toLowerCase()) {\n        case 'revised international staging system (riss)':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii'\n          ];\n          break;\n        case 'lugano staging system':\n          codeList = [\n             'stage i',\n             'stage ia',\n             'stage ib',\n             'stage ie',\n             'stage iea',\n             'stage ieb',\n             'stage ii',\n             'stage iia',\n             'stage iib',\n             'stage iie',\n             'stage iiea',\n             'stage iieb',\n             'stage iii',\n             'stage iiia',\n             'stage iiib',\n             'stage iv',\n             'stage iva',\n             'stage ivb'\n          ];\n          break;\n        case 'st jude staging system':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii',\n            'stage iv'\n          ];\n          break;\n        case 'ann arbor staging system':\n          codeList = [\n            'stage i',\n            'stage ia',\n            'stage ib',\n            'stage ie',\n            'stage is',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iie',\n            'stage iis',\n            'stage iii',\n            'stage iiia',\n            'stage iiib',\n            'stage iiie',\n            'stage iiis',\n            'stage iv',\n            'stage iva',\n            'stage ivb',\n            'stage ive',\n            'stage ivs'\n          ];\n          break;\n        case 'rai staging system':\n          codeList = [\n             'stage 0',\n             'stage i',\n             'stage ii',\n             'stage iii',\n             'stage iv'\n          ];\n          break;\n        case 'durie-salmon staging system':\n          codeList = [\n            'stage 1',\n            'stage 1a',\n            'stage 1b',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iii',\n            'stage iiia',\n            'stage iiib'\n          ];\n          break;\n        case 'figo staging system':\n          codeList = [\n            'stage ia',\n            'stage ia1',\n            'stage ia2',\n            'stage ib',\n            'stage ib1',\n            'stage ib2',\n            'stage iia',\n            'stage iab',\n            'stage iiia',\n            'stage iiib',\n            'stage iva',\n            'stage ivb'\n          ];\n          break;\n        case 'binet staging system':\n          codeList = [\n             'stage a',\n             'stage b',\n             'stage c'\n         ];\n          break;\n        case 'ajcc 8th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ia3','stage ib','stage ib1','stage ib2','stage ic','stage ie','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iie','stage iii','stage iiia','stage iiia1','stage iiia2','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iiid','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'];\n          break;\n        case 'ajcc 7th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ib','stage ib1','stage ib2','stage ic','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iii','stage iiia','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'\n];\n          break;\n        default:\n          codelist = [];\n      }\n\n      if (!codeList.includes($field.trim().toLowerCase()) && codeList.length) {\n        const msg = `'${$field}' is not a permissible value. When 'clinical_tumour_staging_system' is set to '${\n          $row.clinical_tumour_staging_system\n        }', 'clinical_stage_group' must be one of the following: \\n${codeList\n          .map(code => `- \"${code}\"`)\n          .join('\\n')}`;\n\n        result.valid = false;\n        result.message = msg;\n      }\n    }\n    return result;\n  })"
-                ]
-              },
-              "meta": {
-                "core": true,
-                "dependsOn": "primary_diagnosis.clinical_tumour_staging_system",
-                "notes": "This field is dependent on the selected clinical_tumour_staging_system.\nPlease refer to the documentation for Tumour Staging Classifications: http://docs.icgc-argo.org/docs/submission/dictionary-overview#tumour-staging-classifications",
-                "displayName": "Clinical Stage Group"
-              }
-            },
-            {
-              "name": "clinical_t_category",
-              "description": "The code to represent the extent of the primary tumour (T) based on evidence obtained from clinical assessment parameters determined at time of primary diagnosis and prior to treatment, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "primary_diagnosis.clinical_tumour_staging_system",
-                "notes": "This field is required only if the selected clinical_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Clinical T Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "T0",
-                  "T1",
-                  "T1a",
-                  "T1a1",
-                  "T1a2",
-                  "T1b",
-                  "T1b1",
-                  "T1b2",
-                  "T1c",
-                  "T1d",
-                  "T1mi",
-                  "T2",
-                  "T2a",
-                  "T2a1",
-                  "T2a2",
-                  "T2b",
-                  "T2c",
-                  "T2d",
-                  "T3",
-                  "T3a",
-                  "T3b",
-                  "T3c",
-                  "T3d",
-                  "T3e",
-                  "T4",
-                  "T4a",
-                  "T4b",
-                  "T4c",
-                  "T4d",
-                  "T4e",
-                  "Ta",
-                  "Tis",
-                  "Tis(DCIS)",
-                  "Tis(LAMN)",
-                  "Tis(LCIS)",
-                  "Tis(Paget)",
-                  "Tis(Paget’s)",
-                  "Tis pd",
-                  "Tis pu",
-                  "TX"
-                ]
-              }
-            },
-            {
-              "name": "clinical_n_category",
-              "description": "The code to represent the stage of cancer defined by the extent of the regional lymph node (N) involvement for the cancer based on evidence obtained from clinical assessment parameters determined at time of primary diagnosis and prior to treatment, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "primary_diagnosis.clinical_tumour_staging_system",
-                "notes": "This field is required only if the selected clinical_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Clinical N Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "N0",
-                  "N0a",
-                  "N0a (biopsy)",
-                  "N0b",
-                  "N0b (no biopsy)",
-                  "N0(i+)",
-                  "N0(i-)",
-                  "N0(mol+)",
-                  "N0(mol-)",
-                  "N1",
-                  "N1a",
-                  "N1a(sn)",
-                  "N1b",
-                  "N1c",
-                  "N1mi",
-                  "N2",
-                  "N2a",
-                  "N2b",
-                  "N2c",
-                  "N2mi",
-                  "N3",
-                  "N3a",
-                  "N3b",
-                  "N3c",
-                  "N4",
-                  "NX"
-                ]
-              }
-            },
-            {
-              "name": "clinical_m_category",
-              "description": "The code to represent the stage of cancer defined by the extent of the distant metastasis (M) for the cancer based on evidence obtained from clinical assessment parameters determined at time of primary diagnosis and prior to treatment, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual. MX is NOT a valid category and cannot be assigned.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "primary_diagnosis.clinical_tumour_staging_system",
-                "notes": "This field is required only if the selected clinical_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Clinical M Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "M0",
-                  "M0(i+)",
-                  "M1",
-                  "M1a",
-                  "M1a(0)",
-                  "M1a(1)",
-                  "M1b",
-                  "M1b(0)",
-                  "M1b(1)",
-                  "M1c",
-                  "M1c(0)",
-                  "M1c(1)",
-                  "M1d",
-                  "M1d(0)",
-                  "M1d(1)",
-                  "M1e"
-                ]
-              }
-            },
-            {
-              "name": "presenting_symptoms",
-              "description": "Indicate presenting symptoms at time of primary diagnosis.",
-              "valueType": "string",
-              "isArray": true,
-              "restrictions": {
-                "codeList": [
-                  "Abdominal Pain",
-                  "Anemia",
-                  "Back Pain",
-                  "Bloating",
-                  "Cholangitis",
-                  "Constipation",
-                  "Dark Urine",
-                  "Decreased Appetite",
-                  "Diabetes",
-                  "Diarrhea",
-                  "Fatigue",
-                  "Fever",
-                  "Hypoglycemia",
-                  "Jaundice",
-                  "Loss of Appetite",
-                  "Nausea",
-                  "None",
-                  "Not Reported",
-                  "Pale Stools",
-                  "Pancreatitis",
-                  "Pruritus/Itchiness",
-                  "Steatorrhea",
-                  "Swelling in the Neck",
-                  "Unknown",
-                  "Vomiting",
-                  "Weight Loss"
-                ]
-              },
-              "meta": {
-                "displayName": "Presenting Symptoms",
-                "notes": "To include multiple values, separate values with a pipe delimiter '|' within your file.",
-                "examples": "Anemia|Bloating|Diabetes"
-              }
-            },
-            {
-              "name": "performance_status",
-              "description": "Indicate the donor's performance status grade at the time of primary diagnosis. (Reference: ECOG performance score grades from https://ecog-acrin.org/resources/ecog-performance-status).",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": ["Grade 0", "Grade 1", "Grade 2", "Grade 3", "Grade 4"]
-              },
-              "meta": {
-                "notes": "Grade 0: Fully active, able to carry on all pre-disease performance without restriction.\nGrade 1: Restricted in physically strenuous activity but ambulatory and able to carry out work of a light or sedentary nature (ie. Light house work, office work).\nGrade 2: Ambulatory and capable of all selfcare but unable to carry out any work activities; up and about more than 50% of waking hours.\nGrade 3: Capable of only limited selfcare; confined to bed or chair more than 50% of waking hours.\nGrade 4: Completely disabled; cannot carry on any selfcare; totally confined to bed or chair",
-                "displayName": "Performance Status"
-              }
-            }
-          ]
-        },
-        {
-          "name": "treatment",
-          "description": "The collection of data elements related to a donor's treatment at a specific point in the clinical record. To submit multiple treatments for a single donor, please submit treatment rows in the treatment file for this donor.",
-          "meta": {
-            "parent": "donor"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "submitter_donor_id",
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_treatment_id",
-              "description": "Unique identifier of the treatment, assigned by the data provider.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "displayName": "Submitter Treatment ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_primary_diagnosis_id",
-              "valueType": "string",
-              "description": "Indicate the primary diagnosis event in the clinical timeline that this treatment was related to.",
-              "meta": {
-                "primaryId": true,
-                "displayName": "Submitter Primary Diagnosis ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "treatment_type",
-              "description": "Indicate the type of treatment regimen that the donor completed.",
-              "valueType": "string",
-              "isArray": true,
-              "restrictions": {
-                "required": true,
-                "codeList": [
-                  "Ablation",
-                  "Bone marrow transplant",
-                  "Chemotherapy",
-                  "Endoscopic therapy",
-                  "Hormonal therapy",
-                  "Immunotherapy",
-                  "No treatment",
-                  "Other targeting molecular therapy",
-                  "Photodynamic therapy",
-                  "Radiation therapy",
-                  "Stem cell transplant",
-                  "Surgery"
-                ]
-              },
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "notes": "Depending on the treatment_type(s) selected, additional treatment details may be required to be submitted. For example, if treatment_type includes 'Chemotherapy', the supplemental Chemotherapy treatment type file is required.\nTo include multiple values, separate values with a pipe delimiter '|' within your file.",
-                "displayName": "Treatment Type",
-                "examples": "Chemotherapy|Hormonal therapy"
-              }
-            },
-            {
-              "name": "age_at_consent_for_treatment",
-              "description": "Indicate the age of donor when consent was given for treatment.",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Age At Consent For Treatment"
-              }
-            },
-            {
-              "name": "is_primary_treatment",
-              "description": "Indicate if the treatment was the primary treatment following the initial diagnosis.",
-              "valueType": "string",
-              "restrictions": {
-                "required": true,
-                "codeList": ["Yes", "No", "Unknown"]
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Is Primary Treatment"
-              }
-            },
-            {
-              "name": "line_of_treatment",
-              "description": "Indicate the line of treatment if it is not the primary treatment.",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Line Of treatment",
-                "examples": "2,3,4"
-              }
-            },
-            {
-              "name": "treatment_start_interval",
-              "description": "The interval between the primary diagnosis and initiation of treatment, in days.",
-              "valueType": "integer",
-              "restrictions": {
-                "required": true
-              },
-              "meta": {
-                "core": true,
-                "units": "days",
-                "notes": "The associated primary diagnosis is used as the reference point for this interval. To calculate this, find the number of days since the date of primary diagnosis.",
-                "displayName": "Treatment Start Interval"
-              }
-            },
-            {
-              "name": "treatment_duration",
-              "description": "The duration of treatment regimen, in days.",
-              "valueType": "integer",
-              "restrictions": {
-                "required": true
-              },
-              "meta": {
-                "core": true,
-                "units": "days",
-                "displayName": "Treatment Duration"
-              }
-            },
-            {
-              "name": "days_per_cycle",
-              "description": "Indicate the number of days in a treatment cycle.",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Days Per Cycle"
-              }
-            },
-            {
-              "name": "number_of_cycles",
-              "description": "Indicate the number of treatment cycles.",
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Number Of Cycles"
-              }
-            },
-            {
-              "name": "therapeutic_intent",
-              "description": "The therapeutic intent, the reason behind the choice of a therapy, of the treatment.",
-              "valueType": "string",
-              "restrictions": {
-                "required": true,
-                "codeList": [
-                  "Adjuvant",
-                  "Concurrent",
-                  "Curative",
-                  "Neoadjuvant",
-                  "Not applicable",
-                  "Palliative",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Therapeutic Intent"
-              }
-            },
-            {
-              "name": "response_to_therapy",
-              "description": "The donor's response to the applied treatment regimen. (Source: RECIST)",
-              "valueType": "string",
-              "restrictions": {
-                "required": true,
-                "codeList": [
-                  "Complete response",
-                  "Disease progression",
-                  "NED",
-                  "Partial response",
-                  "Stable disease"
-                ]
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Response To Therapy"
-              }
-            },
-            {
-              "name": "outcome_of_treatment",
-              "description": "Indicate the donor's outcome of the prescribed treatment.",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Treatment completed as prescribed",
-                  "Treatment incomplete due to technical or organizational problems",
-                  "Treatment incomplete because patient died",
-                  "Patient choice (stopped or interrupted treatment)",
-                  "Physician decision (stopped or interrupted treatment)",
-                  "Treatment stopped due to lack of efficacy (disease progression)",
-                  "Treatment stopped due to acute toxicity",
-                  "Other",
-                  "Not applicable",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "Outcome Of Treatment"
-              }
-            },
-            {
-              "name": "toxicity_type",
-              "description": "If the treatment was terminated early due to acute toxicity, indicate whether it was due to hemotological toxicity or non-hemotological toxicity.",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": ["Hemotological", "Non-hemotological"]
-              },
-              "meta": {
-                "displayName": "Toxicity Type"
-              }
-            },
-            {
-              "name": "hemotological_toxicity",
-              "description": "Indicate the hemotological toxicities which caused early termination of the treatment. (Codelist reference: NCI-CTCAE (v5.0))",
-              "valueType": "string",
-              "isArray": true,
-              "restrictions": {
-                "codeList": [
-                  "Anemia - Grade 3",
-                  "Anemia - Grade 4",
-                  "Anemia - Grade 5",
-                  "Neutropenia - Grade 3",
-                  "Neutropenia - Grade 4",
-                  "Neutropenia - Grade 5",
-                  "Thrombocytopenia - Grade 3",
-                  "Thrombocytopenia - Grade 4",
-                  "Thrombocytopenia - Grade 5"
-                ]
-              },
-              "meta": {
-                "displayName": "Hemotological Toxicity",
-                "notes": "To include multiple values, separate values with a pipe delimiter '|' within your file."
-              }
-            },
-            {
-              "name": "adverse_events",
-              "description": "Report any treatment related adverse events. (Codelist reference: NCI-CTCAE (v5.0))",
-              "valueType": "string",
-              "isArray": true,
-              "restrictions": {
-                "codeList": [
-                  "Abdominal distension",
-                  "Abdominal infection",
-                  "Abdominal pain",
-                  "Abdominal soft tissue necrosis",
-                  "Abducens nerve disorder",
-                  "Accessory nerve disorder",
-                  "Acidosis",
-                  "Acoustic nerve disorder NOS",
-                  "Activated partial thromboplastin time prolonged",
-                  "Acute kidney injury",
-                  "Adrenal insufficiency",
-                  "Adult respiratory distress syndrome",
-                  "Agitation",
-                  "Akathisia",
-                  "Alanine aminotransferase increased",
-                  "Alcohol intolerance",
-                  "Alkaline phosphatase increased",
-                  "Alkalosis",
-                  "Allergic reaction",
-                  "Allergic rhinitis",
-                  "Alopecia",
-                  "Amenorrhea",
-                  "Amnesia",
-                  "Anal fissure",
-                  "Anal fistula",
-                  "Anal hemorrhage",
-                  "Anal mucositis",
-                  "Anal necrosis",
-                  "Anal pain",
-                  "Anal stenosis",
-                  "Anal ulcer",
-                  "Anaphylaxis",
-                  "Anemia",
-                  "Ankle fracture",
-                  "Anorectal infection",
-                  "Anorexia",
-                  "Anorgasmia",
-                  "Anosmia",
-                  "Anxiety",
-                  "Aortic injury",
-                  "Aortic valve disease",
-                  "Aphonia",
-                  "Apnea",
-                  "Appendicitis",
-                  "Appendicitis perforated",
-                  "Arachnoiditis",
-                  "Arterial injury",
-                  "Arterial thromboembolism",
-                  "Arteritis infective",
-                  "Arthralgia",
-                  "Arthritis",
-                  "Ascites",
-                  "Aspartate aminotransferase increased",
-                  "Aspiration",
-                  "Asystole",
-                  "Ataxia",
-                  "Atelectasis",
-                  "Atrial fibrillation",
-                  "Atrial flutter",
-                  "Atrioventricular block complete",
-                  "Atrioventricular block first degree",
-                  "Autoimmune disorder",
-                  "Avascular necrosis",
-                  "Azoospermia",
-                  "Back pain",
-                  "Bacteremia",
-                  "Belching",
-                  "Bile duct stenosis",
-                  "Biliary anastomotic leak",
-                  "Biliary fistula",
-                  "Biliary tract infection",
-                  "Bladder anastomotic leak",
-                  "Bladder infection",
-                  "Bladder perforation",
-                  "Bladder spasm",
-                  "Bloating",
-                  "Blood and lymphatic system disorders - Other, specify",
-                  "Blood antidiuretic hormone abnormal",
-                  "Blood bicarbonate decreased",
-                  "Blood bilirubin increased",
-                  "Blood corticotrophin decreased",
-                  "Blood gonadotrophin abnormal",
-                  "Blood lactate dehydrogenase increased",
-                  "Blood prolactin abnormal",
-                  "Blurred vision",
-                  "Body odor",
-                  "Bone infection",
-                  "Bone marrow hypocellular",
-                  "Bone pain",
-                  "Brachial plexopathy",
-                  "Breast atrophy",
-                  "Breast infection",
-                  "Breast pain",
-                  "Bronchial fistula",
-                  "Bronchial infection",
-                  "Bronchial obstruction",
-                  "Bronchial stricture",
-                  "Bronchopleural fistula",
-                  "Bronchopulmonary hemorrhage",
-                  "Bronchospasm",
-                  "Bruising",
-                  "Budd-Chiari syndrome",
-                  "Bullous dermatitis",
-                  "Burn",
-                  "Buttock pain",
-                  "Capillary leak syndrome",
-                  "Carbon monoxide diffusing capacity decreased",
-                  "Cardiac arrest",
-                  "Cardiac disorders - Other, specify",
-                  "Cardiac troponin I increased",
-                  "Cardiac troponin T increased",
-                  "Cataract",
-                  "Catheter related infection",
-                  "CD4 lymphocytes decreased",
-                  "Cecal hemorrhage",
-                  "Cecal infection",
-                  "Central nervous system necrosis",
-                  "Cerebrospinal fluid leakage",
-                  "Cervicitis infection",
-                  "Cheilitis",
-                  "Chest pain - cardiac",
-                  "Chest wall necrosis",
-                  "Chest wall pain",
-                  "Chills",
-                  "Cholecystitis",
-                  "Cholesterol high",
-                  "Chronic kidney disease",
-                  "Chylothorax",
-                  "Chylous ascites",
-                  "Cognitive disturbance",
-                  "Colitis",
-                  "Colonic fistula",
-                  "Colonic hemorrhage",
-                  "Colonic obstruction",
-                  "Colonic perforation",
-                  "Colonic stenosis",
-                  "Colonic ulcer",
-                  "Concentration impairment",
-                  "Conduction disorder",
-                  "Confusion",
-                  "Congenital, familial and genetic disorders - Other, specify",
-                  "Conjunctivitis",
-                  "Conjunctivitis infective",
-                  "Constipation",
-                  "Corneal infection",
-                  "Corneal ulcer",
-                  "Cough",
-                  "CPK increased",
-                  "Cranial nerve infection",
-                  "Creatinine increased",
-                  "Cushingoid",
-                  "Cyanosis",
-                  "Cystitis noninfective",
-                  "Cytokine release syndrome",
-                  "Cytomegalovirus infection reactivation",
-                  "Death neonatal",
-                  "Death NOS",
-                  "Dehydration",
-                  "Delayed orgasm",
-                  "Delayed puberty",
-                  "Delirium",
-                  "Delusions",
-                  "Dental caries",
-                  "Depressed level of consciousness",
-                  "Depression",
-                  "Dermatitis radiation",
-                  "Device related infection",
-                  "Diarrhea",
-                  "Disease progression",
-                  "Disseminated intravascular coagulation",
-                  "Dizziness",
-                  "Dry eye",
-                  "Dry mouth",
-                  "Dry skin",
-                  "Duodenal fistula",
-                  "Duodenal hemorrhage",
-                  "Duodenal infection",
-                  "Duodenal obstruction",
-                  "Duodenal perforation",
-                  "Duodenal stenosis",
-                  "Duodenal ulcer",
-                  "Dysarthria",
-                  "Dysesthesia",
-                  "Dysgeusia",
-                  "Dysmenorrhea",
-                  "Dyspareunia",
-                  "Dyspepsia",
-                  "Dysphagia",
-                  "Dysphasia",
-                  "Dyspnea",
-                  "Dysuria",
-                  "Ear and labyrinth disorders - Other, specify",
-                  "Ear pain",
-                  "Eczema",
-                  "Edema cerebral",
-                  "Edema face",
-                  "Edema limbs",
-                  "Edema trunk",
-                  "Ejaculation disorder",
-                  "Ejection fraction decreased",
-                  "Electrocardiogram QT corrected interval prolonged",
-                  "Electrocardiogram T wave abnormal",
-                  "Encephalitis infection",
-                  "Encephalomyelitis infection",
-                  "Encephalopathy",
-                  "Endocarditis infective",
-                  "Endocrine disorders - Other, specify",
-                  "Endophthalmitis",
-                  "Enterocolitis",
-                  "Enterocolitis infectious",
-                  "Enterovesical fistula",
-                  "Eosinophilia",
-                  "Epistaxis",
-                  "Epstein-Barr virus infection reactivation",
-                  "Erectile dysfunction",
-                  "Erythema multiforme",
-                  "Erythroderma",
-                  "Esophageal anastomotic leak",
-                  "Esophageal fistula",
-                  "Esophageal hemorrhage",
-                  "Esophageal infection",
-                  "Esophageal necrosis",
-                  "Esophageal obstruction",
-                  "Esophageal pain",
-                  "Esophageal perforation",
-                  "Esophageal stenosis",
-                  "Esophageal ulcer",
-                  "Esophageal varices hemorrhage",
-                  "Esophagitis",
-                  "Euphoria",
-                  "Exostosis",
-                  "External ear pain",
-                  "Extraocular muscle paresis",
-                  "Extrapyramidal disorder",
-                  "Eye disorders - Other, specify",
-                  "Eye infection",
-                  "Eye pain",
-                  "Eyelid function disorder",
-                  "Facial muscle weakness",
-                  "Facial nerve disorder",
-                  "Facial pain",
-                  "Fall",
-                  "Fallopian tube anastomotic leak",
-                  "Fallopian tube obstruction",
-                  "Fallopian tube perforation",
-                  "Fat atrophy",
-                  "Fatigue",
-                  "Febrile neutropenia",
-                  "Fecal incontinence",
-                  "Feminization acquired",
-                  "Fetal growth retardation",
-                  "Fever",
-                  "Fibrinogen decreased",
-                  "Fibrosis deep connective tissue",
-                  "Flank pain",
-                  "Flashing lights",
-                  "Flatulence",
-                  "Floaters",
-                  "Flu like symptoms",
-                  "Flushing",
-                  "Folliculitis",
-                  "Forced expiratory volume decreased",
-                  "Fracture",
-                  "Fungemia",
-                  "Gait disturbance",
-                  "Gallbladder fistula",
-                  "Gallbladder infection",
-                  "Gallbladder necrosis",
-                  "Gallbladder obstruction",
-                  "Gallbladder pain",
-                  "Gallbladder perforation",
-                  "Gastric anastomotic leak",
-                  "Gastric fistula",
-                  "Gastric hemorrhage",
-                  "Gastric necrosis",
-                  "Gastric perforation",
-                  "Gastric stenosis",
-                  "Gastric ulcer",
-                  "Gastritis",
-                  "Gastroesophageal reflux disease",
-                  "Gastrointestinal anastomotic leak",
-                  "Gastrointestinal disorders - Other, specify",
-                  "Gastrointestinal fistula",
-                  "Gastrointestinal pain",
-                  "Gastrointestinal stoma necrosis",
-                  "Gastroparesis",
-                  "General disorders and administration site conditions - Other, specify",
-                  "Generalized edema",
-                  "Generalized muscle weakness",
-                  "Genital edema",
-                  "GGT increased",
-                  "Gingival pain",
-                  "Glaucoma",
-                  "Glossopharyngeal nerve disorder",
-                  "Glucose intolerance",
-                  "Glucosuria",
-                  "Growth accelerated",
-                  "Growth hormone abnormal",
-                  "Growth suppression",
-                  "Guillain-Barre syndrome",
-                  "Gum infection",
-                  "Gynecomastia",
-                  "Hair color changes",
-                  "Hair texture abnormal",
-                  "Hallucinations",
-                  "Haptoglobin decreased",
-                  "Head soft tissue necrosis",
-                  "Headache",
-                  "Hearing impaired",
-                  "Heart failure",
-                  "Hematoma",
-                  "Hematosalpinx",
-                  "Hematuria",
-                  "Hemoglobin increased",
-                  "Hemoglobinuria",
-                  "Hemolysis",
-                  "Hemolytic uremic syndrome",
-                  "Hemorrhoidal hemorrhage",
-                  "Hemorrhoids",
-                  "Hepatic failure",
-                  "Hepatic hemorrhage",
-                  "Hepatic infection",
-                  "Hepatic necrosis",
-                  "Hepatic pain",
-                  "Hepatitis B reactivation",
-                  "Hepatitis viral",
-                  "Hepatobiliary disorders - Other, specify",
-                  "Herpes simplex reactivation",
-                  "Hiccups",
-                  "Hip fracture",
-                  "Hirsutism",
-                  "Hoarseness",
-                  "Hot flashes",
-                  "Hydrocephalus",
-                  "Hypercalcemia",
-                  "Hyperglycemia",
-                  "Hyperhidrosis",
-                  "Hyperkalemia",
-                  "Hyperkeratosis",
-                  "Hyperlipidemia",
-                  "Hypermagnesemia",
-                  "Hypernatremia",
-                  "Hyperparathyroidism",
-                  "Hyperphosphatemia",
-                  "Hypersomnia",
-                  "Hypertension",
-                  "Hyperthyroidism",
-                  "Hypertrichosis",
-                  "Hypertriglyceridemia",
-                  "Hyperuricemia",
-                  "Hypoalbuminemia",
-                  "Hypocalcemia",
-                  "Hypoglossal nerve disorder",
-                  "Hypoglycemia",
-                  "Hypohidrosis",
-                  "Hypokalemia",
-                  "Hypomagnesemia",
-                  "Hyponatremia",
-                  "Hypoparathyroidism",
-                  "Hypophosphatemia",
-                  "Hypophysitis",
-                  "Hypopituitarism",
-                  "Hypotension",
-                  "Hypothermia",
-                  "Hypothyroidism",
-                  "Hypoxia",
-                  "Ileal fistula",
-                  "Ileal hemorrhage",
-                  "Ileal obstruction",
-                  "Ileal perforation",
-                  "Ileal stenosis",
-                  "Ileal ulcer",
-                  "Ileus",
-                  "Immune system disorders - Other, specify",
-                  "Infections and infestations - Other, specify",
-                  "Infective myositis",
-                  "Infusion related reaction",
-                  "Infusion site extravasation",
-                  "Injection site reaction",
-                  "Injury to carotid artery",
-                  "Injury to inferior vena cava",
-                  "Injury to jugular vein",
-                  "Injury to superior vena cava",
-                  "Injury, poisoning and procedural complications - Other, specify",
-                  "INR increased",
-                  "Insomnia",
-                  "Intestinal stoma leak",
-                  "Intestinal stoma obstruction",
-                  "Intestinal stoma site bleeding",
-                  "Intra-abdominal hemorrhage",
-                  "Intracranial hemorrhage",
-                  "Intraoperative arterial injury",
-                  "Intraoperative breast injury",
-                  "Intraoperative cardiac injury",
-                  "Intraoperative ear injury",
-                  "Intraoperative endocrine injury",
-                  "Intraoperative gastrointestinal injury",
-                  "Intraoperative head and neck injury",
-                  "Intraoperative hemorrhage",
-                  "Intraoperative hepatobiliary injury",
-                  "Intraoperative musculoskeletal injury",
-                  "Intraoperative neurological injury",
-                  "Intraoperative ocular injury",
-                  "Intraoperative renal injury",
-                  "Intraoperative reproductive tract injury",
-                  "Intraoperative respiratory injury",
-                  "Intraoperative splenic injury",
-                  "Intraoperative urinary injury",
-                  "Intraoperative venous injury",
-                  "Investigations - Other, specify",
-                  "Iron overload",
-                  "Irregular menstruation",
-                  "Irritability",
-                  "Ischemia cerebrovascular",
-                  "Jejunal fistula",
-                  "Jejunal hemorrhage",
-                  "Jejunal obstruction",
-                  "Jejunal perforation",
-                  "Jejunal stenosis",
-                  "Jejunal ulcer",
-                  "Joint effusion",
-                  "Joint infection",
-                  "Joint range of motion decreased",
-                  "Joint range of motion decreased cervical spine",
-                  "Joint range of motion decreased lumbar spine",
-                  "Keratitis",
-                  "Kidney anastomotic leak",
-                  "Kidney infection",
-                  "Kyphosis",
-                  "Lactation disorder",
-                  "Large intestinal anastomotic leak",
-                  "Laryngeal edema",
-                  "Laryngeal fistula",
-                  "Laryngeal hemorrhage",
-                  "Laryngeal inflammation",
-                  "Laryngeal mucositis",
-                  "Laryngeal obstruction",
-                  "Laryngeal stenosis",
-                  "Laryngitis",
-                  "Laryngopharyngeal dysesthesia",
-                  "Laryngospasm",
-                  "Left ventricular systolic dysfunction",
-                  "Lethargy",
-                  "Leukemia secondary to oncology chemotherapy",
-                  "Leukocytosis",
-                  "Leukoencephalopathy",
-                  "Libido decreased",
-                  "Libido increased",
-                  "Lip infection",
-                  "Lip pain",
-                  "Lipase increased",
-                  "Lipohypertrophy",
-                  "Localized edema",
-                  "Lordosis",
-                  "Lower gastrointestinal hemorrhage",
-                  "Lung infection",
-                  "Lymph gland infection",
-                  "Lymph leakage",
-                  "Lymph node pain",
-                  "Lymphedema",
-                  "Lymphocele",
-                  "Lymphocyte count decreased",
-                  "Lymphocyte count increased",
-                  "Malabsorption",
-                  "Malaise",
-                  "Mania",
-                  "Mediastinal hemorrhage",
-                  "Mediastinal infection",
-                  "Memory impairment",
-                  "Meningismus",
-                  "Meningitis",
-                  "Menorrhagia",
-                  "Metabolism and nutrition disorders - Other, specify",
-                  "Methemoglobinemia",
-                  "Middle ear inflammation",
-                  "Mitral valve disease",
-                  "Mobitz (type) II atrioventricular block",
-                  "Mobitz type I",
-                  "Movements involuntary",
-                  "Mucosal infection",
-                  "Mucositis oral",
-                  "Multi-organ failure",
-                  "Muscle cramp",
-                  "Muscle weakness left-sided",
-                  "Muscle weakness lower limb",
-                  "Muscle weakness right-sided",
-                  "Muscle weakness trunk",
-                  "Muscle weakness upper limb",
-                  "Musculoskeletal and connective tissue disorder - Other, specify",
-                  "Musculoskeletal deformity",
-                  "Myalgia",
-                  "Myasthenia gravis",
-                  "Myelitis",
-                  "Myelodysplastic syndrome",
-                  "Myocardial infarction",
-                  "Myocarditis",
-                  "Myositis",
-                  "Nail changes",
-                  "Nail discoloration",
-                  "Nail infection",
-                  "Nail loss",
-                  "Nail ridging",
-                  "Nasal congestion",
-                  "Nausea",
-                  "Neck edema",
-                  "Neck pain",
-                  "Neck soft tissue necrosis",
-                  "Neoplasms benign, malignant and unspecified (incl cysts and polyps) - Other, specify",
-                  "Nephrotic syndrome",
-                  "Nervous system disorders - Other, specify",
-                  "Neuralgia",
-                  "Neutrophil count decreased",
-                  "Night blindness",
-                  "Nipple deformity",
-                  "Non-cardiac chest pain",
-                  "Nystagmus",
-                  "Obesity",
-                  "Obstruction gastric",
-                  "Oculomotor nerve disorder",
-                  "Olfactory nerve disorder",
-                  "Oligospermia",
-                  "Optic nerve disorder",
-                  "Oral cavity fistula",
-                  "Oral dysesthesia",
-                  "Oral hemorrhage",
-                  "Oral pain",
-                  "Oropharyngeal pain",
-                  "Osteonecrosis",
-                  "Osteonecrosis of jaw",
-                  "Osteoporosis",
-                  "Otitis externa",
-                  "Otitis media",
-                  "Ovarian hemorrhage",
-                  "Ovarian infection",
-                  "Ovarian rupture",
-                  "Ovulation pain",
-                  "Pain",
-                  "Pain in extremity",
-                  "Pain of skin",
-                  "Palmar-plantar erythrodysesthesia syndrome",
-                  "Palpitations",
-                  "Pancreas infection",
-                  "Pancreatic anastomotic leak",
-                  "Pancreatic duct stenosis",
-                  "Pancreatic enzymes decreased",
-                  "Pancreatic fistula",
-                  "Pancreatic hemorrhage",
-                  "Pancreatic necrosis",
-                  "Pancreatitis",
-                  "Papilledema",
-                  "Papulopustular rash",
-                  "Paresthesia",
-                  "Paronychia",
-                  "Paroxysmal atrial tachycardia",
-                  "Pelvic floor muscle weakness",
-                  "Pelvic infection",
-                  "Pelvic pain",
-                  "Pelvic soft tissue necrosis",
-                  "Penile infection",
-                  "Penile pain",
-                  "Perforation bile duct",
-                  "Pericardial effusion",
-                  "Pericardial tamponade",
-                  "Pericarditis",
-                  "Perineal pain",
-                  "Periodontal disease",
-                  "Periorbital edema",
-                  "Periorbital infection",
-                  "Peripheral ischemia",
-                  "Peripheral motor neuropathy",
-                  "Peripheral nerve infection",
-                  "Peripheral sensory neuropathy",
-                  "Peritoneal infection",
-                  "Peritoneal necrosis",
-                  "Personality change",
-                  "Phantom pain",
-                  "Pharyngeal anastomotic leak",
-                  "Pharyngeal fistula",
-                  "Pharyngeal hemorrhage",
-                  "Pharyngeal mucositis",
-                  "Pharyngeal necrosis",
-                  "Pharyngeal stenosis",
-                  "Pharyngitis",
-                  "Pharyngolaryngeal pain",
-                  "Phlebitis",
-                  "Phlebitis infective",
-                  "Photophobia",
-                  "Photosensitivity",
-                  "Platelet count decreased",
-                  "Pleural effusion",
-                  "Pleural hemorrhage",
-                  "Pleural infection",
-                  "Pleuritic pain",
-                  "Pneumonitis",
-                  "Pneumothorax",
-                  "Portal hypertension",
-                  "Portal vein thrombosis",
-                  "Postnasal drip",
-                  "Postoperative hemorrhage",
-                  "Postoperative thoracic procedure complication",
-                  "Precocious puberty",
-                  "Pregnancy loss",
-                  "Pregnancy, puerperium and perinatal conditions - Other, specify",
-                  "Premature delivery",
-                  "Premature menopause",
-                  "Presyncope",
-                  "Proctitis",
-                  "Productive cough",
-                  "Prolapse of intestinal stoma",
-                  "Prolapse of urostomy",
-                  "Prostate infection",
-                  "Prostatic hemorrhage",
-                  "Prostatic obstruction",
-                  "Prostatic pain",
-                  "Proteinuria",
-                  "Pruritus",
-                  "Psychiatric disorders - Other, specify",
-                  "Psychosis",
-                  "Pulmonary edema",
-                  "Pulmonary fibrosis",
-                  "Pulmonary fistula",
-                  "Pulmonary hypertension",
-                  "Pulmonary valve disease",
-                  "Purpura",
-                  "Pyramidal tract syndrome",
-                  "Radiation recall reaction (dermatologic)",
-                  "Radiculitis",
-                  "Rash acneiform",
-                  "Rash maculo-papular",
-                  "Rash pustular",
-                  "Rectal anastomotic leak",
-                  "Rectal fissure",
-                  "Rectal fistula",
-                  "Rectal hemorrhage",
-                  "Rectal mucositis",
-                  "Rectal necrosis",
-                  "Rectal obstruction",
-                  "Rectal pain",
-                  "Rectal perforation",
-                  "Rectal stenosis",
-                  "Rectal ulcer",
-                  "Recurrent laryngeal nerve palsy",
-                  "Renal and urinary disorders - Other, specify",
-                  "Renal calculi",
-                  "Renal colic",
-                  "Renal hemorrhage",
-                  "Reproductive system and breast disorders - Other, specify",
-                  "Respiratory failure",
-                  "Respiratory, thoracic and mediastinal disorders - Other, specify",
-                  "Restlessness",
-                  "Restrictive cardiomyopathy",
-                  "Retinal detachment",
-                  "Retinal tear",
-                  "Retinal vascular disorder",
-                  "Retinoic acid syndrome",
-                  "Retinopathy",
-                  "Retroperitoneal hemorrhage",
-                  "Reversible posterior leukoencephalopathy syndrome",
-                  "Rhabdomyolysis",
-                  "Rhinitis infective",
-                  "Rhinorrhea",
-                  "Right ventricular dysfunction",
-                  "Rotator cuff injury",
-                  "Salivary duct inflammation",
-                  "Salivary gland fistula",
-                  "Salivary gland infection",
-                  "Scalp pain",
-                  "Scleral disorder",
-                  "Scoliosis",
-                  "Scrotal infection",
-                  "Scrotal pain",
-                  "Seizure",
-                  "Sepsis",
-                  "Seroma",
-                  "Serum amylase increased",
-                  "Serum sickness",
-                  "Shingles",
-                  "Sick sinus syndrome",
-                  "Sinus bradycardia",
-                  "Sinus disorder",
-                  "Sinus pain",
-                  "Sinus tachycardia",
-                  "Sinusitis",
-                  "Sinusoidal obstruction syndrome",
-                  "Skin and subcutaneous tissue disorders - Other, specify",
-                  "Skin atrophy",
-                  "Skin hyperpigmentation",
-                  "Skin hypopigmentation",
-                  "Skin induration",
-                  "Skin infection",
-                  "Skin papilloma",
-                  "Skin ulceration",
-                  "Sleep apnea",
-                  "Small intestinal anastomotic leak",
-                  "Small intestinal mucositis",
-                  "Small intestinal obstruction",
-                  "Small intestinal perforation",
-                  "Small intestinal stenosis",
-                  "Small intestine infection",
-                  "Small intestine ulcer",
-                  "Sneezing",
-                  "Social circumstances - Other, specify",
-                  "Soft tissue infection",
-                  "Soft tissue necrosis lower limb",
-                  "Soft tissue necrosis upper limb",
-                  "Somnolence",
-                  "Sore throat",
-                  "Spasticity",
-                  "Spermatic cord anastomotic leak",
-                  "Spermatic cord hemorrhage",
-                  "Spermatic cord obstruction",
-                  "Spinal cord compression",
-                  "Spinal fracture",
-                  "Splenic infection",
-                  "Stenosis of gastrointestinal stoma",
-                  "Stevens-Johnson syndrome",
-                  "Stoma site infection",
-                  "Stomach pain",
-                  "Stomal ulcer",
-                  "Stridor",
-                  "Stroke",
-                  "Subcutaneous emphysema",
-                  "Sudden death NOS",
-                  "Suicidal ideation",
-                  "Suicide attempt",
-                  "Superficial soft tissue fibrosis",
-                  "Superficial thrombophlebitis",
-                  "Superior vena cava syndrome",
-                  "Supraventricular tachycardia",
-                  "Surgical and medical procedures - Other, specify",
-                  "Syncope",
-                  "Telangiectasia",
-                  "Tendon reflex decreased",
-                  "Testicular disorder",
-                  "Testicular hemorrhage",
-                  "Testicular pain",
-                  "Testosterone deficiency",
-                  "Thromboembolic event",
-                  "Thrombotic thrombocytopenic purpura",
-                  "Thrush",
-                  "Thyroid stimulating hormone increased",
-                  "Tinnitus",
-                  "Tooth development disorder",
-                  "Tooth discoloration",
-                  "Tooth infection",
-                  "Toothache",
-                  "Toxic epidermal necrolysis",
-                  "Tracheal fistula",
-                  "Tracheal hemorrhage",
-                  "Tracheal mucositis",
-                  "Tracheal obstruction",
-                  "Tracheal stenosis",
-                  "Tracheitis",
-                  "Tracheostomy site bleeding",
-                  "Transient ischemic attacks",
-                  "Treatment related secondary malignancy",
-                  "Tremor",
-                  "Tricuspid valve disease",
-                  "Trigeminal nerve disorder",
-                  "Trismus",
-                  "Trochlear nerve disorder",
-                  "Tumor hemorrhage",
-                  "Tumor lysis syndrome",
-                  "Tumor pain",
-                  "Typhlitis",
-                  "Unequal limb length",
-                  "Upper gastrointestinal hemorrhage",
-                  "Upper respiratory infection",
-                  "Ureteric anastomotic leak",
-                  "Urethral anastomotic leak",
-                  "Urethral infection",
-                  "Urinary fistula",
-                  "Urinary frequency",
-                  "Urinary incontinence",
-                  "Urinary retention",
-                  "Urinary tract infection",
-                  "Urinary tract obstruction",
-                  "Urinary tract pain",
-                  "Urinary urgency",
-                  "Urine discoloration",
-                  "Urine output decreased",
-                  "Urostomy leak",
-                  "Urostomy obstruction",
-                  "Urostomy site bleeding",
-                  "Urostomy stenosis",
-                  "Urticaria",
-                  "Uterine anastomotic leak",
-                  "Uterine fistula",
-                  "Uterine hemorrhage",
-                  "Uterine infection",
-                  "Uterine obstruction",
-                  "Uterine pain",
-                  "Uterine perforation",
-                  "Uveitis",
-                  "Vaccination complication",
-                  "Vaccination site lymphadenopathy",
-                  "Vaginal anastomotic leak",
-                  "Vaginal discharge",
-                  "Vaginal dryness",
-                  "Vaginal fistula",
-                  "Vaginal hemorrhage",
-                  "Vaginal infection",
-                  "Vaginal inflammation",
-                  "Vaginal obstruction",
-                  "Vaginal pain",
-                  "Vaginal perforation",
-                  "Vaginal stricture",
-                  "Vagus nerve disorder",
-                  "Vas deferens anastomotic leak",
-                  "Vascular access complication",
-                  "Vascular disorders - Other, specify",
-                  "Vasculitis",
-                  "Vasovagal reaction",
-                  "Venous injury",
-                  "Ventricular arrhythmia",
-                  "Ventricular fibrillation",
-                  "Ventricular tachycardia",
-                  "Vertigo",
-                  "Vestibular disorder",
-                  "Viremia",
-                  "Virilization",
-                  "Visceral arterial ischemia",
-                  "Vision decreased",
-                  "Vital capacity abnormal",
-                  "Vitreous hemorrhage",
-                  "Voice alteration",
-                  "Vomiting",
-                  "Vulval infection",
-                  "Watering eyes",
-                  "Weight gain",
-                  "Weight loss",
-                  "Wheezing",
-                  "White blood cell decreased",
-                  "Wound complication",
-                  "Wound dehiscence",
-                  "Wound infection",
-                  "Wrist fracture"
-                ]
-              },
-              "meta": {
-                "displayName": "Adverse Events",
-                "notes": "To include multiple values, separate values with a pipe delimiter '|' within your file."
-              }
-            },
-            {
-              "name": "clinical_trials_database",
-              "description": "If the donor is a participant in a clinical trial, indicate the clinical trial database where the clinical trial is registered.",
-              "valueType": "string",
-              "meta": {
-                "display name": "Clinical Trials Database"
-              },
-              "restrictions": {
-                "codeList": ["NCI Clinical Trials", "EU Clinical Trials Register"]
-              }
-            },
-            {
-              "name": "clinical_trial_number",
-              "description": "Based on the clinical_trial_database, indicate the unique NCT or EudraCT clinical trial identifier of which the donor is a participant.",
-              "valueType": "string",
-              "meta": {
-                "display name": "Clinical Trial Number",
-                "dependsOn": "treatment.clinical_trials_database",
-                "examples": "2016-002120-83,NCT02465060"
-              },
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n      // checks for a string just consisting of whitespace\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      \n      //regex check for clinical trial number\n      const NCTCheck = (entry) => {return /(^([Nn][Cc][Tt])[0-9]{8})/.test(decodeURI(entry))};\n      const EudraCTCheck = (entry) => {return /(^[2][0-9]{3}-[0-9]{6}-[0-9]{2})/.test(decodeURI(entry))};\n\n      // list of valid clinical trial databases\n      const clinical_dbs = [\"nci clinical trials\", \"eu clinical trials register\"];\n      \n      if ($row.clinical_trials_database && $field) {\n          const trialNumber = $field.trim();\n          const clinicalTrialsDB = $row.clinical_trials_database.trim().toLowerCase();\n          if ((clinicalTrialsDB === \"nci clinical trials\") && (!NCTCheck(trialNumber))) {\n            result = {valid: false, message: 'The submitted NCI clinical trial number is in incorrect format.'};\n          }\n          else if ((clinicalTrialsDB === \"eu clinical trials register\") && (!EudraCTCheck(trialNumber))) {\n            result = {valid: false, message: \"The submitted EudraCT clinical trial number is in incorrect format.\"};\n          }\n          else if (!clinical_dbs.includes(clinicalTrialsDB)) {\n            result = {valid: false, message: \"The submitted clinical trials database '${$row.clinical_trials_database}' is not included in the list of clinical trial database.\"};\n          }\n      }\n      else if ((!$row.clinical_trials_database || checkforEmpty($row.clnical_trials_database)) && (!$field || checkforEmpty($field))) {\n          result = {valid: true, message: \"Ok\"};\n      }\n      else if ($row.clinical_trials_database && !$field) {\n          if (clinical_dbs.includes($row.clinical_trials_database.trim().toLowerCase())) {\n            result = {valid: false, message: \"'${$name}' must be provided if 'clinical_trial_database' is set to '${$row.clinical_trials_database}'.\"};\n          } \n      }\n      return result;\n    })"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "chemotherapy",
-          "description": "The collection of data elements describing the details of a chemotherapy treatment regimen completed by a donor. To submit multiple treatment drugs for a single regimen, submit multiple rows in the chemotherapy file.",
-          "meta": {
-            "parent": "treatment"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_treatment_id",
-              "valueType": "string",
-              "description": "Unique identifier of the treatment, as assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "treatment.submitter_treatment_id",
-                "displayName": "Submitter Treatment ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "drug_rxnormcui",
-              "description": "The unique RxNormID assigned to the treatment regimen drug.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
-                "displayName": "RxNormCUI"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "drug_name",
-              "description": "Name of agent or drug administered to patient as part of the treatment regimen.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
-                "displayName": "Chemotherapy Drug Name"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "chemotherapy_dosage_units",
-              "description": "Indicate units used to record chemotherapy drug dosage.",
-              "valueType": "string",
-              "restrictions": {
-                "required": true,
-                "codeList": ["mg/m2", "IU/m2", "ug/m2", "g/m2", "mg/kg"]
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Chemotherapy Dosage Units"
-              }
-            },
-            {
-              "name": "cumulative_drug_dosage",
-              "description": "Indicate the total actual drug dose in the same units specified in chemotherapy_dosage_units.",
-              "valueType": "number",
-              "restrictions": {
-                "required": true
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Cumulative Drug Dosage"
-              }
-            }
-          ]
-        },
-        {
-          "name": "hormone_therapy",
-          "description": "The collection of data elements describing the details of a hormone treatment therapy completed by a donor. To submit multiple treatment drugs for a single regimen, submit multiple rows in the hormone_therapy file.",
-          "meta": {
-            "parent": "treatment"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_treatment_id",
-              "valueType": "string",
-              "description": "Unique identifier of the treatment, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "treatment.submitter_treatment_id",
-                "displayName": "Submitter Treatment ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "drug_rxnormcui",
-              "description": "The unique RxNormID assigned to the treatment regimen drug.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
-                "displayName": "RxNormCUI"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "drug_name",
-              "description": "Name of agent or drug administered to patient as part of the treatment regimen.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
-                "displayName": "Hormone Therapy Drug Name"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "hormone_drug_dosage_units",
-              "description": "Indicate the units used to record hormone drug dosage.",
-              "valueType": "string",
-              "restrictions": {
-                "required": true,
-                "codeList": ["mg/m2", "IU/m2", "ug/m2", "g/m2", "mg/kg"]
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Hormone Therapy Dosage Units"
-              }
-            },
-            {
-              "name": "cumulative_drug_dosage",
-              "description": "Indicate total drug dose in units specified in hormone_drug_dosage_units.",
-              "valueType": "number",
-              "restrictions": {
-                "required": true
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Cumulative Drug Dosage"
-              }
-            }
-          ]
-        },
-        {
-          "name": "radiation",
-          "description": "The collection of data elements describing the details of a radiation treatment completed by a donor.",
-          "meta": {
-            "parent": "treatment"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_treatment_id",
-              "valueType": "string",
-              "description": "Unique identifier of the treatment, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "treatment.submitter_treatment_id",
-                "displayName": "Submitter Treatment ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "radiation_therapy_modality",
-              "description": "Indicate the method of radiation treatment or modality.",
-              "valueType": "string",
-              "restrictions": {
-                "required": true,
-                "codeList": ["Electron", "Heavy Ions", "Photon", "Proton"]
-              },
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "displayName": "Radiation Therapy Modality"
-              }
-            },
-            {
-              "name": "radiation_therapy_type",
-              "description": "Indicate type of radiation therapy administered.",
-              "valueType": "string",
-              "restrictions": {
-                "required": true,
-                "codeList": ["External", "Internal"]
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Type of Radiation Therapy",
-                "notes": "Internal application includes Brachytherapy."
-              }
-            },
-            {
-              "name": "radiation_therapy_fractions",
-              "description": "Indicate the total number of fractions delivered as part of treatment.",
-              "valueType": "integer",
-              "restrictions": {
-                "required": true
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Radiation Therapy Fractions"
-              }
-            },
-            {
-              "name": "radiation_therapy_dosage",
-              "description": "Indicate the total dose given in units of Gray (Gy).",
-              "valueType": "integer",
-              "restrictions": {
-                "required": true
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Radiation Therapy Dosage"
-              }
-            },
-            {
-              "name": "anatomical_site_irradiated",
-              "description": "Indicate localization site where radiation therapy was administered.",
-              "valueType": "string",
-              "restrictions": {
-                "required": true,
-                "codeList": [
-                  "Abdomen",
-                  "Bone",
-                  "Brain",
-                  "Extremities",
-                  "Head",
-                  "Head-Neck",
-                  "Liver",
-                  "Lung",
-                  "Pelvis",
-                  "Peritoneum",
-                  "Spine",
-                  "Thorax"
-                ]
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Anatomical Site Irradiated"
-              }
-            },
-            {
-              "name": "radiation_boost",
-              "description": "A radiation boost is an extra radiation treatment targeted at the tumor bed, given after the regular sessions of radiation is complete (Reference NCIt: C137812). Indicate if this radiation treatment was a radiation boost.",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": ["Yes", "No"]
-              },
-              "meta": {
-                "displayName": "Radiation Boost"
-              }
-            },
-            {
-              "name": "reference_radiation_treatment_id",
-              "description": "If a radiation boost was given, indicate the 'submitter_treatment_id' of the primary radiation treatment the radiation boost treatment is linked to.",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": ["Yes", "No"]
-              },
-              "meta": {
-                "displayName": "Reference Radiation Treatment for Boost"
-              }
-            }
-          ]
-        },
-        {
-          "name": "immunotherapy",
-          "description": "The collection of data elements describing the details of an immunotherapy treatment completed by a donor.",
-          "meta": {
-            "parent": "treatment"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_treatment_id",
-              "valueType": "string",
-              "description": "Unique identifier of the treatment, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "treatment.submitter_treatment_id",
-                "displayName": "Submitter Treatment ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "immunotherapy_type",
-              "valueType": "string",
-              "description": "Indicate the type of immunotherapy administered to patient.",
-              "meta": {
-                "displayName": "Immunotherapy Type"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Cell-based",
-                  "Immune checkpoint inhibitors",
-                  "Monoclonal antibodies other than immune checkpoint inhibitors",
-                  "Other immunomodulatory substances"
-                ]
-              }
-            },
-            {
-              "name": "drug_rxnormcui",
-              "description": "The unique RxNormID assigned to the treatment regimen drug.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
-                "displayName": "RxNormCUI"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "drug_name",
-              "description": "Name of agent or drug administered to patient as part of the treatment regimen.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "core": true,
-                "notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
-                "displayName": "Immunotherapy Drug Name"
-              },
-              "restrictions": {
-                "required": true
-              }
-            }
-          ]
-        },
-        {
-          "name": "follow_up",
-          "description": "The collection of data elements related to a specific follow-up visit to a donor. A follow-up is defined as any point of contact with a patient after primary diagnosis. To submit multiple follow-ups for a single donor, please submit multiple rows in the follow-up file for this donor.",
-          "meta": {
-            "parent": "donor"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "description": "Unique identifier for a follow-up event in a donor's clinical record, assigned by the data provider.",
-              "name": "submitter_follow_up_id",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "displayName": "Submitter Follow-Up ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "description": "Interval from the primary diagnosis date to the follow-up date, in days.",
-              "name": "interval_of_followup",
-              "valueType": "integer",
-              "restrictions": {
-                "required": true
-              },
-              "meta": {
-                "core": true,
-                "units": "days",
-                "displayName": "Interval Of Follow-Up",
-                "notes": "The associated primary diagnosis is used as the reference point for this interval. To calculate this, find the number of days since the date of primary diagnosis."
-              }
-            },
-            {
-              "description": "Indicate the donor's disease status at time of follow-up. (Reference: RECIST)",
-              "name": "disease_status_at_followup",
-              "valueType": "string",
-              "restrictions": {
-                "required": true,
-                "codeList": [
-                  "Complete remission",
-                  "Distant progression",
-                  "Loco-regional progression",
-                  "No evidence of disease",
-                  "Partial remission",
-                  "Progression NOS",
-                  "Relapse or recurrence",
-                  "Stable"
-                ]
-              },
-              "meta": {
-                "core": true,
-                "displayName": "Disease Status at Follow-Up"
-              }
-            },
-            {
-              "name": "submitter_primary_diagnosis_id",
-              "valueType": "string",
-              "description": "Indicate if the follow-up is related to a specific primary diagnosis event in the clinical timeline.",
-              "meta": {
-                "displayName": "Submitter Primary Diagnosis ID",
-                "primaryId": true
-              },
-              "restrictions": {
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_treatment_id",
-              "valueType": "string",
-              "description": "Indicate if the follow-up is related to a specific treatment event in the clinical timeline.",
-              "meta": {
-                "primaryId": true,
-                "displayName": "Submitter Treatment ID"
-              },
-              "restrictions": {
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "description": "Indicate the donor's weight, in kilograms (kg), at the time of follow-up.",
-              "name": "weight_at_followup",
-              "valueType": "integer",
-              "restrictions": {},
-              "meta": {
-                "displayName": "Weight at Follow-Up"
-              }
-            },
-            {
-              "description": "Indicate the donor's relapse type.",
-              "name": "relapse_type",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Distant recurrence/metastasis",
-                  "Local recurrence",
-                  "Local recurrence and distant metastasis",
-                  "Progression (liquid tumours)"
-                ],
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        \n        /* required field, cannot be null */\n        const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();\n    \n        const stateOfProgression = (entry) => {return /(progression)$/.test(decodeURI(entry))}; \n        const relapseOrRecurrence = diseaseStatus === \"relapse or recurrence\";\n   \n        // checks for a string just consisting of whitespace\n        const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n\n\n        if ((!$field || checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set a state of progression, relapse, or recurrence.` }\n        }\n        else if (!(!$field || checkforEmpty($field)) && !stateOfProgression(diseaseStatus) && !relapseOrRecurrence) {\n            result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not a state of progression, relapse, or recurrence.` }\n        }\n        return  result;\n    })"
-                ]
-              },
-              "meta": {
-                "core": true,
-                "dependsOn": "follow_up.disease_status_at_followup",
-                "notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.",
-                "displayName": "Relapse Type"
-              }
-            },
-            {
-              "description": "If the donor was clinically disease free following primary treatment and then relapse or recurrence or progression (for liquid tumours) occurred afterwards, then this field will indicate the length of disease free interval, in days.",
-              "name": "relapse_interval",
-              "valueType": "integer",
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n      \n      /* required field, cannot be null */\n      const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();\n      const intervalOfFollowup = parseInt($row.interval_of_followup);\n\n      const stateOfProgression = (entry) => {return /(progression)$/.test(decodeURI(entry))}; \n      const relapseOrRecurrence = diseaseStatus === \"relapse or recurrence\";\n  \n      // checks for a string just consisting of whitespace\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n\n\n      if ((!$field || checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n          result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set a state of progression, relapse, or recurrence.` }\n      }\n      else if (!(!$field || checkforEmpty($field)) && !stateOfProgression(diseaseStatus) && !relapseOrRecurrence) {\n          result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not a state of progression, relapse, or recurrence.` }\n      }\n      else if (!(checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n          relapseInterval = parseInt($field);\n          if (relapseInterval > intervalOfFollowup) {\n              result = {valid: false, message: `'${$name}' cannot be greater than the 'interval_of_followup'.` }\n          }\n      }\n      return  result;\n    })"
-                ]
-              },
-              "meta": {
-                "core": true,
-                "units": "days",
-                "dependsOn": "follow_up.disease_status_at_followup",
-                "notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.",
-                "displayName": "Relapse Interval"
-              }
-            },
-            {
-              "description": "Indicate the method(s) used to confirm the donor's progression or relapse or recurrence disease status. (Reference: caDSR CDE ID 6161031)",
-              "name": "method_of_progression_status",
-              "valueType": "string",
-              "isArray": true,
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        \n        /* required field, cannot be null */\n        const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();\n    \n        const stateOfProgression = (entry) => {return /(progression)$/.test(decodeURI(entry))}; \n        const relapseOrRecurrence = diseaseStatus === \"relapse or recurrence\";\n   \n        // checks for a string just consisting of whitespace\n        const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n\n\n        if ((!$field || checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set a state of progression, relapse, or recurrence.` }\n        }\n        else if (!(!$field || checkforEmpty($field)) && !stateOfProgression(diseaseStatus) && !relapseOrRecurrence) {\n            result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not a state of progression, relapse, or recurrence.` }\n        }\n        return  result;\n    })"
-                ],
-                "codeList": [
-                  "Biomarker in liquid biopsy (e.g. tumour marker in blood or urine)",
-                  "Biopsy",
-                  "Blood draw",
-                  "Bone marrow aspirate",
-                  "Core biopsy",
-                  "Cystoscopy",
-                  "Cytology",
-                  "Debulking",
-                  "Diagnostic imaging",
-                  "Dilation and curettage procedure",
-                  "Enucleation",
-                  "Excisional biopsy",
-                  "Fine needle aspiration",
-                  "Imaging",
-                  "Incisional biopsy",
-                  "Laparoscopy",
-                  "Laparotomy",
-                  "Other",
-                  "Pap Smear",
-                  "Pathologic review",
-                  "Physical exam",
-                  "Surgical resection",
-                  "Thoracentesis",
-                  "Ultrasound guided biopsy"
-                ]
-              },
-              "meta": {
-                "core": true,
-                "dependsOn": "follow_up.disease_status_at_followup",
-                "notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.\nTo include multiple values, separate values with a pipe delimiter '|' within your file.",
-                "displayName": "Method Of Progression Status"
-              }
-            },
-            {
-              "description": "Indicate the ICD-O-3 topography code for the anatomic site where disease progression, relapse or recurrence occurred, according to the International Classification of Diseases for Oncology, 3rd Edition (WHO ICD-O-3). Refer to the ICD-O-3 manual for guidelines at https://apps.who.int/iris/handle/10665/42344.",
-              "name": "anatomic_site_progression_or_recurrences",
-              "valueType": "string",
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        \n        /* required field, cannot be null */\n        const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();\n    \n        const stateOfProgression = (entry) => {return /(progression)$/.test(decodeURI(entry))}; \n        const relapseOrRecurrence = diseaseStatus === \"relapse or recurrence\";\n   \n        // checks for a string just consisting of whitespace\n        const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n\n\n        if ((!$field || checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set a state of progression, relapse, or recurrence.` }\n        }\n        else if (!(!$field || checkforEmpty($field)) && !stateOfProgression(diseaseStatus) && !relapseOrRecurrence) {\n            result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not a state of progression, relapse, or recurrence.` }\n        }\n        return  result;\n    })"
-                ],
-                "regex": "^[C][0-9]{2}(.[0-9]{1})?$"
-              },
-              "meta": {
-                "core": true,
-                "dependsOn": "follow_up.disease_status_at_followup",
-                "displayName": "Anatomic Site Progression or Recurrences",
-                "examples": "C50.1,C18",
-                "notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence."
-              }
-            },
-            {
-              "description": "Specify the tumour staging system used to stage the cancer at time of retreatment for recurrence or disease progression. This may be represented as rTNM in the medical report.",
-              "name": "recurrence_tumour_staging_system",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "AJCC 8th edition",
-                  "AJCC 7th edition",
-                  "Ann Arbor staging system",
-                  "Binet staging system",
-                  "Durie-Salmon staging system",
-                  "FIGO staging system",
-                  "Lugano staging system",
-                  "Rai staging system",
-                  "Revised International staging system (RISS)",
-                  "St Jude staging system"
-                ],
-                "script": [
-                  "(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    const arrayFormatter = arr => `\\n${arr.map(entry => `- \"${entry}\"`).join('\\n')}`;\n    /* This is not a required field, so first ensure that it exists */\n    if ($field) {\n      /* Contingent on the naming system for tumour staging systems to remain consistent */\n      const stagingName = $name\n        .trim()\n        .toLowerCase()\n        .split('_tumour_staging_system')[0];\n      const requiredFields = [\n        `${stagingName}_m_category`,\n        `${stagingName}_n_category`,\n        `${stagingName}_t_category`,\n      ];\n      const convertedRow = Object.fromEntries(\n        Object.entries($row).map(([fieldName, fieldVal]) => [fieldName.toLowerCase(), fieldVal]),\n      );\n      /* Check for contigous spaces wrapped with quotes (empty strings) */\n      const checkforEmpty = entry => {\n        return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'));\n      };\n\n      /* search for fields with falsy values*/\n      const emptyFields = requiredFields.filter(\n        field => !convertedRow[field] || checkforEmpty(convertedRow[field]),\n      );\n\n      /* The fields should be provided IF and ONLY IF the AJCC regex passes */\n      if (/^(AJCC)\\b/i.test($field) && emptyFields.length) {\n        result = {\n          valid: false,\n          message: `The following fields are required when ${$name} is set to an AJCC option: ${arrayFormatter(\n            emptyFields,\n          )}`,\n        };\n      } else if (!/^(AJCC)\\b/i.test($field) && emptyFields.length != requiredFields.length) {\n        const errorFields = requiredFields.filter(fieldName => !emptyFields.includes(fieldName));\n        result = {\n          valid: false,\n          message: `The following fields cannot be provided when ${$name} is not set to an AJCC option: ${arrayFormatter(\n            errorFields,\n          )}`,\n        };\n      }\n    }\n    return result;\n  })",
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        \n        /* required field, cannot be null */\n        const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();\n    \n        const stateOfProgression = (entry) => {return /(progression)$/.test(decodeURI(entry))}; \n        const relapseOrRecurrence = diseaseStatus === \"relapse or recurrence\";\n   \n        // checks for a string just consisting of whitespace\n        const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n\n\n        if ((!$field || checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set a state of progression, relapse, or recurrence.` }\n        }\n        else if (!(!$field || checkforEmpty($field)) && !stateOfProgression(diseaseStatus) && !relapseOrRecurrence) {\n            result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not a state of progression, relapse, or recurrence.` }\n        }\n        return  result;\n    })"
-                ]
-              },
-              "meta": {
-                "core": true,
-                "dependsOn": "follow_up.disease_status_at_followup",
-                "notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.",
-                "displayName": "Recurrance Tumour Staging System"
-              }
-            },
-            {
-              "name": "recurrence_t_category",
-              "description": "The code to represent the extent of the primary tumour (T) based on evidence obtained from clinical assessment parameters determined at the time of retreatment for a recurrence or disease progression, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "follow_up.recurrence_tumour_staging_system",
-                "notes": "This field is required only if the selected recurrence_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Recurrence T Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "T0",
-                  "T1",
-                  "T1a",
-                  "T1a1",
-                  "T1a2",
-                  "T1b",
-                  "T1b1",
-                  "T1b2",
-                  "T1c",
-                  "T1d",
-                  "T1mi",
-                  "T2",
-                  "T2a",
-                  "T2a1",
-                  "T2a2",
-                  "T2b",
-                  "T2c",
-                  "T2d",
-                  "T3",
-                  "T3a",
-                  "T3b",
-                  "T3c",
-                  "T3d",
-                  "T3e",
-                  "T4",
-                  "T4a",
-                  "T4b",
-                  "T4c",
-                  "T4d",
-                  "T4e",
-                  "Ta",
-                  "Tis",
-                  "Tis(DCIS)",
-                  "Tis(LAMN)",
-                  "Tis(LCIS)",
-                  "Tis(Paget)",
-                  "Tis(Paget’s)",
-                  "Tis pd",
-                  "Tis pu",
-                  "TX"
-                ]
-              }
-            },
-            {
-              "name": "recurrence_n_category",
-              "description": "The code to represent the stage of cancer defined by the extent of the regional lymph node (N) involvement for the cancer based on evidence obtained from clinical assessment parameters determined at the time of retreatment for a recurrence or disease progression, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "follow_up.recurrence_tumour_staging_system",
-                "notes": "This field is required only if the selected recurrence_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Recurrence N Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "N0",
-                  "N0a",
-                  "N0a (biopsy)",
-                  "N0b",
-                  "N0b (no biopsy)",
-                  "N0(i+)",
-                  "N0(i-)",
-                  "N0(mol+)",
-                  "N0(mol-)",
-                  "N1",
-                  "N1a",
-                  "N1a(sn)",
-                  "N1b",
-                  "N1c",
-                  "N1mi",
-                  "N2",
-                  "N2a",
-                  "N2b",
-                  "N2c",
-                  "N2mi",
-                  "N3",
-                  "N3a",
-                  "N3b",
-                  "N3c",
-                  "N4",
-                  "NX"
-                ]
-              }
-            },
-            {
-              "name": "recurrence_m_category",
-              "description": "The code to represent the stage of cancer defined by the extent of the distant metastasis (M) for the cancer based on evidence obtained from clinical assessment parameters determined at the time of retreatment for a recurrence or disease progression, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "follow_up.recurrence_tumour_staging_system",
-                "notes": "This field is required only if the selected recurrence_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Recurrence M Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "M0",
-                  "M0(i+)",
-                  "M1",
-                  "M1a",
-                  "M1a(0)",
-                  "M1a(1)",
-                  "M1b",
-                  "M1b(0)",
-                  "M1b(1)",
-                  "M1c",
-                  "M1c(0)",
-                  "M1c(1)",
-                  "M1d",
-                  "M1d(0)",
-                  "M1d(1)",
-                  "M1e"
-                ]
-              }
-            },
-            {
-              "name": "recurrence_stage_group",
-              "description": "The code to represent the stage group of the tumour, as assigned by the reporting recurrence_tumour_staging_system, that indicates the overall prognostic tumour stage (ie. Stage I, Stage II, Stage III etc.) at the time of retreatment for a recurrence or disease progression.",
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "dependsOn": "follow_up.recurrence_tumour_staging_system",
-                "notes": "This field is dependent on the selected recurrence_tumour_staging_system.\nPlease refer to the documentation for Tumour Staging Classifications: http://docs.icgc-argo.org/docs/submission/dictionary-overview#tumour-staging-classifications",
-                "displayName": "Recurrence Stage Group"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Stage 0",
-                  "Stage 0a",
-                  "Stage 0is",
-                  "Stage I",
-                  "Stage IA",
-                  "Stage IA1",
-                  "Stage IA2",
-                  "Stage IA3",
-                  "Stage IB",
-                  "Stage IB1",
-                  "Stage IB2",
-                  "Stage IC",
-                  "Stage IS",
-                  "Stage IE",
-                  "Stage II",
-                  "Stage IIA",
-                  "Stage IIA1",
-                  "Stage IIA2",
-                  "Stage IIE",
-                  "Stage IIB",
-                  "Stage IIC",
-                  "Stage III",
-                  "Stage IIIA",
-                  "Stage IIIA1",
-                  "Stage IIIA2",
-                  "Stage IIIB",
-                  "Stage IIIC",
-                  "Stage IIIC1",
-                  "Stage IIIC2",
-                  "Stage IIID",
-                  "Stage IV",
-                  "Stage IVA",
-                  "Stage IVA1",
-                  "Stage IVA2",
-                  "Stage IVB",
-                  "Stage IVC",
-                  "Occult carcinoma",
-                  "Stage 1",
-                  "Stage 1A",
-                  "Stage 1B",
-                  "Stage ISA",
-                  "Stage ISB",
-                  "Stage IEA",
-                  "Stage IEB",
-                  "Stage IIEA",
-                  "Stage IIEB",
-                  "Stage IIES",
-                  "Stage IIESA",
-                  "Stage IIESB",
-                  "Stage IIS",
-                  "Stage IISA",
-                  "Stage IISB",
-                  "Stage IIIE",
-                  "Stage IIIEA",
-                  "Stage IIIEB",
-                  "Stage IIIES",
-                  "Stage IIIESA",
-                  "Stage IIIESB",
-                  "Stage IIIS",
-                  "Stage IIISA",
-                  "Stage IIISB",
-                  "Stage IAB",
-                  "Stage A",
-                  "Stage B",
-                  "Stage C"
-                ],
-                "script": [
-                  "(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    if ($row.recurrence_tumour_staging_system && $field) {\n      let codeList = [];\n      switch ($row.recurrence_tumour_staging_system && $row.recurrence_tumour_staging_system.trim().toLowerCase()) {\n        case 'revised international staging system (riss)':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii'\n          ];\n          break;\n        case 'lugano staging system':\n          codeList = [\n             'stage i',\n             'stage ia',\n             'stage ib',\n             'stage ie',\n             'stage iea',\n             'stage ieb',\n             'stage ii',\n             'stage iia',\n             'stage iib',\n             'stage iie',\n             'stage iiea',\n             'stage iieb',\n             'stage iii',\n             'stage iiia',\n             'stage iiib',\n             'stage iv',\n             'stage iva',\n             'stage ivb'\n          ];\n          break;\n        case 'st jude staging system':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii',\n            'stage iv'\n          ];\n          break;\n        case 'ann arbor staging system':\n          codeList = [\n            'stage i',\n            'stage ia',\n            'stage ib',\n            'stage ie',\n            'stage is',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iie',\n            'stage iis',\n            'stage iii',\n            'stage iiia',\n            'stage iiib',\n            'stage iiie',\n            'stage iiis',\n            'stage iv',\n            'stage iva',\n            'stage ivb',\n            'stage ive',\n            'stage ivs'\n          ];\n          break;\n        case 'rai staging system':\n          codeList = [\n             'stage 0',\n             'stage i',\n             'stage ii',\n             'stage iii',\n             'stage iv'\n          ];\n          break;\n        case 'durie-salmon staging system':\n          codeList = [\n            'stage 1',\n            'stage 1a',\n            'stage 1b',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iii',\n            'stage iiia',\n            'stage iiib'\n          ];\n          break;\n        case 'figo staging system':\n          codeList = [\n            'stage ia',\n            'stage ia1',\n            'stage ia2',\n            'stage ib',\n            'stage ib1',\n            'stage ib2',\n            'stage iia',\n            'stage iab',\n            'stage iiia',\n            'stage iiib',\n            'stage iva',\n            'stage ivb'\n          ];\n          break;\n        case 'binet staging system':\n          codeList = [\n             'stage a',\n             'stage b',\n             'stage c'\n         ];\n          break;\n        case 'ajcc 8th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ia3','stage ib','stage ib1','stage ib2','stage ic','stage ie','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iie','stage iii','stage iiia','stage iiia1','stage iiia2','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iiid','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'];\n          break;\n        case 'ajcc 7th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ib','stage ib1','stage ib2','stage ic','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iii','stage iiia','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'\n];\n          break;\n        default:\n          codelist = [];\n      }\n\n      if (!codeList.includes($field.trim().toLowerCase()) && codeList.length) {\n        const msg = `'${$field}' is not a permissible value. When 'recurrence_tumour_staging_system' is set to '${\n          $row.recurrence_tumour_staging_system\n        }', 'recurrence_stage_group' must be one of the following: \\n${codeList\n          .map(code => `- \"${code}\"`)\n          .join('\\n')}`;\n\n        result.valid = false;\n        result.message = msg;\n      }\n    }\n    return result;\n  })"
-                ]
-              }
-            },
-            {
-              "description": "Specify the tumour staging system used to stage the cancer after treatment for patients receiving systemic and/or radiation therapy alone or as a component of their initial treatment, or as neoadjuvant therapy before planned surgery. This may be represented as ypTNM or ycTNM in the medical report.",
-              "name": "posttherapy_tumour_staging_system",
-              "valueType": "string",
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    const arrayFormatter = arr => `\\n${arr.map(entry => `- \"${entry}\"`).join('\\n')}`;\n    /* This is not a required field, so first ensure that it exists */\n    if ($field) {\n      /* Contingent on the naming system for tumour staging systems to remain consistent */\n      const stagingName = $name\n        .trim()\n        .toLowerCase()\n        .split('_tumour_staging_system')[0];\n      const requiredFields = [\n        `${stagingName}_m_category`,\n        `${stagingName}_n_category`,\n        `${stagingName}_t_category`,\n      ];\n      const convertedRow = Object.fromEntries(\n        Object.entries($row).map(([fieldName, fieldVal]) => [fieldName.toLowerCase(), fieldVal]),\n      );\n      /* Check for contigous spaces wrapped with quotes (empty strings) */\n      const checkforEmpty = entry => {\n        return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'));\n      };\n\n      /* search for fields with falsy values*/\n      const emptyFields = requiredFields.filter(\n        field => !convertedRow[field] || checkforEmpty(convertedRow[field]),\n      );\n\n      /* The fields should be provided IF and ONLY IF the AJCC regex passes */\n      if (/^(AJCC)\\b/i.test($field) && emptyFields.length) {\n        result = {\n          valid: false,\n          message: `The following fields are required when ${$name} is set to an AJCC option: ${arrayFormatter(\n            emptyFields,\n          )}`,\n        };\n      } else if (!/^(AJCC)\\b/i.test($field) && emptyFields.length != requiredFields.length) {\n        const errorFields = requiredFields.filter(fieldName => !emptyFields.includes(fieldName));\n        result = {\n          valid: false,\n          message: `The following fields cannot be provided when ${$name} is not set to an AJCC option: ${arrayFormatter(\n            errorFields,\n          )}`,\n        };\n      }\n    }\n    return result;\n  })"
-                ],
-                "codeList": [
-                  "AJCC 8th edition",
-                  "AJCC 7th edition",
-                  "Ann Arbor staging system",
-                  "Binet staging system",
-                  "Durie-Salmon staging system",
-                  "FIGO staging system",
-                  "Lugano staging system",
-                  "Rai staging system",
-                  "Revised International staging system (RISS)",
-                  "St Jude staging system"
-                ]
-              },
-              "meta": {
-                "displayName": "Post-therapy Tumour Staging System"
-              }
-            },
-            {
-              "name": "posttherapy_t_category",
-              "description": "The code to represent the extent of the primary tumour (T) based on evidence obtained from clinical assessment parameters determined after treatment for patients receiving systemic and/or radiation therapy alone or as a component of their initial treatment, or as neoadjuvant therapy before planned surgery, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "dependsOn": "follow_up.posttherapy_tumour_staging_system",
-                "notes": "This field is required only if the selected posttherapy_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Post-therapy T Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "T0",
-                  "T1",
-                  "T1a",
-                  "T1a1",
-                  "T1a2",
-                  "T1b",
-                  "T1b1",
-                  "T1b2",
-                  "T1c",
-                  "T1d",
-                  "T1mi",
-                  "T2",
-                  "T2a",
-                  "T2a1",
-                  "T2a2",
-                  "T2b",
-                  "T2c",
-                  "T2d",
-                  "T3",
-                  "T3a",
-                  "T3b",
-                  "T3c",
-                  "T3d",
-                  "T3e",
-                  "T4",
-                  "T4a",
-                  "T4b",
-                  "T4c",
-                  "T4d",
-                  "T4e",
-                  "Ta",
-                  "Tis",
-                  "Tis(DCIS)",
-                  "Tis(LAMN)",
-                  "Tis(LCIS)",
-                  "Tis(Paget)",
-                  "Tis(Paget’s)",
-                  "Tis pd",
-                  "Tis pu",
-                  "TX"
-                ]
-              }
-            },
-            {
-              "name": "posttherapy_n_category",
-              "description": "The code to represent the stage of cancer defined by the extent of the regional lymph node (N) involvement for the cancer based on evidence obtained from clinical assessment parameters determined determined after treatment for patients receiving systemic and/or radiation therapy alone or as a component of their initial treatment, or as neoadjuvant therapy before planned surgery, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "dependsOn": "follow_up.posttherapy_tumour_staging_system",
-                "notes": "This field is required only if the selected posttherapy_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Post-therapy N Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "N0",
-                  "N0a",
-                  "N0a (biopsy)",
-                  "N0b",
-                  "N0b (no biopsy)",
-                  "N0(i+)",
-                  "N0(i-)",
-                  "N0(mol+)",
-                  "N0(mol-)",
-                  "N1",
-                  "N1a",
-                  "N1a(sn)",
-                  "N1b",
-                  "N1c",
-                  "N1mi",
-                  "N2",
-                  "N2a",
-                  "N2b",
-                  "N2c",
-                  "N2mi",
-                  "N3",
-                  "N3a",
-                  "N3b",
-                  "N3c",
-                  "N4",
-                  "NX"
-                ]
-              }
-            },
-            {
-              "name": "posttherapy_m_category",
-              "description": "The code to represent the stage of cancer defined by the extent of the distant metastasis (M) for the cancer based on evidence obtained from clinical assessment parameters determined after treatment for patients receiving systemic and/or radiation therapy alone or as a component of their initial treatment, or as neoadjuvant therapy before planned surgery, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
-              "valueType": "string",
-              "meta": {
-                "dependsOn": "follow_up.posttherapy_tumour_staging_system",
-                "notes": "This field is required only if the selected posttherapy_tumour_staging_system is any edition of the AJCC cancer staging system.",
-                "displayName": "Post-therapy M Category"
-              },
-              "restrictions": {
-                "codeList": [
-                  "M0",
-                  "M0(i+)",
-                  "M1",
-                  "M1a",
-                  "M1a(0)",
-                  "M1a(1)",
-                  "M1b",
-                  "M1b(0)",
-                  "M1b(1)",
-                  "M1c",
-                  "M1c(0)",
-                  "M1c(1)",
-                  "M1d",
-                  "M1d(0)",
-                  "M1d(1)",
-                  "M1e"
-                ]
-              }
-            },
-            {
-              "name": "posttherapy_stage_group",
-              "description": "The code to represent the stage group of the tumour, as assigned by the reporting posttherapy_tumour_staging_system, that indicates the overall prognostic tumour stage (ie. Stage I, Stage II, Stage III etc.) after treatment for patients receiving systemic and/or radiation therapy alone or as a component of their initial treatment, or as neoadjuvant therapy before planned surgery.",
-              "valueType": "string",
-              "meta": {
-                "dependsOn": "follow_up.posttherapy_tumour_staging_system",
-                "notes": "This field is dependent on the selected posttherapy_tumour_staging_system.\nPlease refer to the documentation for Tumour Staging Classifications: http://docs.icgc-argo.org/docs/submission/dictionary-overview#tumour-staging-classifications",
-                "displayName": "Post-therapy Stage Group"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Stage 0",
-                  "Stage 0a",
-                  "Stage 0is",
-                  "Stage I",
-                  "Stage IA",
-                  "Stage IA1",
-                  "Stage IA2",
-                  "Stage IA3",
-                  "Stage IB",
-                  "Stage IB1",
-                  "Stage IB2",
-                  "Stage IC",
-                  "Stage IS",
-                  "Stage IE",
-                  "Stage II",
-                  "Stage IIA",
-                  "Stage IIA1",
-                  "Stage IIA2",
-                  "Stage IIE",
-                  "Stage IIB",
-                  "Stage IIC",
-                  "Stage III",
-                  "Stage IIIA",
-                  "Stage IIIA1",
-                  "Stage IIIA2",
-                  "Stage IIIB",
-                  "Stage IIIC",
-                  "Stage IIIC1",
-                  "Stage IIIC2",
-                  "Stage IIID",
-                  "Stage IV",
-                  "Stage IVA",
-                  "Stage IVA1",
-                  "Stage IVA2",
-                  "Stage IVB",
-                  "Stage IVC",
-                  "Occult carcinoma",
-                  "Stage 1",
-                  "Stage 1A",
-                  "Stage 1B",
-                  "Stage ISA",
-                  "Stage ISB",
-                  "Stage IEA",
-                  "Stage IEB",
-                  "Stage IIEA",
-                  "Stage IIEB",
-                  "Stage IIES",
-                  "Stage IIESA",
-                  "Stage IIESB",
-                  "Stage IIS",
-                  "Stage IISA",
-                  "Stage IISB",
-                  "Stage IIIE",
-                  "Stage IIIEA",
-                  "Stage IIIEB",
-                  "Stage IIIES",
-                  "Stage IIIESA",
-                  "Stage IIIESB",
-                  "Stage IIIS",
-                  "Stage IIISA",
-                  "Stage IIISB",
-                  "Stage IAB",
-                  "Stage A",
-                  "Stage B",
-                  "Stage C"
-                ],
-                "script": [
-                  "(function validate(inputs) {\n    const {$row, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    if ($row.posttherapy_tumour_staging_system && $field) {\n      let codeList = [];\n      switch ($row.posttherapy_tumour_staging_system && $row.posttherapy_tumour_staging_system.trim().toLowerCase()) {\n        case 'revised international staging system (riss)':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii'\n          ];\n          break;\n        case 'lugano staging system':\n          codeList = [\n             'stage i',\n             'stage ia',\n             'stage ib',\n             'stage ie',\n             'stage iea',\n             'stage ieb',\n             'stage ii',\n             'stage iia',\n             'stage iib',\n             'stage iie',\n             'stage iiea',\n             'stage iieb',\n             'stage iii',\n             'stage iiia',\n             'stage iiib',\n             'stage iv',\n             'stage iva',\n             'stage ivb'\n          ];\n          break;\n        case 'st jude staging system':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii',\n            'stage iv'\n          ];\n          break;\n        case 'ann arbor staging system':\n          codeList = [\n            'stage i',\n            'stage ia',\n            'stage ib',\n            'stage ie',\n            'stage is',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iie',\n            'stage iis',\n            'stage iii',\n            'stage iiia',\n            'stage iiib',\n            'stage iiie',\n            'stage iiis',\n            'stage iv',\n            'stage iva',\n            'stage ivb',\n            'stage ive',\n            'stage ivs'\n          ];\n          break;\n        case 'rai staging system':\n          codeList = [\n             'stage 0',\n             'stage i',\n             'stage ii',\n             'stage iii',\n             'stage iv'\n          ];\n          break;\n        case 'durie-salmon staging system':\n          codeList = [\n            'stage 1',\n            'stage 1a',\n            'stage 1b',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iii',\n            'stage iiia',\n            'stage iiib'\n          ];\n          break;\n        case 'figo staging system':\n          codeList = [\n            'stage ia',\n            'stage ia1',\n            'stage ia2',\n            'stage ib',\n            'stage ib1',\n            'stage ib2',\n            'stage iia',\n            'stage iab',\n            'stage iiia',\n            'stage iiib',\n            'stage iva',\n            'stage ivb'\n          ];\n          break;\n        case 'binet staging system':\n          codeList = [\n             'stage a',\n             'stage b',\n             'stage c'\n         ];\n          break;\n        case 'ajcc 8th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ia3','stage ib','stage ib1','stage ib2','stage ic','stage ie','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iie','stage iii','stage iiia','stage iiia1','stage iiia2','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iiid','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'];\n          break;\n        case 'ajcc 7th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ib','stage ib1','stage ib2','stage ic','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iii','stage iiia','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'\n];\n          break;\n        default:\n          codelist = [];\n      }\n\n      if (!codeList.includes($field.trim().toLowerCase()) && codeList.length) {\n        const msg = `'${$field}' is not a permissible value. When 'posttherapy_tumour_staging_system' is set to '${\n          $row.posttherapy_tumour_staging_system\n        }', 'posttherapy_stage_group' must be one of the following: \\n${codeList\n          .map(code => `- \"${code}\"`)\n          .join('\\n')}`;\n\n        result.valid = false;\n        result.message = msg;\n      }\n    }\n    return result;\n  })"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "family_history",
-          "description": "The collection of data elements describing a donors familial relationships and familial cancer history.",
-          "meta": {
-            "parent": "donor"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "description": "Unique identifier of the relative, assigned by the data provider.",
-              "name": "family_relative_id",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Family Relative ID",
-                "notes": "This field is required to ensure that family members are identified in unique records.  Ids can be as simple as an incremented numeral to ensure uniqueness."
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "description": "Indicate if patient has any genetic relatives with a history of cancer. (Reference: NCIt C159104, caDSR CDE ID 6161023)",
-              "name": "relative_with_cancer_history",
-              "restrictions": {
-                "codeList": ["Yes", "No", "Unknown"]
-              },
-              "valueType": "string",
-              "meta": {
-                "displayName": "Relative with Cancer History"
-              }
-            },
-            {
-              "description": "Indicate genetic relationship of the relative to patient. (Reference: caDSR CDE ID 2179937)",
-              "name": "relationship_type",
-              "restrictions": {
-                "codeList": [
-                  "Aunt",
-                  "Brother",
-                  "Cousin",
-                  "Daughter",
-                  "Father",
-                  "Grandchild",
-                  "Grandfather",
-                  "Grandmother",
-                  "Maternal Aunt",
-                  "Maternal Cousin",
-                  "Maternal Grandfather",
-                  "Maternal Grandmother",
-                  "Maternal Half-brother",
-                  "Maternal Half-sister",
-                  "Mother",
-                  "Nephew",
-                  "Niece",
-                  "Other",
-                  "Paternal Aunt",
-                  "Paternal Cousin",
-                  "Paternal Grandfather",
-                  "Paternal Grandmother",
-                  "Paternal Half-brother",
-                  "Paternal Half-sister",
-                  "Sister",
-                  "Son",
-                  "Unknown"
-                ]
-              },
-              "valueType": "string",
-              "meta": {
-                "displayName": "Relationship Type"
-              }
-            },
-            {
-              "description": "The self-reported gender of related individual.",
-              "name": "gender_of_relative",
-              "restrictions": {
-                "codeList": ["Female", "Male", "Other", "Unknown"]
-              },
-              "valueType": "string",
-              "meta": {
-                "displayName": "Gender of Relative"
-              }
-            },
-            {
-              "description": "The age (in years) when the patient's relative was first diagnosed. (Reference: caDSR CDE ID 5300571)",
-              "name": "age_of_relative_at_diagnosis",
-              "restrictions": {},
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Age Of Relative At Diagnosis"
-              }
-            },
-            {
-              "name": "cancer_type_code_of_relative",
-              "valueType": "string",
-              "description": "The code to describe the malignant diagnosis of the patient's relative with a history of cancer using the WHO ICD-10 code (https://icd.who.int/browse10/2019/en) classification.",
-              "restrictions": {
-                "regex": "^[C|D][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$"
-              },
-              "meta": {
-                "core": true,
-                "examples": "C41.1,C16.9,C00.5,D46.9",
-                "displayName": "Cancer Type Code (ICD-10) of Relative"
-              }
-            },
-            {
-              "description": "Indicate the cause of the death of the relative.",
-              "name": "cause_of_death_of_relative",
-              "restrictions": {
-                "codeList": ["Died of cancer", "Died of other reasons", "Unknown"]
-              },
-              "valueType": "string",
-              "meta": {
-                "core": true,
-                "displayName": "Cause of Death of Relative"
-              }
-            },
-            {
-              "description": "Indicate how long, in years, the relative survived from the time of diagnosis if the patient's relative died from the cancer they were diagnosed with.",
-              "name": "relative_survival_time",
-              "restrictions": {},
-              "valueType": "integer",
-              "meta": {
-                "displayName": "Survival Time Of Relative"
-              }
-            }
-          ]
-        },
-        {
-          "name": "exposure",
-          "description": "The collection of data elements related to a donor's clinically relevant information not immediately resulting from genetic predispositions.",
-          "meta": {
-            "parent": "donor"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "description": "Indicate the type(s) of tobacco used by donor. (Reference: NCIT)",
-              "name": "tobacco_type",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Tobacco Type",
-                "notes": "To include multiple values, separate values with a pipe delimiter '|' within your file."
-              },
-              "isArray": true,
-              "restrictions": {
-                "codeList": [
-                  "Chewing Tobacco",
-                  "Cigar",
-                  "Cigarettes",
-                  "Electronic cigarettes",
-                  "Roll-ups",
-                  "Snuff",
-                  "Unknown",
-                  "Waterpipe"
-                ]
-              }
-            },
-            {
-              "description": "Indicate donor's self-reported smoking status and history. (Reference: caDSR CDE ID 2181650)",
-              "name": "tobacco_smoking_status",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Tobacco Smoking Status",
-                "notes": "Current smoker: Has smoked 100 cigarettes in their lifetime and who currently smokes. Includes daily smokers and non-daily smokers (also known as occassional smokers). Current reformed smoker for >15 years: A person who currently does not smoke and has been a non-smoker for more than 15 years, but has smoked at least 100 cigarettes in their life. Current reformed smoker for <= 15 years: A person who currently does not smoke and has been a non-smoker for less than 15 years, but has smoked at least 100 cigarettes in their life. Current reformed smoker, duration not specified: A person who currently does not smoke and has been a non-smoker for unspecified time, but has smoked at least 100 cigarettes in their lifetime. Smoking history not documented: Smoking history has not be recorded or is unknown."
-              },
-              "restrictions": {
-                "codeList": [
-                  "Current reformed smoker for <= 15 years",
-                  "Current reformed smoker for > 15 years",
-                  "Current reformed smoker, duration not specified",
-                  "Current smoker",
-                  "Lifelong non-smoker (<100 cigarettes smoked in lifetime)",
-                  "Smoking history not documented"
-                ]
-              }
-            },
-            {
-              "description": "This field applies to cigarettes. Indicate the smoking intensity in Pack Years, where the number of pack years is defined as the number of cigarettes smoked per day times (x) the number of years smoked divided (/) by 20. (Reference: caDSR CDE ID 2955385)",
-              "name": "pack_years_smoked",
-              "valueType": "number",
-              "meta": {
-                "displayName": "Pack Years Smoked",
-                "notes": "Current smoker: Has smoked 100 cigarettes in their lifetime and who currently smokes. Includes daily smokers and non-daily smokers (also known as occassional smokers). Current reformed smoker for >15 years: A person who currently does not smoke and has been a non-smoker for more than 15 years, but has smoked at least 100 cigarettes in their life. Current reformed smoker for <= 15 years: A person who currently does not smoke and has been a non-smoker for less than 15 years, but has smoked at least 100 cigarettes in their life. Current reformed smoker, duration not specified: A person who currently does not smoke and has been a non-smoker for unspecified time, but has smoked at least 100 cigarettes in their lifetime. Smoking history not documented: Smoking history has not be recorded or is unknown."
-              },
-              "restrictions": {
-                "min": 0
-              }
-            },
-            {
-              "description": "Indicate if the donor has consumed at least 12 drinks of any alcoholic beverage in their lifetime. (Reference: caDSR CDE ID 2201918)",
-              "name": "alcohol_history",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Alcohol History"
-              },
-              "restrictions": {
-                "codeList": ["Yes", "No", "Unknown"]
-              }
-            },
-            {
-              "description": "Describe the donor's current level of alcohol use as self-reported by the donor. (Reference: caDSR CDE ID 3457767)",
-              "name": "alcohol_consumption_category",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Alcohol Consumption Category",
-                "notes": ""
-              },
-              "restrictions": {
-                "codeList": [
-                  "Daily Drinker",
-                  "None",
-                  "Not Documented",
-                  "Occasional Drinker (< once a month)",
-                  "Social Drinker (> once a month, < once a week)",
-                  "Weekly Drinker (>=1x a week)"
-                ]
-              }
-            },
-            {
-              "description": "Indicate the type(s) of alcohol the donor consumed. (Reference: NCIt CDE C173647)",
-              "name": "alcohol_type",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Alcohol Type",
-                "notes": "To include multiple values, separate values with a pipe delimiter '|' within your file."
-              },
-              "isArray": true,
-              "restrictions": {
-                "codeList": ["Beer", "Liquor", "Other", "Unknown", "Wine"]
-              }
-            },
-            {
-              "description": "Indicate if the donor has ever used opium or other opiates like opium juice, heroin, or Sukhteh regularly (at least weekly over a 6-month period).",
-              "name": "opiate_use",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Opiate Use"
-              },
-              "restrictions": {
-                "codeList": ["Never", "Unknown", "Yes, currently", "Yes, only in the past"]
-              }
-            },
-            {
-              "description": "Indicate if the donor regularly drinks tea, coffee, or other hot drinks.",
-              "name": "hot_drinks",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Hot Drink Consumption"
-              },
-              "restrictions": {
-                "codeList": ["Never", "Unknown", "Yes, currently", "Yes, only in the past"]
-              }
-            },
-            {
-              "description": "Indicate how frequently the donor eats red meat. Examples of red meat include beef, veal, pork, lamb, mutton, horse, or goat meat.",
-              "name": "red_meat",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Red Meat Consumption Frequency"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Never",
-                  "Less than once a month",
-                  "1-3 times a month",
-                  "Once or twice a week",
-                  "Most days but not every day",
-                  "Every day",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "description": "Indicate how frequently the patient eats processed meat. Examples of processed meat include hams, salamis, or sausages.",
-              "name": "processed_meat",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Processed Meat Consumption Frequency"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Never",
-                  "Less than once a month",
-                  "1-3 times a month",
-                  "Once or twice a week",
-                  "Most days but not every day",
-                  "Every day",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "description": "Indicate the frequency of soft drink consumption by the donor.",
-              "name": "soft_drinks",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Soft Drink Consumption Frequency"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Never",
-                  "Less than once a month",
-                  "1-3 times a month",
-                  "Once or twice a week",
-                  "Most days but not every day",
-                  "Every day",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "description": "Indicate how many times per week the donor exercises for at least 30 minutes. (Reference: NCIt CDE C25367)",
-              "name": "exercise_frequency",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Exercise Frequency"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Never",
-                  "Less than once a month",
-                  "1-3 times a month",
-                  "Once or twice a week",
-                  "Most days but not every day",
-                  "Every day",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "description": "Indicate the intensity of exercise. (Reference: NCIt CDE C25539)",
-              "name": "exercise_intensity",
-              "valueType": "string",
-              "meta": {
-                "displayName": "Exercise Intensity"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Low: No increase in the heart beat, and no perspiration",
-                  "Moderate: Increase in the heart beat slightly with some light perspiration",
-                  "Vigorous: Increase in the heart beat substantially with heavy perspiration"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "comorbidity",
-          "description": "The collection of data elements related to a donor's comorbidities. Comorbidities are any distinct entity that has existed or may occur during the clinical course of a patient who has the index disease under study. To submit multiple comorbidities for a single donor, submit multiple rows in the comorbidity file for this donor",
-          "meta": {
-            "parent": "donor"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "prior_malignancy",
-              "description": "Prior malignancy affecting donor.",
-              "restrictions": {
-                "codeList": ["Yes", "No", "Unknown"]
-              },
-              "valueType": "string",
-              "meta": {
-                "displayName": "Prior Malignancy"
-              }
-            },
-            {
-              "name": "laterality_of_prior_malignancy",
-              "description": "If donor has history of prior malignancy, indicate laterality of previous diagnosis. (Reference: caDSR CDE ID 4122391)",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Bilateral",
-                  "Left",
-                  "Midline",
-                  "Not applicable",
-                  "Right",
-                  "Unilateral, Side not specified",
-                  "Unknown"
-                ],
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n\n      const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n      \n      /* checks for a string just consisting of whitespace */\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      const invalidTypes = [\"no\", \"unknown\"]\n   \n      if ($name === \"laterality_of_prior_malignancy\") {\n         if (($row.prior_malignancy === null || invalidTypes.includes($row.prior_malignancy.trim().toLowerCase())) && (currField || (!(checkforEmpty(currField))!= null))) {\n            result = {\n               valid: false,\n               message: `The 'prior_malignancy' field should be submitted as 'Yes' if the '${$name}' field is submitted.`\n            };\n         }\n      }\n      return result;\n  })"
-                ]
-              },
-              "meta": {
-                "dependsOn": "comorbidity.prior_malignancy",
-                "displayName": "Laterality at Prior Malignancy"
-              }
-            },
-            {
-              "name": "age_at_comorbidity_diagnosis",
-              "valueType": "integer",
-              "description": "Indicate the age of comorbidity diagnosis, in years.",
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n\n      const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n      \n      /* checks for a string just consisting of whitespace */\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      const invalidTypes = [\"no\", \"unknown\"]\n      optionalFields = [\"age_at_comorbidity_diagnosis\", \"comorbidity_treatment_status\", \"comorbidity_treatment\"];\n   \n      if (optionalFields.includes($name) && (currField || (!(checkforEmpty(currField))))) {\n         if (($row.comorbidity_type_code === null || checkforEmpty($row.comorbidity_type_code))) {\n            result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_type_code' field is not submitted.`};\n         }\n         if ($name === \"comorbidity_treatment\" && currField && !(checkforEmpty(currField))) {\n            if ($row.comorbidity_treatment_status === null || checkforEmpty($row.comorbidity_treatment_status)) {\n               result = { valid: false, message: `The 'comorbidity_treatment_status' field should be submitted as 'Yes' if '${$name}' field is submitted.`};\n            }\n            else if (invalidTypes.includes($row.comorbidity_treatment_status.trim().toLowerCase())) {\n               result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_treatment_status' field is not 'Yes'.`};\n            }\n         }\n     }\n     return result;\n  })"
-                ],
-                "range": {
-                  "exclusiveMin": 0
-                }
-              },
-              "meta": {
-                "units": "years",
-                "dependsOn": "comorbidity.comorbidity_type_code",
-                "displayName": "Age at Comorbidity Diagnosis"
-              }
-            },
-            {
-              "name": "comorbidity_type_code",
-              "valueType": "string",
-              "description": "Indicate the code for the comorbidity using the WHO ICD-10 code classification (https://icd.who.int/browse10/2019/en).",
-              "restrictions": {
-                "required": true,
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n      const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n      \n      /* checks for a string just consisting of whitespace */\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      const invalidTypes = [\"no\", \"unknown\"]\n      /* check if ICD-10 code is for neoplasms */\n      const neoplasmCode = (entry) => {return /^[c|d][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$/.test(decodeURI(entry))};\n\n      if (currField || (!(checkforEmpty(currField)))) {\n         if ($row.prior_malignancy === \"yes\" && (!(neoplasmCode(currField)))) {\n            result = { valid: false, message: `The ICD-10 code submitted in the '${$name}' field must be a code for cancer if 'prior_malignancy' is 'Yes'.`}\n         }\n         else if (($row.prior_malignancy === null || invalidTypes.includes($row.prior_malignancy.trim().toLowerCase())) && neoplasmCode(currField)) {\n            result = {valid: false, message: `If an ICD-10 code for cancer is submitted in the '${$name}' field, then 'prior_malignancy' should be submitted as 'Yes'.`}\n         }\n      }\n      else if (checkforEmpty(currField)) {\n         if ($row.prior_malignancy === \"yes\") { \n            result = {valid: false, message: `The 'comorbidity_type_code' field is required if '${$name}' field is 'Yes'.`}\n         }\n         else if ($row.prior_malignancy === null || checkforEmpty($row.prior_malignancy)) {\n            result = {valid: false, message: `The 'comorbidity_type_code' field is required.`}\n         }\n      }\n      return result;\n  })"
-                ],
-                "regex": "^[A-Z][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$"
-              },
-              "meta": {
-                "primaryId": true,
-                "dependsOn": "comorbidity.prior_malignancy",
-                "examples": "E10, C50.1, I11, M06",
-                "displayName": "Comorbidity Type Code"
-              }
-            },
-            {
-              "name": "comorbidity_treatment_status",
-              "valueType": "string",
-              "description": "Indicate if the patient is being treated for the comorbidity (this includes prior malignancies).",
-              "restrictions": {
-                "codeList": ["Yes", "No", "Unknown"],
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n\n      const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n      \n      /* checks for a string just consisting of whitespace */\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      const invalidTypes = [\"no\", \"unknown\"]\n      optionalFields = [\"age_at_comorbidity_diagnosis\", \"comorbidity_treatment_status\", \"comorbidity_treatment\"];\n   \n      if (optionalFields.includes($name) && (currField || (!(checkforEmpty(currField))))) {\n         if (($row.comorbidity_type_code === null || checkforEmpty($row.comorbidity_type_code))) {\n            result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_type_code' field is not submitted.`};\n         }\n         if ($name === \"comorbidity_treatment\" && currField && !(checkforEmpty(currField))) {\n            if ($row.comorbidity_treatment_status === null || checkforEmpty($row.comorbidity_treatment_status)) {\n               result = { valid: false, message: `The 'comorbidity_treatment_status' field should be submitted as 'Yes' if '${$name}' field is submitted.`};\n            }\n            else if (invalidTypes.includes($row.comorbidity_treatment_status.trim().toLowerCase())) {\n               result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_treatment_status' field is not 'Yes'.`};\n            }\n         }\n     }\n     return result;\n  })"
-                ]
-              },
-              "meta": {
-                "dependsOn": "comorbidity.comorbidity_type_code",
-                "displayName": "Comorbidity Treatment"
-              }
-            },
-            {
-              "name": "comorbidity_treatment",
-              "valueType": "string",
-              "description": "Indicate treatment details for the comorbidity (this includes prior malignancies).",
-              "restrictions": {
-                "script": [
-                  "(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n\n      const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n      \n      /* checks for a string just consisting of whitespace */\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      const invalidTypes = [\"no\", \"unknown\"]\n      optionalFields = [\"age_at_comorbidity_diagnosis\", \"comorbidity_treatment_status\", \"comorbidity_treatment\"];\n   \n      if (optionalFields.includes($name) && (currField || (!(checkforEmpty(currField))))) {\n         if (($row.comorbidity_type_code === null || checkforEmpty($row.comorbidity_type_code))) {\n            result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_type_code' field is not submitted.`};\n         }\n         if ($name === \"comorbidity_treatment\" && currField && !(checkforEmpty(currField))) {\n            if ($row.comorbidity_treatment_status === null || checkforEmpty($row.comorbidity_treatment_status)) {\n               result = { valid: false, message: `The 'comorbidity_treatment_status' field should be submitted as 'Yes' if '${$name}' field is submitted.`};\n            }\n            else if (invalidTypes.includes($row.comorbidity_treatment_status.trim().toLowerCase())) {\n               result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_treatment_status' field is not 'Yes'.`};\n            }\n         }\n     }\n     return result;\n  })"
-                ]
-              },
-              "meta": {
-                "dependsOn": "comorbidity.comorbidity_treatment_status",
-                "displayName": "Comorbidity Treatment Type"
-              }
-            }
-          ]
-        },
-        {
-          "name": "biomarker",
-          "description": "The collection of data elements describing a donor's biomarker tests. A biomarker is a biological molecule found in blood, other body fluids, or tissues that is indicative of the presence of cancer in the body. Each row should include biomarker tests associated with a particular clinical event or time interval.",
-          "meta": {
-            "parent": "donor"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "name": "submitter_donor_id",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_specimen_id",
-              "description": "Unique identifier of the specimen, assigned by the data provider.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_specimen_id",
-                "displayName": "Submitter Specimen ID"
-              },
-              "restrictions": {
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_primary_diagnosis_id",
-              "valueType": "string",
-              "description": "If the biomarker test was done at the time of primary diagnosis, then indicate the associated submitter_primary_diagnosis_id here.",
-              "meta": {
-                "displayName": "Submitter Primary Diagnosis ID",
-                "primaryId": true
-              },
-              "restrictions": {
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_treatment_id",
-              "valueType": "string",
-              "description": "If the biomarker test was done at the initiation of a specific treatment regimen, indicate the associated submitter_treatment_id here.",
-              "meta": {
-                "primaryId": true,
-                "displayName": "Submitter Treatment ID"
-              },
-              "restrictions": {
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "description": "If the biomarker test was done during a follow-up event, then indicate the associated submitter_follow_up_id here.",
-              "name": "submitter_follow_up_id",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "displayName": "Submitter Follow-Up ID"
-              },
-              "restrictions": {
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "description": "If the biomarker test was not associated with a specific follow-up, primary diagnosis or treatment event, then indicate the interval of time since primary diagnosis that the biomarker test was performced at, in days.",
-              "name": "test_interval",
-              "valueType": "integer",
-              "restrictions": {
-                "range": {
-                  "exclusiveMin": 0
-                }
-              },
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "units": "days",
-                "displayName": "Interval Of Test",
-                "notes": "This field is required if the biomarker test is not associated with a primary diagnosis, treatment or follow-up event. The associated primary diagnosis is used as the reference point for this interval. To calculate this, find the number of days since the date of primary diagnosis."
-              }
-            },
-            {
-              "description": "Indicate the level of carbohydrate antigen 19-9 (CA19-9). Carbohydrate antigen 19-9 testing is useful to monitor the response to treatment in pancreatic cancer patients. (Reference: LOINC: 24108-3)",
-              "name": "ca19-9_level",
-              "valueType": "integer",
-              "restrictions": {
-                "range": {
-                  "exclusiveMin": 0
-                }
-              },
-              "meta": {
-                "displayName": "CA19-9 Level"
-              }
-            },
-            {
-              "description": "Indicate the quantitative measurement of the amount of C-reactive protein (CRP), an inflammatory marker, in the blood in mg/L. (Reference: NCIt C64548)",
-              "name": "crp_levels",
-              "valueType": "integer",
-              "restrictions": {
-                "range": {
-                  "exclusiveMin": 0
-                }
-              },
-              "meta": {
-                "displayName": "C-reactive protein (CRP) Level"
-              }
-            },
-            {
-              "description": "Indicate the level of lactate dehydrogenase (LDH), in IU/L.",
-              "name": "ldl_level",
-              "valueType": "integer",
-              "restrictions": {
-                "range": {
-                  "exclusiveMin": 0
-                }
-              },
-              "meta": {
-                "displayName": "Lactate Dehydrogenase (LDH) Level"
-              }
-            },
-            {
-              "description": "Indicate the value for a hemotology laboratory test for the absolute number of neutrophil cells (ANC) present in a sample of peripheral blood from a donor, in cells/uL. (Reference: caDSR CDE ID 2180198)",
-              "name": "anc",
-              "valueType": "integer",
-              "restrictions": {
-                "range": {
-                  "exclusiveMin": 0
-                }
-              },
-              "meta": {
-                "displayName": "Absolute Neutrophil Count (ANC)"
-              }
-            },
-            {
-              "description": "Indicate the absolute number of lymphocytes (ALC) found in a given volume of blood, as cells/uL. (Reference: NCIt: C113237)",
-              "name": "alc",
-              "valueType": "integer",
-              "restrictions": {
-                "range": {
-                  "exclusiveMin": 0
-                }
-              },
-              "meta": {
-                "displayName": "Absolute Lymphocyte Count (ALC)"
-              }
-            },
-            {
-              "description": "Indicate whether donor is a carrier of a mutation in a BRCA gene.",
-              "name": "brca_carrier",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "BRCA1",
-                  "BRCA2",
-                  "Both BRCA1 and BRCA2",
-                  "No",
-                  "Not applicable",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "BRCA Carrier"
-              }
-            },
-            {
-              "description": "Indicate the expression of estrogen receptor (ER). (Reference: NAACCR 3827)",
-              "name": "er_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "Estrogen Receptor Status"
-              }
-            },
-            {
-              "description": "Indicate the Allred score. The Allred score is based on the percentage of cells that stain positive by immunohistochemistry (IHC) for estrogen receptor (ER) and the intensity of that staining. (Reference: NAACCR: 3828, caDSR CDE ID 2725288)",
-              "name": "er_allred_score",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Total ER Allred score of 1",
-                  "Total ER Allred score of 2",
-                  "Total ER Allred score of 3",
-                  "Total ER Allred score of 4",
-                  "Total ER Allred score of 5",
-                  "Total ER Allred score of 6",
-                  "Total ER Allred score of 7",
-                  "Total ER Allred score of 8",
-                  "Not applicable",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "Estrogen Receptor Allred Score"
-              }
-            },
-            {
-              "description": "Indicate the expression of human epidermal growth factor receptor-2 (HER2) assessed by immunohistochemistry (IHC). (Reference: AJCC 8th Edition, Chapter 48)",
-              "name": "her2_ihc_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Equivocal",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "HER2 IHC Status",
-                "notes": "Negative: 0 or 1+ staining, Equivocal: 2+ staining, Positive: 3+ staining"
-              }
-            },
-            {
-              "description": "Indicate the expression of human epidermal growth factor receptor-2 (HER2) assessed by in situ hybridization (ISH). (Reference: NAACCR: 3854)",
-              "name": "her2_ish_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Equivocal",
-                  "Positive",
-                  "Negative",
-                  "Not applicable",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "HER2 ISH Status"
-              }
-            },
-            {
-              "description": "Indicate the expression of progestrone receptor (PR). (Reference: NAACCR 3915)",
-              "name": "pr_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "Progesterone Receptor Status"
-              }
-            },
-            {
-              "description": "Indicate the Allred score. The Allred score is based on the percentage of cells that stain positive by IHC for the progesterone receptor (PR) and the intensity of that staining. (Reference: NAACCR: 3916)",
-              "name": "pr_allred_score",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Total PR Allred score of 1",
-                  "Total PR Allred score of 2",
-                  "Total PR Allred score of 3",
-                  "Total PR Allred score of 4",
-                  "Total PR Allred score of 5",
-                  "Total PR Allred score of 6",
-                  "Total PR Allred score of 7",
-                  "Total PR Allred score of 8",
-                  "Not applicable",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "Progesterone Receptor Allred Score"
-              }
-            },
-            {
-              "description": "Indicate the immunohistochemical test result that refers to the overexpression or lack of expression of programmed death ligand 1 (PD-L1) in a tissue sample of a primary or metastatic malignant neoplasm. (Reference NCIt: C122807)",
-              "name": "pd-l1_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "PD-L1 Status"
-              }
-            },
-            {
-              "description": "Indicate the expression of anaplastic lymphoma receptor tyrosine kinase (ALK) as assessed by immunohistochemistry (IHC).",
-              "name": "alk_ihc_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "ALK IHC Status"
-              }
-            },
-            {
-              "description": "Indicate the intensity of anaplastic lymphoma receptor tyrosine kinase (ALK) as assessed by immunohistochemistry (IHC).",
-              "name": "alk_ihc_intensity",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": ["0 (No stain)", "+1", "+2", "+3"]
-              },
-              "meta": {
-                "displayName": "ALK IHC Intensity"
-              }
-            },
-            {
-              "description": "Indicate the expression of anaplastic lymphoma receptor tyrosine kinase (ALK) as assessed by flurescence in situ hybridization (FISH).",
-              "name": "alk_fish_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "ALK FISH Status"
-              }
-            },
-            {
-              "description": "Indicate the expression of receptor lymphoma kinase (ROS1) as assessed by immunohistochemistry (IHC).",
-              "name": "ros1_ihc_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "ROS1 IHC Status"
-              }
-            },
-            {
-              "description": "Indicate the expression of Pan-TRK as assessed by immunohistochemistry (IHC).",
-              "name": "pan-trk_ihc_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "Pan-TRK IHC Status"
-              }
-            },
-            {
-              "description": "Indicate the expression of gene arrangement involving the RET proto-oncogene (RET1) as assessed by fluoresence in situ hybridization (FISH). RET gene rearrangements are associated with several different neoplastic conditions. (Reference: NCIt C46005)",
-              "name": "ret_fish_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "RET1 FISH Status"
-              }
-            },
-            {
-              "description": "Indicate the expression of tropomyosin receptor kinase (TRK) as assessed by immunohistochemistry (IHC).",
-              "name": "trk_ihc_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "TRK IHC Status"
-              }
-            },
-            {
-              "description": "Indicate the expression of Human papillomavirus (HPV) p16 as assessed by immunohistochemistry (IHC).",
-              "name": "hpv_ihc_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "HPV IHC Status"
-              }
-            },
-            {
-              "description": "Indicate the expression of Human papillomavirus (HPV) as assessed using a laboratory test in which cells are scraped from the cervix to look for DNA of HPV. (Reference: NCIt C93141)",
-              "name": "hpv_dna_status",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": [
-                  "Cannot be determined",
-                  "Negative",
-                  "Not applicable",
-                  "Positive",
-                  "Unknown"
-                ]
-              },
-              "meta": {
-                "displayName": "HPV DNA Status"
-              }
-            }
-          ]
-        },
-        {
-          "name": "surgery",
-          "description": "The collection of data elements related to a donor's surgical treatment at a specific point in the clinical record. To submit multiple surgeries for a single donor, please submit multiple rows in the treatment file for this donor.",
-          "meta": {
-            "parent": "donor"
-          },
-          "fields": [
-            {
-              "name": "program_id",
-              "valueType": "string",
-              "description": "Unique identifier of the ARGO program.",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.program_id",
-                "displayName": "Program ID"
-              },
-              "restrictions": {
-                "required": true
-              }
-            },
-            {
-              "name": "submitter_donor_id",
-              "description": "Unique identifier of the donor, assigned by the data provider.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "foreignKey": "sample_registration.submitter_donor_id",
-                "displayName": "Submitter Donor ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "submitter_treatment_id",
-              "description": "Unique identifier of the treatment, assigned by the data provider.",
-              "valueType": "string",
-              "meta": {
-                "validationDependency": true,
-                "primaryId": true,
-                "displayName": "Submitter Treatment ID"
-              },
-              "restrictions": {
-                "required": true,
-                "regex": "^[A-Za-z0-9\\-\\._]{1,64}"
-              }
-            },
-            {
-              "name": "procedure_type",
-              "valueType": "string",
-              "description": "Indicate they type of surgical procedure that was performed.",
-              "meta": {
-                "displayName": "Procedure Type "
-              },
-              "restrictions": {
-                "codeList": [
-                  "Biopsy",
-                  "Breast-conserving surgery (BCN)",
-                  "Bypass procedure / Jejunostomy only",
-                  "Cholecystojejunostomy",
-                  "Choledochojejunostomy",
-                  "Classic Whipple",
-                  "Distal Pancreatectomy",
-                  "Gastrectomy: Completion",
-                  "Gastrectomy: Distal",
-                  "Gastrectomy: Extended Total",
-                  "Gastrectomy: Merendino",
-                  "Gastrectomy: Proximal",
-                  "Gastrectomy: Total",
-                  "Gastrojejunostomy",
-                  "Hepaticojejunostomy",
-                  "Jejunostomy",
-                  "Laparotomy",
-                  "Laparotomy (Open and Shut)",
-                  "Lobectomy",
-                  "Lumpectomy",
-                  "Lymph node dissection performed at time of resection of primary",
-                  "Lymph node surgery",
-                  "Mastectomy",
-                  "Minimally Invasive Oesophagectomy",
-                  "Morcellation",
-                  "Oesophagectomy: 2 – Phase (Ivor-Lewis)",
-                  "Oesophagectomy: 3 – Phase (McKeown)",
-                  "Oesophagectomy: Left thoraco-abdominal approach",
-                  "Oesophagectomy: Transhiatal",
-                  "Omentectomy",
-                  "Other",
-                  "Partial Resection",
-                  "Pneumonectomy",
-                  "Prophylactic mastectomy",
-                  "Pylorus Whipple",
-                  "Radical Whipple",
-                  "Sleeve Resection",
-                  "Stent",
-                  "Subtotal Pancreatectomy",
-                  "Surgical resection",
-                  "Thoracotomy (Open & Shut)",
-                  "Total Pancreatectomy",
-                  "Wedge resection (Segmentectomy)",
-                  "Wedge/localised gastric resection"
-                ]
-              }
-            },
-            {
-              "name": "biopsy_type",
-              "valueType": "string",
-              "description": "If Biopsy was selected as the `procedure_type', indicate the type of biopsy that was performed.",
-              "meta": {
-                "displayName": "Biopsy Type",
-                "dependsOn": "surgery.procedure_type"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Biopsy",
-                  "Endoscopic biopsy",
-                  "Endoscopic brushing ",
-                  "Fine Need Aspiration (FNA) ",
-                  "NOS",
-                  "Open/Surgical biopsy ",
-                  "Other",
-                  "Percutaneous",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "name": "procedure_intent",
-              "description": "Indicate the intended disease outcome for which the procedure is given. (Reference: NCIt C124307)",
-              "valueType": "string",
-              "restrictions": {
-                "codeList": ["Exploratory", "Curative", "Palliative", "Other", "Staging", "Unknown"]
-              },
-              "meta": {
-                "displayName": "Procedure  Intent"
-              }
-            },
-            {
-              "name": "procedure_interval",
-              "valueType": "integer",
-              "description": "The interval between primary diagnosis and when the surgical procedure was performed, in days.",
-              "meta": {
-                "displayName": "Procedure Interval"
-              },
-              "restrictions": {
-                "range": {
-                  "exclusiveMin": 0
-                }
-              }
-            },
-            {
-              "name": "procedure_site",
-              "valueType": "string",
-              "description": "Indicate the ICD-O-3 topography code for the anatomic site where procedure was performed, according to the International Classification of Diseases for Oncology, 3rd Edition (WHO ICD-O-3).",
-              "meta": {
-                "displayName": "Procedure Site",
-                "notes": "Refer to the ICD-O-3 manual for guidelines at https://apps.who.int/iris/handle/10665/42344."
-              },
-              "restrictions": {
-                "regex": "^[C][0-9]{2}(.[0-9]{1})?$"
-              }
-            },
-            {
-              "name": "procedure_site_other",
-              "valueType": "string",
-              "description": "Free text to indicate additional details about the procedure site.",
-              "meta": {
-                "displayName": "Procedure Site Details"
-              },
-              "restrictions": {}
-            },
-            {
-              "name": "procedure_location",
-              "valueType": "string",
-              "description": "Indicate whether procedure was done on primary, local recurrence or metastatic location.",
-              "meta": {
-                "displayName": "Procedure Location"
-              },
-              "restrictions": {
-                "codeList": ["Local recurrence", "Metastatic", "Primary"]
-              }
-            },
-            {
-              "name": "tumour_size_status",
-              "valueType": "string",
-              "description": "Indicate if tumour size was determined during the procedure.",
-              "meta": {
-                "displayName": "Tumour Size Status"
-              },
-              "restrictions": {
-                "codeList": ["Yes", "No", "Not Reported", "Not Applicable", "Unknown"]
-              }
-            },
-            {
-              "name": "tumour_length",
-              "valueType": "number",
-              "description": "Indicate the length of the tumour, in mm.",
-              "meta": {
-                "displayName": "Tumour Length"
-              },
-              "restrictions": {
-                "range": {
-                  "exclusiveMin": 0
-                }
-              }
-            },
-            {
-              "name": "tumour_width",
-              "valueType": "number",
-              "description": "Indicate the width of the tumour, in mm.",
-              "meta": {
-                "displayName": "Tumour Width"
-              },
-              "restrictions": {
-                "range": {
-                  "exclusiveMin": 0
-                }
-              }
-            },
-            {
-              "name": "total_tumour_size",
-              "valueType": "number",
-              "description": "Indicate the total tumour size, in mm.",
-              "meta": {
-                "displayName": "Total Tumour Size"
-              },
-              "restrictions": {
-                "range": {
-                  "exclusiveMin": 0
-                }
-              }
-            },
-            {
-              "name": "tumour_focality",
-              "valueType": "string",
-              "description": "Indicate the tumour focality, the definition of the limitaion to a specific area of a tumour. ",
-              "meta": {
-                "displayName": "Tumour Focality"
-              },
-              "restrictions": {
-                "codeList": ["Cannot be assessed", "Multifocal", "Unifocal"]
-              }
-            },
-            {
-              "name": "margin_status",
-              "valueType": "string",
-              "description": "Indicate if intraoperative margins were involved.",
-              "meta": {
-                "displayName": "Margin Status"
-              },
-              "restrictions": {
-                "codeList": ["Negative", "Other", "Positive", "Suspicious for cancer", "Unknown"]
-              }
-            },
-            {
-              "name": "proximal_margin",
-              "valueType": "string",
-              "description": "Indicate if proximal margin is involved.",
-              "meta": {
-                "displayName": "Proximal Margin"
-              },
-              "restrictions": {
-                "codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
-              }
-            },
-            {
-              "name": "distal_margin",
-              "valueType": "string",
-              "description": "Indicate if distal margin is involved.",
-              "meta": {
-                "displayName": "Distal Margin"
-              },
-              "restrictions": {
-                "codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
-              }
-            },
-            {
-              "name": "circumferential_resection_margin",
-              "valueType": "string",
-              "description": "Indicate if circumferential margin is involved.",
-              "meta": {
-                "displayName": "Circumferential Resection Margin"
-              },
-              "restrictions": {
-                "codeList": ["Yes", "No", "Not Reported"]
-              }
-            },
-            {
-              "name": "lymphovascular_invasion",
-              "valueType": "string",
-              "description": "Indicate whether lymphovascular invasion (LVI) has occurred.",
-              "meta": {
-                "displayName": "Lymphovascular Invasion (LVI)"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Not present",
-                  "Present",
-                  "Lymphatic and small vessel invasion only",
-                  "Venous (large vessel) invasion only",
-                  "Both lymphatic and small vessel and venous (large vessel) invasion",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "name": "perineural_invasion",
-              "valueType": "string",
-              "description": "Indicate whether perineural invasion has occurred.",
-              "meta": {
-                "displayName": "Perineural Invasion"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Absent or not identified",
-                  "Cannot be assessed",
-                  "Present or identified",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "name": "microvenous_invasion",
-              "valueType": "string",
-              "description": "Indicate whether microvenous invasion has occurred.",
-              "meta": {
-                "displayName": "Microvenous Invasion"
-              },
-              "restrictions": {
-                "codeList": ["Indeterminate", "No", "Yes", "Unknown"]
-              }
-            },
-            {
-              "name": "intraoperative_findings",
-              "valueType": "string",
-              "description": "Indicate other additional intraoperative findings.",
-              "meta": {
-                "displayName": "Intraoperative Findings"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Ascites",
-                  "Borderline resectable",
-                  "Coeliac axis involvement",
-                  "Metastasis to distant lymph nodes",
-                  "Metastasis to other sites",
-                  "None",
-                  "Peritoneal dissemination",
-                  "Resectable",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "name": "common_bile_duct_margin",
-              "valueType": "string",
-              "description": "Indicate if common bile duct margin is involved.",
-              "meta": {
-                "displayName": "Common Bile Duct Margin"
-              },
-              "restrictions": {
-                "codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
-              }
-            },
-            {
-              "name": "unicinate_margin",
-              "valueType": "string",
-              "description": "Indicate if unicinate margin (retroperitoneal/superior mesenteric artery) is involved.",
-              "meta": {
-                "displayName": "Unicinate Margin"
-              },
-              "restrictions": {
-                "codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
-              }
-            },
-            {
-              "name": "periuncinate_margin",
-              "valueType": "string",
-              "description": "Indicate if periuncinate margin is involved.",
-              "meta": {
-                "displayName": "Periuncinate Margin"
-              },
-              "restrictions": {
-                "codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
-              }
-            },
-            {
-              "name": "pancreatic_carcinoma_groove_margin",
-              "valueType": "string",
-              "description": "Indicate if pancreatic carcinoma groove margin is involved.",
-              "meta": {
-                "displayName": "Pancreatic Carcinoma Groove Margin"
-              },
-              "restrictions": {
-                "codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
-              }
-            },
-            {
-              "name": "state_of_pv_smv",
-              "valueType": "string",
-              "description": "Indicate the state of portal vein and/or superior mesenteric vein.",
-              "meta": {
-                "displayName": "State of Portal/Superior Mesenteric Vein"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Abutment (<180 degree contact)",
-                  "Encasement",
-                  "Indeterminate",
-                  "No involvement",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "name": "state_of_pma",
-              "valueType": "string",
-              "description": "Indicate the state of superior mesenteric artery.",
-              "meta": {
-                "displayName": "State of Superior Mesenteric Artery"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Abutment (<180 degree contact)",
-                  "Encasement",
-                  "Indeterminate",
-                  "No involvement",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "name": "state_of_duodenal",
-              "valueType": "string",
-              "description": "Indicate the state of duodenal involvement.",
-              "meta": {
-                "displayName": "State of Duodenal Involvement"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Abutment (<180 degree contact)",
-                  "Encasement",
-                  "Indeterminate",
-                  "No involvement",
-                  "Unknown"
-                ]
-              }
-            },
-            {
-              "name": "state_of_common_bile_duct",
-              "valueType": "string",
-              "description": "Indicate the state of common bile duct involvement",
-              "meta": {
-                "displayName": "State of Common Bile Duct Involvement"
-              },
-              "restrictions": {
-                "codeList": [
-                  "Abutment (<180 degree contact)",
-                  "Encasement",
-                  "Indeterminate",
-                  "No involvement",
-                  "Unknown"
-                ]
-              }
-            }
-          ]
-        }
-      ],
-      "name": "ARGO Clinical Submission",
-      "version": "1.0"
-    }
-  ]
+	"dictionaries": [
+		{
+			"schemas": [
+				{
+					"name": "sample_registration",
+					"description": "The collection of data elements required to register the required Donor-Specimen-Sample data to the ARGO Data Platform. Registration of samples is required before molecular and clinical data submission can proceed.",
+					"restrictions": {},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"examples": "TEST-CA",
+								"notes": "This is the unique id that is assigned to your program.  If you have logged into the platform, this is the Program Id that you see in the Program Services area. For example, TEST-CA is a Program ID.",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"examples": "90234,BLD_donor_89,AML-90",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "gender",
+							"valueType": "string",
+							"description": "Description of the donor self-reported gender. Gender is described as the assemblage of properties that distinguish people on the basis of their societal roles.",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"displayName": "Gender"
+							},
+							"restrictions": {
+								"required": true,
+								"codeList": ["Female", "Male", "Other"]
+							}
+						},
+						{
+							"name": "submitter_specimen_id",
+							"valueType": "string",
+							"description": "Unique identifier of the specimen, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"examples": "LAML_PO,00445,THY_099-tumour",
+								"displayName": "Submitter Specimen ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "specimen_tissue_source",
+							"valueType": "string",
+							"description": "Tissue source of the biospecimen.",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"displayName": "Specimen Tissue Source"
+							},
+							"restrictions": {
+								"required": true,
+								"codeList": [
+									"Blood derived - bone marrow",
+									"Blood derived - peripheral blood",
+									"Blood derived",
+									"Bone marrow",
+									"Bone",
+									"Buccal cell",
+									"Buffy coat",
+									"Cerebellum",
+									"Cerebrospinal fluid",
+									"Endometrium",
+									"Esophagus",
+									"Intestine",
+									"Lymph node",
+									"Mononuclear cells from bone marrow",
+									"Other",
+									"Plasma",
+									"Pleural effusion",
+									"Saliva",
+									"Serum",
+									"Skin",
+									"Solid tissue",
+									"Spleen",
+									"Sputum",
+									"Stomach",
+									"Tonsil",
+									"Urine"
+								]
+							}
+						},
+						{
+							"name": "tumour_normal_designation",
+							"valueType": "string",
+							"description": "Description of specimens tumour/normal status for data processing.",
+							"restrictions": {
+								"required": true,
+								"codeList": ["Normal", "Tumour"]
+							},
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"displayName": "Tumour Normal Designation"
+							}
+						},
+						{
+							"name": "specimen_type",
+							"valueType": "string",
+							"description": "Description of the kind of specimen that was collected with respect to tumour/normal tissue origin.",
+							"restrictions": {
+								"required": true,
+								"codeList": [
+									"Cell line - derived from normal",
+									"Cell line - derived from tumour",
+									"Cell line - derived from xenograft tumour",
+									"Metastatic tumour - additional metastatic",
+									"Metastatic tumour - metastasis local to lymph node",
+									"Metastatic tumour - metastasis to distant location",
+									"Metastatic tumour",
+									"Normal - tissue adjacent to primary tumour",
+									"Normal",
+									"Primary tumour - additional new primary",
+									"Primary tumour - adjacent to normal",
+									"Primary tumour",
+									"Recurrent tumour",
+									"Xenograft - derived from primary tumour",
+									"Xenograft - derived from tumour cell line"
+								],
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      const row = $row;\n      let result = {valid: true, message: \"Ok\"};\n      \n      const designation = row.tumour_normal_designation.trim().toLowerCase();\n      const specimen_type = $field.trim().toLowerCase();\n      \n      if (designation === \"normal\"){\n          const validTypes = [\"normal\", \"normal - tissue adjacent to primary tumour\", \"cell line - derived from normal\"];\n          if (!validTypes.includes(specimen_type)){\n              result = {valid: false, message: \"Invalid specimen_type. Specimen_type can only be set to a normal type value (Normal, Normal - tissue adjacent to primary tumour, or Cell line - derived from normal) when tumour_normal_designation is set to Normal.\"};\n          }\n      }\n      else if (designation === \"tumour\") {\n          const invalidTypes = [\"normal\", \"cell line - derived from normal\"];\n          if (invalidTypes.includes(specimen_type)){\n              result = {valid: false, message: \"Invalid specimen_type. Specimen_type cannot be set to normal type value (Normal or Cell line - derived from normal) when tumour_normal_designation is set to Tumour.\"};\n          }\n      }\n      return result;\n    })"
+								]
+							},
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"displayName": "Specimen Type"
+							}
+						},
+						{
+							"name": "submitter_sample_id",
+							"valueType": "string",
+							"description": "Unique identifier of the sample, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"examples": "hnc_12,CCG_34_94583,BRCA47832-3239",
+								"displayName": "Submitter Sample ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "sample_type",
+							"valueType": "string",
+							"description": "Description of the type of molecular sample used for testing.",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"displayName": "Sample Type"
+							},
+							"restrictions": {
+								"required": true,
+								"codeList": [
+									"Amplified DNA",
+									"ctDNA",
+									"Other DNA enrichments",
+									"Other RNA fractions",
+									"polyA+ RNA",
+									"Ribo-Zero RNA",
+									"Total DNA",
+									"Total RNA"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "donor",
+					"description": "The collection of data elements related to a specific donor in an ARGO program.",
+					"meta": {
+						"parent": "specimen"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"description": "Donor's last known state of living or deceased.",
+							"name": "vital_status",
+							"restrictions": {
+								"codeList": ["Alive", "Deceased", "Unknown"],
+								"required": true
+							},
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"displayName": "Vital Status"
+							}
+						},
+						{
+							"description": "Indicate the cause of a donor's death.",
+							"name": "cause_of_death",
+							"restrictions": {
+								"codeList": ["Died of cancer", "Died of other reasons", "Unknown"],
+								"script": [
+									"(function validate(inputs) {\n        const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n        const vitalStatus = $row.vital_status.trim().toLowerCase();\n    \n        if (!currField && vitalStatus === \"deceased\"){\n            result = {valid: false, message: `${$name} must be provided when the donor's vital_status is deceased.`}\n        }\n        else if (currField && vitalStatus != \"deceased\"){\n            result = {valid: false, message: `${$name} cannot be provided if the donor's vital_status is not deceased.`}\n        }\n        return result;\n    })"
+								]
+							},
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "donor.vital_status",
+								"notes": "Cause of death is only required to be submitted if the donor's vital_status is Deceased.",
+								"displayName": "Cause of Death"
+							}
+						},
+						{
+							"description": "Interval of how long the donor has survived since primary diagnosis, in days.",
+							"name": "survival_time",
+							"valueType": "integer",
+							"meta": {
+								"dependsOn": "donor.vital_status",
+								"notes": "Survival_time is only required to be submitted if the donor's vital_status is Deceased.",
+								"validationDependency": true,
+								"units": "days",
+								"core": "true",
+								"displayName": "Survival Time"
+							},
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n        const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n        const vitalStatus = $row.vital_status.trim().toLowerCase();\n    \n        if (!currField && vitalStatus === \"deceased\"){\n            result = {valid: false, message: `${$name} must be provided when the donor's vital_status is deceased.`}\n        }\n        else if (currField && vitalStatus != \"deceased\"){\n            result = {valid: false, message: `${$name} cannot be provided if the donor's vital_status is not deceased.`}\n        }\n        return result;\n    })"
+								]
+							}
+						},
+						{
+							"name": "primary_site",
+							"valueType": "string",
+							"description": "The text term used to describe the primary site of disease, as categorized by the World Health Organization's (WHO) International Classification of Diseases for Oncology (ICD-O). This categorization groups cases into general categories.",
+							"meta": {
+								"displayName": "Primary Site",
+								"core": true
+							},
+							"restrictions": {
+								"required": true,
+								"codeList": [
+									"Accessory sinuses",
+									"Adrenal gland",
+									"Anus and anal canal",
+									"Base of tongue",
+									"Bladder",
+									"Bones, joints and articular cartilage of limbs",
+									"Bones, joints and articular cartilage of other and unspecified sites",
+									"Brain",
+									"Breast",
+									"Bronchus and lung",
+									"Cervix uteri",
+									"Colon",
+									"Connective, subcutaneous and other soft tissues",
+									"Corpus uteri",
+									"Esophagus",
+									"Eye and adnexa",
+									"Floor of mouth",
+									"Gallbladder",
+									"Gum",
+									"Heart, mediastinum, and pleura",
+									"Hematopoietic and reticuloendothelial systems",
+									"Hypopharynx",
+									"Kidney",
+									"Larynx",
+									"Lip",
+									"Liver and intrahepatic bile ducts",
+									"Lymph nodes",
+									"Meninges",
+									"Nasal cavity and middle ear",
+									"Nasopharynx",
+									"Not Reported",
+									"Oropharynx",
+									"Other and ill-defined digestive organs",
+									"Other and ill-defined sites",
+									"Other and ill-defined sites in lip, oral cavity and pharynx",
+									"Other and ill-defined sites within respiratory system and intrathoracic organs",
+									"Other and unspecified female genital organs",
+									"Other and unspecified major salivary glands",
+									"Other and unspecified male genital organs",
+									"Other and unspecified parts of biliary tract",
+									"Other and unspecified parts of mouth",
+									"Other and unspecified parts of tongue",
+									"Other and unspecified urinary organs",
+									"Other endocrine glands and related structures",
+									"Ovary",
+									"Palate",
+									"Pancreas",
+									"Parotid gland",
+									"Penis",
+									"Peripheral nerves and autonomic nervous system",
+									"Placenta",
+									"Prostate gland",
+									"Pyriform sinus",
+									"Rectosigmoid junction",
+									"Rectum",
+									"Renal pelvis",
+									"Retroperitoneum and peritoneum",
+									"Skin",
+									"Small intestine",
+									"Spinal cord, cranial nerves, and other parts of central nervous system",
+									"Stomach",
+									"Testis",
+									"Thymus",
+									"Thyroid gland",
+									"Tonsil",
+									"Trachea",
+									"Ureter",
+									"Uterus, NOS",
+									"Vagina",
+									"Vulva",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"description": "Indicate the donor's height, in centimeters (cm).",
+							"name": "height",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Height"
+							}
+						},
+						{
+							"description": "Indicate the donor's weight, in kilograms (kg).",
+							"name": "weight",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Weight"
+							}
+						},
+						{
+							"description": "Indicate the donor's Body Mass Index (BMI) in kg/m².",
+							"name": "bmi",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "BMI"
+							}
+						},
+						{
+							"description": "Indicate the donor's menopause status at the time of primary diagnosis. (Reference: caDSR CDE ID 2434914)",
+							"name": "menopause_status",
+							"restrictions": {
+								"codeList": [
+									"Indeterminate or unknown",
+									"Not applicable",
+									"Perimenopausal",
+									"Postmenopausal",
+									"Premenopausal"
+								]
+							},
+							"valueType": "string",
+							"meta": {
+								"displayName": "Menopause Status"
+							}
+						},
+						{
+							"description": "Indicate the donor's age of menarche, the first occurrence of menstruation.",
+							"name": "age_at_menarche",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Age at Menarche"
+							}
+						},
+						{
+							"description": "Indicate the number of pregnancies a donor has had.",
+							"name": "number_of_pregnancies",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Number of Pregnancies"
+							}
+						},
+						{
+							"description": "Indicate the number of children the donor has birthed.",
+							"name": "number_of_children",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Number of Children"
+							}
+						},
+						{
+							"description": "If the donor became lost to follow up, indicate the identifier of the clinical event (eg. submitter_primary_diagnosis_id, submitter_treatment_id or submitter_follow_up_id) after which the donor became lost to follow up.",
+							"name": "lost_to_followup_after_clinical_event_id",
+							"valueType": "string",
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n       const {$row, $name, $field} = inputs;\n       let result = {valid: true, message: \"Ok\"};\n       const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n       /* checks for a string just consisting of whitespace */\n       const checkforEmpty = (entry) => {return /^s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n       if (currField != null && !(checkforEmpty(currField))) {\n       const vitalStatus = $row.vital_status.trim().toLowerCase();\n       if (vitalStatus === \"deceased\") {\n       result = {valid: false, message: `${$name} cannot be submitted if the donor's vital_status is deceased.`}\n       }\n       }\n       return result;\n       });"
+								]
+							},
+							"meta": {
+								"displayName": "Lost To Follow Up After Clinical Event",
+								"foreignKey": "primary_diagnosis.submitter_primary_diagnosis_id",
+								"validationDependency": true
+							}
+						}
+					]
+				},
+				{
+					"name": "specimen",
+					"description": "The collection of data elements related to a donor's specimen. A specimen is any material sample taken for testing, diagnostic or research purposes.",
+					"meta": {
+						"parent": "sample_registration"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "submitter_donor_id",
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_specimen_id",
+							"description": "Unique identifier of the specimen, assigned by the data provider.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_specimen_id",
+								"displayName": "Submitter Specimen ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_primary_diagnosis_id",
+							"valueType": "string",
+							"description": "Indicate the primary diagnosis event in the clinical timeline that this specimen acquisition was related to.",
+							"meta": {
+								"primaryId": true,
+								"displayName": "Submitter Primary Diagnosis ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "pathological_tumour_staging_system",
+							"description": "Specify the tumour staging system used to assess the cancer at the time the tumour specimen was resected. Pathological classification is based on the clinical stage information (acquired before treatment) and supplemented/modified by operative findings and pathological evaluation of the resected specimen.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"dependsOn": "sample_registration.tumour_normal_designation",
+								"notes": "This field is only required if the specimen is a tumour.",
+								"displayName": "Pathological Tumour Staging System"
+							},
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    const arrayFormatter = arr => `\\n${arr.map(entry => `- \"${entry}\"`).join('\\n')}`;\n    /* This is not a required field, so first ensure that it exists */\n    if ($field) {\n      /* Contingent on the naming system for tumour staging systems to remain consistent */\n      const stagingName = $name\n        .trim()\n        .toLowerCase()\n        .split('_tumour_staging_system')[0];\n      const requiredFields = [\n        `${stagingName}_m_category`,\n        `${stagingName}_n_category`,\n        `${stagingName}_t_category`,\n      ];\n      const convertedRow = Object.fromEntries(\n        Object.entries($row).map(([fieldName, fieldVal]) => [fieldName.toLowerCase(), fieldVal]),\n      );\n      /* Check for contigous spaces wrapped with quotes (empty strings) */\n      const checkforEmpty = entry => {\n        return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'));\n      };\n\n      /* search for fields with falsy values*/\n      const emptyFields = requiredFields.filter(\n        field => !convertedRow[field] || checkforEmpty(convertedRow[field]),\n      );\n\n      /* The fields should be provided IF and ONLY IF the AJCC regex passes */\n      if (/^(AJCC)\\b/i.test($field) && emptyFields.length) {\n        result = {\n          valid: false,\n          message: `The following fields are required when ${$name} is set to an AJCC option: ${arrayFormatter(\n            emptyFields,\n          )}`,\n        };\n      } else if (!/^(AJCC)\\b/i.test($field) && emptyFields.length != requiredFields.length) {\n        const errorFields = requiredFields.filter(fieldName => !emptyFields.includes(fieldName));\n        result = {\n          valid: false,\n          message: `The following fields cannot be provided when ${$name} is not set to an AJCC option: ${arrayFormatter(\n            errorFields,\n          )}`,\n        };\n      }\n    }\n    return result;\n  })"
+								],
+								"codeList": [
+									"AJCC 8th edition",
+									"AJCC 7th edition",
+									"Ann Arbor staging system",
+									"Binet staging system",
+									"Durie-Salmon staging system",
+									"FIGO staging system",
+									"Lugano staging system",
+									"Rai staging system",
+									"Revised International staging system (RISS)",
+									"St Jude staging system"
+								]
+							}
+						},
+						{
+							"name": "pathological_t_category",
+							"description": "The code to represent the stage of cancer defined by the size or contiguous extension of the primary tumour (T), according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "specimen.pathological_tumour_staging_system",
+								"notes": "This field is required only if the selected pathological_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Pathological T Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"T0",
+									"T1",
+									"T1a",
+									"T1a1",
+									"T1a2",
+									"T1b",
+									"T1b1",
+									"T1b2",
+									"T1c",
+									"T1d",
+									"T1mi",
+									"T2",
+									"T2a",
+									"T2a1",
+									"T2a2",
+									"T2b",
+									"T2c",
+									"T2d",
+									"T3",
+									"T3a",
+									"T3b",
+									"T3c",
+									"T3d",
+									"T3e",
+									"T4",
+									"T4a",
+									"T4b",
+									"T4c",
+									"T4d",
+									"T4e",
+									"Ta",
+									"Tis",
+									"Tis(DCIS)",
+									"Tis(LAMN)",
+									"Tis(LCIS)",
+									"Tis(Paget)",
+									"Tis(Paget’s)",
+									"Tis pd",
+									"Tis pu",
+									"TX"
+								]
+							}
+						},
+						{
+							"name": "pathological_n_category",
+							"description": "The code to represent the stage of cancer defined by whether or not the cancer has reached nearby lymph nodes (N), according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "specimen.pathological_tumour_staging_system",
+								"notes": "This field is required only if the selected pathological_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Pathological N Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"N0",
+									"N0a",
+									"N0a (biopsy)",
+									"N0b",
+									"N0b (no biopsy)",
+									"N0(i+)",
+									"N0(i-)",
+									"N0(mol+)",
+									"N0(mol-)",
+									"N1",
+									"N1a",
+									"N1a(sn)",
+									"N1b",
+									"N1c",
+									"N1mi",
+									"N2",
+									"N2a",
+									"N2b",
+									"N2c",
+									"N2mi",
+									"N3",
+									"N3a",
+									"N3b",
+									"N3c",
+									"N4",
+									"NX"
+								]
+							}
+						},
+						{
+							"name": "pathological_m_category",
+							"description": "The code to represent the stage of cancer defined by whether there are distant metastases (M), meaning spread of cancer to other parts of the body, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "specimen.pathological_tumour_staging_system",
+								"notes": "This field is required only if the selected pathological_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Pathological M Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"M0",
+									"M0(i+)",
+									"M1",
+									"M1a",
+									"M1a(0)",
+									"M1a(1)",
+									"M1b",
+									"M1b(0)",
+									"M1b(1)",
+									"M1c",
+									"M1c(0)",
+									"M1c(1)",
+									"M1d",
+									"M1d(0)",
+									"M1d(1)",
+									"M1e"
+								]
+							}
+						},
+						{
+							"name": "pathological_stage_group",
+							"description": "Specify the tumour stage, based on pathological_tumour_staging_system, used to assess the cancer at the time the tumour specimen was resected.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "specimen.pathological_tumour_staging_system",
+								"notes": "This field depends on the selected pathological_tumour_staging_system, and is only required if the specimen is a tumour.\nPlease refer to the documentation for Tumour Staging Classifications: http://docs.icgc-argo.org/docs/submission/dictionary-overview#tumour-staging-classifications",
+								"displayName": "Pathological Stage Group"
+							},
+							"restrictions": {
+								"codeList": [
+									"Stage 0",
+									"Stage 0a",
+									"Stage 0is",
+									"Stage I",
+									"Stage IA",
+									"Stage IA1",
+									"Stage IA2",
+									"Stage IA3",
+									"Stage IB",
+									"Stage IB1",
+									"Stage IB2",
+									"Stage IC",
+									"Stage IS",
+									"Stage IE",
+									"Stage II",
+									"Stage IIA",
+									"Stage IIA1",
+									"Stage IIA2",
+									"Stage IIE",
+									"Stage IIB",
+									"Stage IIC",
+									"Stage III",
+									"Stage IIIA",
+									"Stage IIIA1",
+									"Stage IIIA2",
+									"Stage IIIB",
+									"Stage IIIC",
+									"Stage IIIC1",
+									"Stage IIIC2",
+									"Stage IIID",
+									"Stage IV",
+									"Stage IVA",
+									"Stage IVA1",
+									"Stage IVA2",
+									"Stage IVB",
+									"Stage IVC",
+									"Occult carcinoma",
+									"Stage 1",
+									"Stage 1A",
+									"Stage 1B",
+									"Stage ISA",
+									"Stage ISB",
+									"Stage IEA",
+									"Stage IEB",
+									"Stage IIEA",
+									"Stage IIEB",
+									"Stage IIES",
+									"Stage IIESA",
+									"Stage IIESB",
+									"Stage IIS",
+									"Stage IISA",
+									"Stage IISB",
+									"Stage IIIE",
+									"Stage IIIEA",
+									"Stage IIIEB",
+									"Stage IIIES",
+									"Stage IIIESA",
+									"Stage IIIESB",
+									"Stage IIIS",
+									"Stage IIISA",
+									"Stage IIISB",
+									"Stage IAB",
+									"Stage A",
+									"Stage B",
+									"Stage C"
+								],
+								"script": [
+									"(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    if ($row.pathological_tumour_staging_system && $field) {\n      let codeList = [];\n      switch ($row.pathological_tumour_staging_system && $row.pathological_tumour_staging_system.trim().toLowerCase()) {\n        case 'revised international staging system (riss)':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii'\n          ];\n          break;\n        case 'lugano staging system':\n          codeList = [\n             'stage i',\n             'stage ia',\n             'stage ib',\n             'stage ie',\n             'stage iea',\n             'stage ieb',\n             'stage ii',\n             'stage iia',\n             'stage iib',\n             'stage iie',\n             'stage iiea',\n             'stage iieb',\n             'stage iii',\n             'stage iiia',\n             'stage iiib',\n             'stage iv',\n             'stage iva',\n             'stage ivb'\n          ];\n          break;\n        case 'st jude staging system':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii',\n            'stage iv'\n          ];\n          break;\n        case 'ann arbor staging system':\n          codeList = [\n            'stage i',\n            'stage ia',\n            'stage ib',\n            'stage ie',\n            'stage is',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iie',\n            'stage iis',\n            'stage iii',\n            'stage iiia',\n            'stage iiib',\n            'stage iiie',\n            'stage iiis',\n            'stage iv',\n            'stage iva',\n            'stage ivb',\n            'stage ive',\n            'stage ivs'\n          ];\n          break;\n        case 'rai staging system':\n          codeList = [\n             'stage 0',\n             'stage i',\n             'stage ii',\n             'stage iii',\n             'stage iv'\n          ];\n          break;\n        case 'durie-salmon staging system':\n          codeList = [\n            'stage 1',\n            'stage 1a',\n            'stage 1b',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iii',\n            'stage iiia',\n            'stage iiib'\n          ];\n          break;\n        case 'figo staging system':\n          codeList = [\n            'stage ia',\n            'stage ia1',\n            'stage ia2',\n            'stage ib',\n            'stage ib1',\n            'stage ib2',\n            'stage iia',\n            'stage iab',\n            'stage iiia',\n            'stage iiib',\n            'stage iva',\n            'stage ivb'\n          ];\n          break;\n        case 'binet staging system':\n          codeList = [\n             'stage a',\n             'stage b',\n             'stage c'\n         ];\n          break;\n        case 'ajcc 8th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ia3','stage ib','stage ib1','stage ib2','stage ic','stage ie','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iie','stage iii','stage iiia','stage iiia1','stage iiia2','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iiid','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'];\n          break;\n        case 'ajcc 7th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ib','stage ib1','stage ib2','stage ic','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iii','stage iiia','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'\n];\n          break;\n        default:\n          codelist = [];\n      }\n\n      if (!codeList.includes($field.trim().toLowerCase()) && codeList.length) {\n        const msg = `'${$field}' is not a permissible value. When 'pathological_tumour_staging_system' is set to '${\n          $row.pathological_tumour_staging_system\n        }', 'pathological_stage_group' must be one of the following: \\n${codeList\n          .map(code => `- \"${code}\"`)\n          .join('\\n')}`;\n\n        result.valid = false;\n        result.message = msg;\n      }\n    }\n    return result;\n  })"
+								]
+							}
+						},
+						{
+							"name": "specimen_acquisition_interval",
+							"description": "Interval between primary diagnosis and specimen acquisition, in days.",
+							"valueType": "integer",
+							"meta": {
+								"validationDependency": true,
+								"units": "days",
+								"core": true,
+								"notes": "The associated primary diagnosis is used as the reference point for this interval. To calculate this, find the number of days since the date of primary diagnosis.",
+								"displayName": "Specimen Acquisition Interval"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "tumour_histological_type",
+							"description": "The code to represent the histology (morphology) of neoplasms that is usually obtained from a pathology report, according to the International Classification of Diseases for Oncology, 3rd Edition (WHO ICD-O-3). Refer to the ICD-O-3 manual for guidelines at https://apps.who.int/iris/handle/10665/42344.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"dependsOn": "sample_registration.tumour_normal_designation",
+								"notes": "This field is only required if the specimen is a tumour.",
+								"examples": "8260/3,9691/36",
+								"displayName": "Tumour Histological Type"
+							},
+							"restrictions": {
+								"regex": "^[8,9]{1}[0-9]{3}/[0,1,2,3,6,9]{1}[1-9]{0,1}$"
+							}
+						},
+						{
+							"name": "specimen_anatomic_location",
+							"description": "Indicate the ICD-O-3 topography code for the anatomic location of a specimen when it was collected. Refer to the guidelines provided in the ICD-O-3 manual at https://apps.who.int/iris/handle/10665/42344.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"displayName": "Specimen Anatomic Location",
+								"examples": "C50.1,C18"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[C][0-9]{2}(.[0-9]{1})?$"
+							}
+						},
+						{
+							"name": "specimen_processing",
+							"description": "Indicate the technique used to process specimen.",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cryopreservation in liquid nitrogen (dead tissue)",
+									"Cryopreservation in dry ice (dead tissue)",
+									"Cryopreservation of live cells in liquid nitrogen",
+									"Cryopreservation - other",
+									"Formalin fixed & paraffin embedded",
+									"Formalin fixed - buffered",
+									"Formalin fixed - unbuffered",
+									"Fresh",
+									"Other"
+								]
+							},
+							"meta": {
+								"displayName": "Specimen Processing"
+							}
+						},
+						{
+							"name": "specimen_storage",
+							"description": "Indicate the method of specimen storage for specimens that were not extracted freshly or immediately cultured.",
+							"valueType": "string",
+							"meta": {
+								"notes": "For specimens that were freshly extracted or immediately cultured, select Not Applicable.",
+								"displayName": "Specimen Storage"
+							},
+							"restrictions": {
+								"codeList": [
+									"Cut slide",
+									"Frozen in -70 freezer",
+									"Frozen in liquid nitrogen",
+									"Frozen in vapour phase",
+									"Not Applicable",
+									"Other",
+									"Paraffin block",
+									"RNA later frozen"
+								]
+							}
+						},
+						{
+							"name": "reference_pathology_confirmed",
+							"description": "Indicate whether the pathological diagnosis was confirmed by a (central) reference pathologist.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"dependsOn": "sample_registration.tumour_normal_designation",
+								"notes": "This field is only required if the specimen is a tumour.",
+								"displayName": "Reference Pathology Confirmed"
+							},
+							"restrictions": {
+								"codeList": ["Yes", "No", "Unknown"]
+							}
+						},
+						{
+							"name": "tumour_grading_system",
+							"description": "Specify the tumour staging system used to assess the description of a tumour based on how abnormal the tumour cells and the tumour tissue look under a microscope. Tumour grade is an indicator of how quickly a tumour is likely to grow.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "sample_registration.tumour_normal_designation",
+								"notes": "This field is only required if the specimen is a tumour.",
+								"displayName": "Tumour Grading System"
+							},
+							"restrictions": {
+								"codeList": [
+									"FNCLCC grading system",
+									"Four-tier grading system",
+									"Gleason grade group system",
+									"Grading system for GISTs",
+									"Grading system for GNETs",
+									"ISUP grading system",
+									"Nuclear grading system for DCIS",
+									"Scarff-Bloom-Richardson grading system",
+									"Three-tier grading system",
+									"Two-tier grading system",
+									"WHO grading system for CNS tumours"
+								]
+							}
+						},
+						{
+							"name": "tumour_grade",
+							"description": "Grade of the tumour as assigned by the reporting tumour_grading_system.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "specimen.tumour_grading_system",
+								"notes": "This field depends on the selected tumour_grading_system, and is only required if the specimen is a tumour.\nPlease refer to the documentation for Tumour Grading Classifications: http://docs.icgc-argo.org/docs/submission/dictionary-overview#tumour-grading-classifications",
+								"displayName": "Tumour Grade"
+							},
+							"restrictions": {
+								"codeList": [
+									"Low grade",
+									"High grade",
+									"GX",
+									"G1",
+									"G2",
+									"G3",
+									"G4",
+									"Low",
+									"High",
+									"Grade I",
+									"Grade II",
+									"Grade III",
+									"Grade IV",
+									"Grade Group 1",
+									"Grade Group 2",
+									"Grade Group 3",
+									"Grade Group 4",
+									"Grade Group 5"
+								],
+								"script": [
+									"(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    if ($row.tumour_grading_system && $field) {\n      let codeList = [];\n      const tieredGradingList = ['gx','g1','g2','g3'];\n      const gradingSystems = ['two-tier grading system', 'three-tier grading system', 'four-tier grading system', 'grading system for gists', 'grading system for gnets', 'isup grading system', 'who grading system for cns tumours', 'fnclcc grading system', 'gleason grade group system', 'scarff-bloom-richardson grading system', 'nuclear grading system for dcis'];\n      switch ($row.tumour_grading_system && $row.tumour_grading_system.trim().toLowerCase()) {\n        case 'two-tier grading system':\n          codeList = [\n            'low grade',\n            'high grade',\n          ];\n          break;\n        case 'three-tier grading system':\n          codeList = tieredGradingList;\n          break;\n        case 'four-tier grading system':\n          codeList = [\n            'gx',\n            'g1',\n            'g2',\n            'g3',\n            'g4',\n          ];\n          break;\n        case 'grading system for gists':\n          codeList = [\n            'low',\n            'high',\n          ];\n          break;\n        case 'grading system for gnets':\n          codeList = tieredGradingList;\n          break;\n        case 'isup grading system':\n          codeList = [\n            'gx',\n            'g1',\n            'g2',\n            'g3',\n            'g4',\n          ];\n          break;\n        case 'who grading system for cns tumours':\n          codeList = [\n            'grade i',\n            'grade ii',\n            'grade iii',\n            'grade iv',\n          ];\n          break;\n        case 'fnclcc grading system':\n          codeList = tieredGradingList;\n          break;\n        case 'gleason grade group system':\n          codeList = [\n            'grade group 1',\n            'grade group 2',\n            'grade group 3',\n            'grade group 4',\n            'grade group 5',\n          ];\n          break;\n        case 'scarff-bloom-richardson grading system':\n          codeList = tieredGradingList;\n          break;\n        case 'nuclear grading system for dcis':\n          codeList = tieredGradingList;\n          break;\n      }\n\n      if (!codeList.includes($field.trim().toLowerCase())) {\n        const msg = `'${$field}' is not a permissible value. When 'tumour_grading_system' is set to '${\n          $row.tumour_grading_system\n        }', 'tumour_grade' must be one of the following: \\n${codeList\n          .map(code => `- \"${code}\"`)\n          .join('\\n')}`;\n        result.valid = false;\n        result.message = msg;\n      }\n      else if (!gradingSystems.includes($row.tumour_grading_system.trim().toLowerCase())) {\n         result.valid = false;\n         const msg = \"'${$row.tumour_grading_system}' is not a permissible value for 'tumour_grading_system'. If the tumour grading system you use is missing, please contact the DCC.\";\n         result.message = msg;\n      }\n    }\n    return result;\n  })"
+								]
+							}
+						},
+						{
+							"name": "percent_tumour_cells",
+							"description": "Indicate a value, in decimals, that represents the percentage of infiltration by tumour cells in a specimen.",
+							"valueType": "number",
+							"meta": {
+								"core": true,
+								"dependsOn": "sample_registration.tumour_normal_designation",
+								"notes": "This field is only required if the specimen is a tumour.",
+								"displayName": "Percent Tumour Cells"
+							}
+						},
+						{
+							"name": "percent_tumour_cells_measurement_method",
+							"description": "Indicate method used to measure percent_tumour_cells.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "sample_registration.tumour_normal_designation",
+								"notes": "This field is only required if the specimen is a tumour.",
+								"displayName": "Percent Tumour Cells Measurement Method"
+							},
+							"restrictions": {
+								"codeList": ["Genomics", "Image analysis", "Pathology estimate by percent nuclei"]
+							}
+						},
+						{
+							"name": "percent_proliferating_cells",
+							"description": "Indicate a value, in decimals, that represents the count of proliferating cells determined during pathologic review of the specimen.",
+							"valueType": "number",
+							"meta": {
+								"dependsOn": "sample_registration.tumour_normal_designation",
+								"notes": "",
+								"displayName": "Percent Proliferating Cells"
+							}
+						},
+						{
+							"name": "percent_inflammatory_tissue",
+							"description": "Indicate a value, in decimals, that represents local response to cellular injury, marked by capillary dilatation, edema and leukocyte infiltration; clinically, inflammation is manifest by redness, heat, pain, swelling and loss of function, with the need to heal damaged tissue.",
+							"valueType": "number",
+							"meta": {
+								"dependsOn": "sample_registration.tumour_normal_designation",
+								"notes": "",
+								"displayName": "Percent Inflammatory Tissue"
+							}
+						},
+						{
+							"name": "percent_stromal_cells",
+							"description": "Indicate a value, in decimals, that represents the percentage of reactive cells that are present in a malignant tumour specimen but are not malignant such as fibroblasts, vascular structures, etc.",
+							"valueType": "number",
+							"meta": {
+								"dependsOn": "sample_registration.tumour_normal_designation",
+								"notes": "",
+								"displayName": "Percent Stromal Cells"
+							}
+						},
+						{
+							"name": "percent_necrosis",
+							"description": "Indicate a value, in decimals, that represents the percentage of cell death in a malignant tumour specimen.",
+							"valueType": "number",
+							"meta": {
+								"dependsOn": "sample_registration.tumour_normal_designation",
+								"notes": "",
+								"displayName": "Percent Necrosis"
+							}
+						}
+					]
+				},
+				{
+					"name": "primary_diagnosis",
+					"description": "The collection of data elements related to a donor's primary diagnosis. The primary diagnosis is the first diagnosed case of cancer in a donor. To submit multiple primary diagnoses for a single donor, submit multiple rows in the primary diagnosis file for this donor.",
+					"meta": {
+						"parent": "donor"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_primary_diagnosis_id",
+							"valueType": "string",
+							"description": "Unique identifier of the primary diagnosis event, assigned by the data provider.",
+							"meta": {
+								"primaryId": true,
+								"displayName": "Submitter Primary Diagnosis ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "age_at_diagnosis",
+							"valueType": "integer",
+							"description": "Age that the donor was first diagnosed with cancer, in years. This should be based on the earliest diagnosis of cancer.",
+							"restrictions": {
+								"required": true
+							},
+							"meta": {
+								"units": "years",
+								"core": true,
+								"displayName": "Age at Diagnosis"
+							}
+						},
+						{
+							"name": "cancer_type_code",
+							"valueType": "string",
+							"description": "The code to represent the cancer type using the WHO ICD-10 code (https://icd.who.int/browse10/2019/en) classification.",
+							"restrictions": {
+								"required": true,
+								"regex": "^[C|D][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$"
+							},
+							"meta": {
+								"core": true,
+								"examples": "C41.1,C16.9,C00.5,D46.9",
+								"displayName": "Cancer Type Code"
+							}
+						},
+						{
+							"name": "cancer_type_additional_information",
+							"valueType": "string",
+							"description": "Additional details related to the cancer type that are not covered by the ICD-10 code provided in the cancer_type field.",
+							"meta": {
+								"displayName": "Cancer Type Additional Information"
+							}
+						},
+						{
+							"name": "basis_of_diagnosis",
+							"description": "Indicate the most valid basis of how the primary diagnosis was identified. If more than one diagnosis technique was used, select the term that has the highest code number (see notes). (Reference: IACR Standard for Basis of Diagnosis http://www.iacr.com.fr/images/doc/basis.pdf)",
+							"restrictions": {
+								"codeList": [
+									"Clinical investigation",
+									"Clinical",
+									"Cytology",
+									"Death certificate only",
+									"Histology of a metastasis",
+									"Histology of a primary tumour",
+									"Specific tumour markers",
+									"Unknown"
+								]
+							},
+							"valueType": "string",
+							"meta": {
+								"notes": "0: Death certificate only: Information provided is from a death certificate.\n1: Clinical: Diagnosis made before death.\n2: Clinical investigation: All diagnostic techniques, including X-ray, endoscopy, imaging, ultrasound, exploratory surgery (such as laparotomy), and autopsy, without a tissue diagnosis.\n4: Specific tumour markers: Including biochemical and/or immunologic markers that are specific for a tumour site.\n5: Cytology: Examination of cells from a primary or secondary site, including fluids aspirated by endoscopy or needle; also includes the microscopic examination of peripheral blood and bone marrow aspirates.\n6: Histology of a metastasis: Histologic examination of tissue from a metastasis, including autopsy specimens.\n7: Histology of a primary tumour: Histologic examination of tissue from primary tumour, however obtained, including all cutting techniques and bone marrow biopsies; also includes autopsy specimens of primary tumour.\n9: Unknown: No information on how the diagnosis has been made.",
+								"displayName": "Basis of Diagnosis"
+							}
+						},
+						{
+							"name": "number_lymph_nodes_positive",
+							"description": "The number of regional lymph nodes reported as being positive for tumour metastases. (Reference: caDSR CDE ID 6113694)",
+							"valueType": "integer",
+							"restrictions": {
+								"required": true
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Number Of Lymph Nodes Positive"
+							}
+						},
+						{
+							"name": "number_lymph_nodes_examined",
+							"description": "The total number of lymph nodes tested for the presence of cancer. (Reference: caDSR CDE ID 3)",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Number Of Lymph Nodes Examined"
+							}
+						},
+						{
+							"name": "clinical_tumour_staging_system",
+							"valueType": "string",
+							"description": "Indicate the tumour staging system used to stage the cancer at the time of primary diagnosis (prior to treatment).",
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    const arrayFormatter = arr => `\\n${arr.map(entry => `- \"${entry}\"`).join('\\n')}`;\n    /* This is not a required field, so first ensure that it exists */\n    if ($field) {\n      /* Contingent on the naming system for tumour staging systems to remain consistent */\n      const stagingName = $name\n        .trim()\n        .toLowerCase()\n        .split('_tumour_staging_system')[0];\n      const requiredFields = [\n        `${stagingName}_m_category`,\n        `${stagingName}_n_category`,\n        `${stagingName}_t_category`,\n      ];\n      const convertedRow = Object.fromEntries(\n        Object.entries($row).map(([fieldName, fieldVal]) => [fieldName.toLowerCase(), fieldVal]),\n      );\n      /* Check for contigous spaces wrapped with quotes (empty strings) */\n      const checkforEmpty = entry => {\n        return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'));\n      };\n\n      /* search for fields with falsy values*/\n      const emptyFields = requiredFields.filter(\n        field => !convertedRow[field] || checkforEmpty(convertedRow[field]),\n      );\n\n      /* The fields should be provided IF and ONLY IF the AJCC regex passes */\n      if (/^(AJCC)\\b/i.test($field) && emptyFields.length) {\n        result = {\n          valid: false,\n          message: `The following fields are required when ${$name} is set to an AJCC option: ${arrayFormatter(\n            emptyFields,\n          )}`,\n        };\n      } else if (!/^(AJCC)\\b/i.test($field) && emptyFields.length != requiredFields.length) {\n        const errorFields = requiredFields.filter(fieldName => !emptyFields.includes(fieldName));\n        result = {\n          valid: false,\n          message: `The following fields cannot be provided when ${$name} is not set to an AJCC option: ${arrayFormatter(\n            errorFields,\n          )}`,\n        };\n      }\n    }\n    return result;\n  })"
+								],
+								"codeList": [
+									"AJCC 8th edition",
+									"AJCC 7th edition",
+									"Ann Arbor staging system",
+									"Binet staging system",
+									"Durie-Salmon staging system",
+									"FIGO staging system",
+									"Lugano staging system",
+									"Rai staging system",
+									"Revised International staging system (RISS)",
+									"St Jude staging system"
+								]
+							},
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"displayName": "Clinical Tumour Staging System"
+							}
+						},
+						{
+							"name": "clinical_stage_group",
+							"description": "Stage group of the tumour, as assigned by the reporting clinical_tumour_staging_system, that indicates the overall prognostic tumour stage (ie. Stage I, Stage II, Stage III etc.).",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Stage 0",
+									"Stage 0a",
+									"Stage 0is",
+									"Stage I",
+									"Stage IA",
+									"Stage IA1",
+									"Stage IA2",
+									"Stage IA3",
+									"Stage IB",
+									"Stage IB1",
+									"Stage IB2",
+									"Stage IC",
+									"Stage IS",
+									"Stage IE",
+									"Stage II",
+									"Stage IIA",
+									"Stage IIA1",
+									"Stage IIA2",
+									"Stage IIE",
+									"Stage IIB",
+									"Stage IIC",
+									"Stage III",
+									"Stage IIIA",
+									"Stage IIIA1",
+									"Stage IIIA2",
+									"Stage IIIB",
+									"Stage IIIC",
+									"Stage IIIC1",
+									"Stage IIIC2",
+									"Stage IIID",
+									"Stage IV",
+									"Stage IVA",
+									"Stage IVA1",
+									"Stage IVA2",
+									"Stage IVB",
+									"Stage IVC",
+									"Occult carcinoma",
+									"Stage 1",
+									"Stage 1A",
+									"Stage 1B",
+									"Stage ISA",
+									"Stage ISB",
+									"Stage IEA",
+									"Stage IEB",
+									"Stage IIEA",
+									"Stage IIEB",
+									"Stage IIES",
+									"Stage IIESA",
+									"Stage IIESB",
+									"Stage IIS",
+									"Stage IISA",
+									"Stage IISB",
+									"Stage IIIE",
+									"Stage IIIEA",
+									"Stage IIIEB",
+									"Stage IIIES",
+									"Stage IIIESA",
+									"Stage IIIESB",
+									"Stage IIIS",
+									"Stage IIISA",
+									"Stage IIISB",
+									"Stage IAB",
+									"Stage A",
+									"Stage B",
+									"Stage C"
+								],
+								"script": [
+									"(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    if ($row.clinical_tumour_staging_system && $field) {\n      let codeList = [];\n      switch ($row.clinical_tumour_staging_system && $row.clinical_tumour_staging_system.trim().toLowerCase()) {\n        case 'revised international staging system (riss)':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii'\n          ];\n          break;\n        case 'lugano staging system':\n          codeList = [\n             'stage i',\n             'stage ia',\n             'stage ib',\n             'stage ie',\n             'stage iea',\n             'stage ieb',\n             'stage ii',\n             'stage iia',\n             'stage iib',\n             'stage iie',\n             'stage iiea',\n             'stage iieb',\n             'stage iii',\n             'stage iiia',\n             'stage iiib',\n             'stage iv',\n             'stage iva',\n             'stage ivb'\n          ];\n          break;\n        case 'st jude staging system':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii',\n            'stage iv'\n          ];\n          break;\n        case 'ann arbor staging system':\n          codeList = [\n            'stage i',\n            'stage ia',\n            'stage ib',\n            'stage ie',\n            'stage is',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iie',\n            'stage iis',\n            'stage iii',\n            'stage iiia',\n            'stage iiib',\n            'stage iiie',\n            'stage iiis',\n            'stage iv',\n            'stage iva',\n            'stage ivb',\n            'stage ive',\n            'stage ivs'\n          ];\n          break;\n        case 'rai staging system':\n          codeList = [\n             'stage 0',\n             'stage i',\n             'stage ii',\n             'stage iii',\n             'stage iv'\n          ];\n          break;\n        case 'durie-salmon staging system':\n          codeList = [\n            'stage 1',\n            'stage 1a',\n            'stage 1b',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iii',\n            'stage iiia',\n            'stage iiib'\n          ];\n          break;\n        case 'figo staging system':\n          codeList = [\n            'stage ia',\n            'stage ia1',\n            'stage ia2',\n            'stage ib',\n            'stage ib1',\n            'stage ib2',\n            'stage iia',\n            'stage iab',\n            'stage iiia',\n            'stage iiib',\n            'stage iva',\n            'stage ivb'\n          ];\n          break;\n        case 'binet staging system':\n          codeList = [\n             'stage a',\n             'stage b',\n             'stage c'\n         ];\n          break;\n        case 'ajcc 8th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ia3','stage ib','stage ib1','stage ib2','stage ic','stage ie','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iie','stage iii','stage iiia','stage iiia1','stage iiia2','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iiid','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'];\n          break;\n        case 'ajcc 7th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ib','stage ib1','stage ib2','stage ic','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iii','stage iiia','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'\n];\n          break;\n        default:\n          codelist = [];\n      }\n\n      if (!codeList.includes($field.trim().toLowerCase()) && codeList.length) {\n        const msg = `'${$field}' is not a permissible value. When 'clinical_tumour_staging_system' is set to '${\n          $row.clinical_tumour_staging_system\n        }', 'clinical_stage_group' must be one of the following: \\n${codeList\n          .map(code => `- \"${code}\"`)\n          .join('\\n')}`;\n\n        result.valid = false;\n        result.message = msg;\n      }\n    }\n    return result;\n  })"
+								]
+							},
+							"meta": {
+								"core": true,
+								"dependsOn": "primary_diagnosis.clinical_tumour_staging_system",
+								"notes": "This field is dependent on the selected clinical_tumour_staging_system.\nPlease refer to the documentation for Tumour Staging Classifications: http://docs.icgc-argo.org/docs/submission/dictionary-overview#tumour-staging-classifications",
+								"displayName": "Clinical Stage Group"
+							}
+						},
+						{
+							"name": "clinical_t_category",
+							"description": "The code to represent the extent of the primary tumour (T) based on evidence obtained from clinical assessment parameters determined at time of primary diagnosis and prior to treatment, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "primary_diagnosis.clinical_tumour_staging_system",
+								"notes": "This field is required only if the selected clinical_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Clinical T Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"T0",
+									"T1",
+									"T1a",
+									"T1a1",
+									"T1a2",
+									"T1b",
+									"T1b1",
+									"T1b2",
+									"T1c",
+									"T1d",
+									"T1mi",
+									"T2",
+									"T2a",
+									"T2a1",
+									"T2a2",
+									"T2b",
+									"T2c",
+									"T2d",
+									"T3",
+									"T3a",
+									"T3b",
+									"T3c",
+									"T3d",
+									"T3e",
+									"T4",
+									"T4a",
+									"T4b",
+									"T4c",
+									"T4d",
+									"T4e",
+									"Ta",
+									"Tis",
+									"Tis(DCIS)",
+									"Tis(LAMN)",
+									"Tis(LCIS)",
+									"Tis(Paget)",
+									"Tis(Paget’s)",
+									"Tis pd",
+									"Tis pu",
+									"TX"
+								]
+							}
+						},
+						{
+							"name": "clinical_n_category",
+							"description": "The code to represent the stage of cancer defined by the extent of the regional lymph node (N) involvement for the cancer based on evidence obtained from clinical assessment parameters determined at time of primary diagnosis and prior to treatment, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "primary_diagnosis.clinical_tumour_staging_system",
+								"notes": "This field is required only if the selected clinical_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Clinical N Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"N0",
+									"N0a",
+									"N0a (biopsy)",
+									"N0b",
+									"N0b (no biopsy)",
+									"N0(i+)",
+									"N0(i-)",
+									"N0(mol+)",
+									"N0(mol-)",
+									"N1",
+									"N1a",
+									"N1a(sn)",
+									"N1b",
+									"N1c",
+									"N1mi",
+									"N2",
+									"N2a",
+									"N2b",
+									"N2c",
+									"N2mi",
+									"N3",
+									"N3a",
+									"N3b",
+									"N3c",
+									"N4",
+									"NX"
+								]
+							}
+						},
+						{
+							"name": "clinical_m_category",
+							"description": "The code to represent the stage of cancer defined by the extent of the distant metastasis (M) for the cancer based on evidence obtained from clinical assessment parameters determined at time of primary diagnosis and prior to treatment, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual. MX is NOT a valid category and cannot be assigned.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "primary_diagnosis.clinical_tumour_staging_system",
+								"notes": "This field is required only if the selected clinical_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Clinical M Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"M0",
+									"M0(i+)",
+									"M1",
+									"M1a",
+									"M1a(0)",
+									"M1a(1)",
+									"M1b",
+									"M1b(0)",
+									"M1b(1)",
+									"M1c",
+									"M1c(0)",
+									"M1c(1)",
+									"M1d",
+									"M1d(0)",
+									"M1d(1)",
+									"M1e"
+								]
+							}
+						},
+						{
+							"name": "presenting_symptoms",
+							"description": "Indicate presenting symptoms at time of primary diagnosis.",
+							"valueType": "string",
+							"isArray": true,
+							"restrictions": {
+								"codeList": [
+									"Abdominal Pain",
+									"Anemia",
+									"Back Pain",
+									"Bloating",
+									"Cholangitis",
+									"Constipation",
+									"Dark Urine",
+									"Decreased Appetite",
+									"Diabetes",
+									"Diarrhea",
+									"Fatigue",
+									"Fever",
+									"Hypoglycemia",
+									"Jaundice",
+									"Loss of Appetite",
+									"Nausea",
+									"None",
+									"Not Reported",
+									"Pale Stools",
+									"Pancreatitis",
+									"Pruritus/Itchiness",
+									"Steatorrhea",
+									"Swelling in the Neck",
+									"Unknown",
+									"Vomiting",
+									"Weight Loss"
+								]
+							},
+							"meta": {
+								"displayName": "Presenting Symptoms",
+								"notes": "To include multiple values, separate values with a pipe delimiter '|' within your file.",
+								"examples": "Anemia|Bloating|Diabetes"
+							}
+						},
+						{
+							"name": "performance_status",
+							"description": "Indicate the donor's performance status grade at the time of primary diagnosis. (Reference: ECOG performance score grades from https://ecog-acrin.org/resources/ecog-performance-status).",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": ["Grade 0", "Grade 1", "Grade 2", "Grade 3", "Grade 4"]
+							},
+							"meta": {
+								"notes": "Grade 0: Fully active, able to carry on all pre-disease performance without restriction.\nGrade 1: Restricted in physically strenuous activity but ambulatory and able to carry out work of a light or sedentary nature (ie. Light house work, office work).\nGrade 2: Ambulatory and capable of all selfcare but unable to carry out any work activities; up and about more than 50% of waking hours.\nGrade 3: Capable of only limited selfcare; confined to bed or chair more than 50% of waking hours.\nGrade 4: Completely disabled; cannot carry on any selfcare; totally confined to bed or chair",
+								"displayName": "Performance Status"
+							}
+						}
+					]
+				},
+				{
+					"name": "treatment",
+					"description": "The collection of data elements related to a donor's treatment at a specific point in the clinical record. To submit multiple treatments for a single donor, please submit treatment rows in the treatment file for this donor.",
+					"meta": {
+						"parent": "donor"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "submitter_donor_id",
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_treatment_id",
+							"description": "Unique identifier of the treatment, assigned by the data provider.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"displayName": "Submitter Treatment ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_primary_diagnosis_id",
+							"valueType": "string",
+							"description": "Indicate the primary diagnosis event in the clinical timeline that this treatment was related to.",
+							"meta": {
+								"primaryId": true,
+								"displayName": "Submitter Primary Diagnosis ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "treatment_type",
+							"description": "Indicate the type of treatment regimen that the donor completed.",
+							"valueType": "string",
+							"isArray": true,
+							"restrictions": {
+								"required": true,
+								"codeList": [
+									"Ablation",
+									"Bone marrow transplant",
+									"Chemotherapy",
+									"Endoscopic therapy",
+									"Hormonal therapy",
+									"Immunotherapy",
+									"No treatment",
+									"Other targeting molecular therapy",
+									"Photodynamic therapy",
+									"Radiation therapy",
+									"Stem cell transplant",
+									"Surgery"
+								]
+							},
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"notes": "Depending on the treatment_type(s) selected, additional treatment details may be required to be submitted. For example, if treatment_type includes 'Chemotherapy', the supplemental Chemotherapy treatment type file is required.\nTo include multiple values, separate values with a pipe delimiter '|' within your file.",
+								"displayName": "Treatment Type",
+								"examples": "Chemotherapy|Hormonal therapy"
+							}
+						},
+						{
+							"name": "age_at_consent_for_treatment",
+							"description": "Indicate the age of donor when consent was given for treatment.",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Age At Consent For Treatment"
+							}
+						},
+						{
+							"name": "is_primary_treatment",
+							"description": "Indicate if the treatment was the primary treatment following the initial diagnosis.",
+							"valueType": "string",
+							"restrictions": {
+								"required": true,
+								"codeList": ["Yes", "No", "Unknown"]
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Is Primary Treatment"
+							}
+						},
+						{
+							"name": "line_of_treatment",
+							"description": "Indicate the line of treatment if it is not the primary treatment.",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Line Of treatment",
+								"examples": "2,3,4"
+							}
+						},
+						{
+							"name": "treatment_start_interval",
+							"description": "The interval between the primary diagnosis and initiation of treatment, in days.",
+							"valueType": "integer",
+							"restrictions": {
+								"required": true
+							},
+							"meta": {
+								"core": true,
+								"units": "days",
+								"notes": "The associated primary diagnosis is used as the reference point for this interval. To calculate this, find the number of days since the date of primary diagnosis.",
+								"displayName": "Treatment Start Interval"
+							}
+						},
+						{
+							"name": "treatment_duration",
+							"description": "The duration of treatment regimen, in days.",
+							"valueType": "integer",
+							"restrictions": {
+								"required": true
+							},
+							"meta": {
+								"core": true,
+								"units": "days",
+								"displayName": "Treatment Duration"
+							}
+						},
+						{
+							"name": "days_per_cycle",
+							"description": "Indicate the number of days in a treatment cycle.",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Days Per Cycle"
+							}
+						},
+						{
+							"name": "number_of_cycles",
+							"description": "Indicate the number of treatment cycles.",
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Number Of Cycles"
+							}
+						},
+						{
+							"name": "therapeutic_intent",
+							"description": "The therapeutic intent, the reason behind the choice of a therapy, of the treatment.",
+							"valueType": "string",
+							"restrictions": {
+								"required": true,
+								"codeList": [
+									"Adjuvant",
+									"Concurrent",
+									"Curative",
+									"Neoadjuvant",
+									"Not applicable",
+									"Palliative",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Therapeutic Intent"
+							}
+						},
+						{
+							"name": "response_to_therapy",
+							"description": "The donor's response to the applied treatment regimen. (Source: RECIST)",
+							"valueType": "string",
+							"restrictions": {
+								"required": true,
+								"codeList": [
+									"Complete response",
+									"Disease progression",
+									"NED",
+									"Partial response",
+									"Stable disease"
+								]
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Response To Therapy"
+							}
+						},
+						{
+							"name": "outcome_of_treatment",
+							"description": "Indicate the donor's outcome of the prescribed treatment.",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Treatment completed as prescribed",
+									"Treatment incomplete due to technical or organizational problems",
+									"Treatment incomplete because patient died",
+									"Patient choice (stopped or interrupted treatment)",
+									"Physician decision (stopped or interrupted treatment)",
+									"Treatment stopped due to lack of efficacy (disease progression)",
+									"Treatment stopped due to acute toxicity",
+									"Other",
+									"Not applicable",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "Outcome Of Treatment"
+							}
+						},
+						{
+							"name": "toxicity_type",
+							"description": "If the treatment was terminated early due to acute toxicity, indicate whether it was due to hemotological toxicity or non-hemotological toxicity.",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": ["Hemotological", "Non-hemotological"]
+							},
+							"meta": {
+								"displayName": "Toxicity Type"
+							}
+						},
+						{
+							"name": "hemotological_toxicity",
+							"description": "Indicate the hemotological toxicities which caused early termination of the treatment. (Codelist reference: NCI-CTCAE (v5.0))",
+							"valueType": "string",
+							"isArray": true,
+							"restrictions": {
+								"codeList": [
+									"Anemia - Grade 3",
+									"Anemia - Grade 4",
+									"Anemia - Grade 5",
+									"Neutropenia - Grade 3",
+									"Neutropenia - Grade 4",
+									"Neutropenia - Grade 5",
+									"Thrombocytopenia - Grade 3",
+									"Thrombocytopenia - Grade 4",
+									"Thrombocytopenia - Grade 5"
+								]
+							},
+							"meta": {
+								"displayName": "Hemotological Toxicity",
+								"notes": "To include multiple values, separate values with a pipe delimiter '|' within your file."
+							}
+						},
+						{
+							"name": "adverse_events",
+							"description": "Report any treatment related adverse events. (Codelist reference: NCI-CTCAE (v5.0))",
+							"valueType": "string",
+							"isArray": true,
+							"restrictions": {
+								"codeList": [
+									"Abdominal distension",
+									"Abdominal infection",
+									"Abdominal pain",
+									"Abdominal soft tissue necrosis",
+									"Abducens nerve disorder",
+									"Accessory nerve disorder",
+									"Acidosis",
+									"Acoustic nerve disorder NOS",
+									"Activated partial thromboplastin time prolonged",
+									"Acute kidney injury",
+									"Adrenal insufficiency",
+									"Adult respiratory distress syndrome",
+									"Agitation",
+									"Akathisia",
+									"Alanine aminotransferase increased",
+									"Alcohol intolerance",
+									"Alkaline phosphatase increased",
+									"Alkalosis",
+									"Allergic reaction",
+									"Allergic rhinitis",
+									"Alopecia",
+									"Amenorrhea",
+									"Amnesia",
+									"Anal fissure",
+									"Anal fistula",
+									"Anal hemorrhage",
+									"Anal mucositis",
+									"Anal necrosis",
+									"Anal pain",
+									"Anal stenosis",
+									"Anal ulcer",
+									"Anaphylaxis",
+									"Anemia",
+									"Ankle fracture",
+									"Anorectal infection",
+									"Anorexia",
+									"Anorgasmia",
+									"Anosmia",
+									"Anxiety",
+									"Aortic injury",
+									"Aortic valve disease",
+									"Aphonia",
+									"Apnea",
+									"Appendicitis",
+									"Appendicitis perforated",
+									"Arachnoiditis",
+									"Arterial injury",
+									"Arterial thromboembolism",
+									"Arteritis infective",
+									"Arthralgia",
+									"Arthritis",
+									"Ascites",
+									"Aspartate aminotransferase increased",
+									"Aspiration",
+									"Asystole",
+									"Ataxia",
+									"Atelectasis",
+									"Atrial fibrillation",
+									"Atrial flutter",
+									"Atrioventricular block complete",
+									"Atrioventricular block first degree",
+									"Autoimmune disorder",
+									"Avascular necrosis",
+									"Azoospermia",
+									"Back pain",
+									"Bacteremia",
+									"Belching",
+									"Bile duct stenosis",
+									"Biliary anastomotic leak",
+									"Biliary fistula",
+									"Biliary tract infection",
+									"Bladder anastomotic leak",
+									"Bladder infection",
+									"Bladder perforation",
+									"Bladder spasm",
+									"Bloating",
+									"Blood and lymphatic system disorders - Other, specify",
+									"Blood antidiuretic hormone abnormal",
+									"Blood bicarbonate decreased",
+									"Blood bilirubin increased",
+									"Blood corticotrophin decreased",
+									"Blood gonadotrophin abnormal",
+									"Blood lactate dehydrogenase increased",
+									"Blood prolactin abnormal",
+									"Blurred vision",
+									"Body odor",
+									"Bone infection",
+									"Bone marrow hypocellular",
+									"Bone pain",
+									"Brachial plexopathy",
+									"Breast atrophy",
+									"Breast infection",
+									"Breast pain",
+									"Bronchial fistula",
+									"Bronchial infection",
+									"Bronchial obstruction",
+									"Bronchial stricture",
+									"Bronchopleural fistula",
+									"Bronchopulmonary hemorrhage",
+									"Bronchospasm",
+									"Bruising",
+									"Budd-Chiari syndrome",
+									"Bullous dermatitis",
+									"Burn",
+									"Buttock pain",
+									"Capillary leak syndrome",
+									"Carbon monoxide diffusing capacity decreased",
+									"Cardiac arrest",
+									"Cardiac disorders - Other, specify",
+									"Cardiac troponin I increased",
+									"Cardiac troponin T increased",
+									"Cataract",
+									"Catheter related infection",
+									"CD4 lymphocytes decreased",
+									"Cecal hemorrhage",
+									"Cecal infection",
+									"Central nervous system necrosis",
+									"Cerebrospinal fluid leakage",
+									"Cervicitis infection",
+									"Cheilitis",
+									"Chest pain - cardiac",
+									"Chest wall necrosis",
+									"Chest wall pain",
+									"Chills",
+									"Cholecystitis",
+									"Cholesterol high",
+									"Chronic kidney disease",
+									"Chylothorax",
+									"Chylous ascites",
+									"Cognitive disturbance",
+									"Colitis",
+									"Colonic fistula",
+									"Colonic hemorrhage",
+									"Colonic obstruction",
+									"Colonic perforation",
+									"Colonic stenosis",
+									"Colonic ulcer",
+									"Concentration impairment",
+									"Conduction disorder",
+									"Confusion",
+									"Congenital, familial and genetic disorders - Other, specify",
+									"Conjunctivitis",
+									"Conjunctivitis infective",
+									"Constipation",
+									"Corneal infection",
+									"Corneal ulcer",
+									"Cough",
+									"CPK increased",
+									"Cranial nerve infection",
+									"Creatinine increased",
+									"Cushingoid",
+									"Cyanosis",
+									"Cystitis noninfective",
+									"Cytokine release syndrome",
+									"Cytomegalovirus infection reactivation",
+									"Death neonatal",
+									"Death NOS",
+									"Dehydration",
+									"Delayed orgasm",
+									"Delayed puberty",
+									"Delirium",
+									"Delusions",
+									"Dental caries",
+									"Depressed level of consciousness",
+									"Depression",
+									"Dermatitis radiation",
+									"Device related infection",
+									"Diarrhea",
+									"Disease progression",
+									"Disseminated intravascular coagulation",
+									"Dizziness",
+									"Dry eye",
+									"Dry mouth",
+									"Dry skin",
+									"Duodenal fistula",
+									"Duodenal hemorrhage",
+									"Duodenal infection",
+									"Duodenal obstruction",
+									"Duodenal perforation",
+									"Duodenal stenosis",
+									"Duodenal ulcer",
+									"Dysarthria",
+									"Dysesthesia",
+									"Dysgeusia",
+									"Dysmenorrhea",
+									"Dyspareunia",
+									"Dyspepsia",
+									"Dysphagia",
+									"Dysphasia",
+									"Dyspnea",
+									"Dysuria",
+									"Ear and labyrinth disorders - Other, specify",
+									"Ear pain",
+									"Eczema",
+									"Edema cerebral",
+									"Edema face",
+									"Edema limbs",
+									"Edema trunk",
+									"Ejaculation disorder",
+									"Ejection fraction decreased",
+									"Electrocardiogram QT corrected interval prolonged",
+									"Electrocardiogram T wave abnormal",
+									"Encephalitis infection",
+									"Encephalomyelitis infection",
+									"Encephalopathy",
+									"Endocarditis infective",
+									"Endocrine disorders - Other, specify",
+									"Endophthalmitis",
+									"Enterocolitis",
+									"Enterocolitis infectious",
+									"Enterovesical fistula",
+									"Eosinophilia",
+									"Epistaxis",
+									"Epstein-Barr virus infection reactivation",
+									"Erectile dysfunction",
+									"Erythema multiforme",
+									"Erythroderma",
+									"Esophageal anastomotic leak",
+									"Esophageal fistula",
+									"Esophageal hemorrhage",
+									"Esophageal infection",
+									"Esophageal necrosis",
+									"Esophageal obstruction",
+									"Esophageal pain",
+									"Esophageal perforation",
+									"Esophageal stenosis",
+									"Esophageal ulcer",
+									"Esophageal varices hemorrhage",
+									"Esophagitis",
+									"Euphoria",
+									"Exostosis",
+									"External ear pain",
+									"Extraocular muscle paresis",
+									"Extrapyramidal disorder",
+									"Eye disorders - Other, specify",
+									"Eye infection",
+									"Eye pain",
+									"Eyelid function disorder",
+									"Facial muscle weakness",
+									"Facial nerve disorder",
+									"Facial pain",
+									"Fall",
+									"Fallopian tube anastomotic leak",
+									"Fallopian tube obstruction",
+									"Fallopian tube perforation",
+									"Fat atrophy",
+									"Fatigue",
+									"Febrile neutropenia",
+									"Fecal incontinence",
+									"Feminization acquired",
+									"Fetal growth retardation",
+									"Fever",
+									"Fibrinogen decreased",
+									"Fibrosis deep connective tissue",
+									"Flank pain",
+									"Flashing lights",
+									"Flatulence",
+									"Floaters",
+									"Flu like symptoms",
+									"Flushing",
+									"Folliculitis",
+									"Forced expiratory volume decreased",
+									"Fracture",
+									"Fungemia",
+									"Gait disturbance",
+									"Gallbladder fistula",
+									"Gallbladder infection",
+									"Gallbladder necrosis",
+									"Gallbladder obstruction",
+									"Gallbladder pain",
+									"Gallbladder perforation",
+									"Gastric anastomotic leak",
+									"Gastric fistula",
+									"Gastric hemorrhage",
+									"Gastric necrosis",
+									"Gastric perforation",
+									"Gastric stenosis",
+									"Gastric ulcer",
+									"Gastritis",
+									"Gastroesophageal reflux disease",
+									"Gastrointestinal anastomotic leak",
+									"Gastrointestinal disorders - Other, specify",
+									"Gastrointestinal fistula",
+									"Gastrointestinal pain",
+									"Gastrointestinal stoma necrosis",
+									"Gastroparesis",
+									"General disorders and administration site conditions - Other, specify",
+									"Generalized edema",
+									"Generalized muscle weakness",
+									"Genital edema",
+									"GGT increased",
+									"Gingival pain",
+									"Glaucoma",
+									"Glossopharyngeal nerve disorder",
+									"Glucose intolerance",
+									"Glucosuria",
+									"Growth accelerated",
+									"Growth hormone abnormal",
+									"Growth suppression",
+									"Guillain-Barre syndrome",
+									"Gum infection",
+									"Gynecomastia",
+									"Hair color changes",
+									"Hair texture abnormal",
+									"Hallucinations",
+									"Haptoglobin decreased",
+									"Head soft tissue necrosis",
+									"Headache",
+									"Hearing impaired",
+									"Heart failure",
+									"Hematoma",
+									"Hematosalpinx",
+									"Hematuria",
+									"Hemoglobin increased",
+									"Hemoglobinuria",
+									"Hemolysis",
+									"Hemolytic uremic syndrome",
+									"Hemorrhoidal hemorrhage",
+									"Hemorrhoids",
+									"Hepatic failure",
+									"Hepatic hemorrhage",
+									"Hepatic infection",
+									"Hepatic necrosis",
+									"Hepatic pain",
+									"Hepatitis B reactivation",
+									"Hepatitis viral",
+									"Hepatobiliary disorders - Other, specify",
+									"Herpes simplex reactivation",
+									"Hiccups",
+									"Hip fracture",
+									"Hirsutism",
+									"Hoarseness",
+									"Hot flashes",
+									"Hydrocephalus",
+									"Hypercalcemia",
+									"Hyperglycemia",
+									"Hyperhidrosis",
+									"Hyperkalemia",
+									"Hyperkeratosis",
+									"Hyperlipidemia",
+									"Hypermagnesemia",
+									"Hypernatremia",
+									"Hyperparathyroidism",
+									"Hyperphosphatemia",
+									"Hypersomnia",
+									"Hypertension",
+									"Hyperthyroidism",
+									"Hypertrichosis",
+									"Hypertriglyceridemia",
+									"Hyperuricemia",
+									"Hypoalbuminemia",
+									"Hypocalcemia",
+									"Hypoglossal nerve disorder",
+									"Hypoglycemia",
+									"Hypohidrosis",
+									"Hypokalemia",
+									"Hypomagnesemia",
+									"Hyponatremia",
+									"Hypoparathyroidism",
+									"Hypophosphatemia",
+									"Hypophysitis",
+									"Hypopituitarism",
+									"Hypotension",
+									"Hypothermia",
+									"Hypothyroidism",
+									"Hypoxia",
+									"Ileal fistula",
+									"Ileal hemorrhage",
+									"Ileal obstruction",
+									"Ileal perforation",
+									"Ileal stenosis",
+									"Ileal ulcer",
+									"Ileus",
+									"Immune system disorders - Other, specify",
+									"Infections and infestations - Other, specify",
+									"Infective myositis",
+									"Infusion related reaction",
+									"Infusion site extravasation",
+									"Injection site reaction",
+									"Injury to carotid artery",
+									"Injury to inferior vena cava",
+									"Injury to jugular vein",
+									"Injury to superior vena cava",
+									"Injury, poisoning and procedural complications - Other, specify",
+									"INR increased",
+									"Insomnia",
+									"Intestinal stoma leak",
+									"Intestinal stoma obstruction",
+									"Intestinal stoma site bleeding",
+									"Intra-abdominal hemorrhage",
+									"Intracranial hemorrhage",
+									"Intraoperative arterial injury",
+									"Intraoperative breast injury",
+									"Intraoperative cardiac injury",
+									"Intraoperative ear injury",
+									"Intraoperative endocrine injury",
+									"Intraoperative gastrointestinal injury",
+									"Intraoperative head and neck injury",
+									"Intraoperative hemorrhage",
+									"Intraoperative hepatobiliary injury",
+									"Intraoperative musculoskeletal injury",
+									"Intraoperative neurological injury",
+									"Intraoperative ocular injury",
+									"Intraoperative renal injury",
+									"Intraoperative reproductive tract injury",
+									"Intraoperative respiratory injury",
+									"Intraoperative splenic injury",
+									"Intraoperative urinary injury",
+									"Intraoperative venous injury",
+									"Investigations - Other, specify",
+									"Iron overload",
+									"Irregular menstruation",
+									"Irritability",
+									"Ischemia cerebrovascular",
+									"Jejunal fistula",
+									"Jejunal hemorrhage",
+									"Jejunal obstruction",
+									"Jejunal perforation",
+									"Jejunal stenosis",
+									"Jejunal ulcer",
+									"Joint effusion",
+									"Joint infection",
+									"Joint range of motion decreased",
+									"Joint range of motion decreased cervical spine",
+									"Joint range of motion decreased lumbar spine",
+									"Keratitis",
+									"Kidney anastomotic leak",
+									"Kidney infection",
+									"Kyphosis",
+									"Lactation disorder",
+									"Large intestinal anastomotic leak",
+									"Laryngeal edema",
+									"Laryngeal fistula",
+									"Laryngeal hemorrhage",
+									"Laryngeal inflammation",
+									"Laryngeal mucositis",
+									"Laryngeal obstruction",
+									"Laryngeal stenosis",
+									"Laryngitis",
+									"Laryngopharyngeal dysesthesia",
+									"Laryngospasm",
+									"Left ventricular systolic dysfunction",
+									"Lethargy",
+									"Leukemia secondary to oncology chemotherapy",
+									"Leukocytosis",
+									"Leukoencephalopathy",
+									"Libido decreased",
+									"Libido increased",
+									"Lip infection",
+									"Lip pain",
+									"Lipase increased",
+									"Lipohypertrophy",
+									"Localized edema",
+									"Lordosis",
+									"Lower gastrointestinal hemorrhage",
+									"Lung infection",
+									"Lymph gland infection",
+									"Lymph leakage",
+									"Lymph node pain",
+									"Lymphedema",
+									"Lymphocele",
+									"Lymphocyte count decreased",
+									"Lymphocyte count increased",
+									"Malabsorption",
+									"Malaise",
+									"Mania",
+									"Mediastinal hemorrhage",
+									"Mediastinal infection",
+									"Memory impairment",
+									"Meningismus",
+									"Meningitis",
+									"Menorrhagia",
+									"Metabolism and nutrition disorders - Other, specify",
+									"Methemoglobinemia",
+									"Middle ear inflammation",
+									"Mitral valve disease",
+									"Mobitz (type) II atrioventricular block",
+									"Mobitz type I",
+									"Movements involuntary",
+									"Mucosal infection",
+									"Mucositis oral",
+									"Multi-organ failure",
+									"Muscle cramp",
+									"Muscle weakness left-sided",
+									"Muscle weakness lower limb",
+									"Muscle weakness right-sided",
+									"Muscle weakness trunk",
+									"Muscle weakness upper limb",
+									"Musculoskeletal and connective tissue disorder - Other, specify",
+									"Musculoskeletal deformity",
+									"Myalgia",
+									"Myasthenia gravis",
+									"Myelitis",
+									"Myelodysplastic syndrome",
+									"Myocardial infarction",
+									"Myocarditis",
+									"Myositis",
+									"Nail changes",
+									"Nail discoloration",
+									"Nail infection",
+									"Nail loss",
+									"Nail ridging",
+									"Nasal congestion",
+									"Nausea",
+									"Neck edema",
+									"Neck pain",
+									"Neck soft tissue necrosis",
+									"Neoplasms benign, malignant and unspecified (incl cysts and polyps) - Other, specify",
+									"Nephrotic syndrome",
+									"Nervous system disorders - Other, specify",
+									"Neuralgia",
+									"Neutrophil count decreased",
+									"Night blindness",
+									"Nipple deformity",
+									"Non-cardiac chest pain",
+									"Nystagmus",
+									"Obesity",
+									"Obstruction gastric",
+									"Oculomotor nerve disorder",
+									"Olfactory nerve disorder",
+									"Oligospermia",
+									"Optic nerve disorder",
+									"Oral cavity fistula",
+									"Oral dysesthesia",
+									"Oral hemorrhage",
+									"Oral pain",
+									"Oropharyngeal pain",
+									"Osteonecrosis",
+									"Osteonecrosis of jaw",
+									"Osteoporosis",
+									"Otitis externa",
+									"Otitis media",
+									"Ovarian hemorrhage",
+									"Ovarian infection",
+									"Ovarian rupture",
+									"Ovulation pain",
+									"Pain",
+									"Pain in extremity",
+									"Pain of skin",
+									"Palmar-plantar erythrodysesthesia syndrome",
+									"Palpitations",
+									"Pancreas infection",
+									"Pancreatic anastomotic leak",
+									"Pancreatic duct stenosis",
+									"Pancreatic enzymes decreased",
+									"Pancreatic fistula",
+									"Pancreatic hemorrhage",
+									"Pancreatic necrosis",
+									"Pancreatitis",
+									"Papilledema",
+									"Papulopustular rash",
+									"Paresthesia",
+									"Paronychia",
+									"Paroxysmal atrial tachycardia",
+									"Pelvic floor muscle weakness",
+									"Pelvic infection",
+									"Pelvic pain",
+									"Pelvic soft tissue necrosis",
+									"Penile infection",
+									"Penile pain",
+									"Perforation bile duct",
+									"Pericardial effusion",
+									"Pericardial tamponade",
+									"Pericarditis",
+									"Perineal pain",
+									"Periodontal disease",
+									"Periorbital edema",
+									"Periorbital infection",
+									"Peripheral ischemia",
+									"Peripheral motor neuropathy",
+									"Peripheral nerve infection",
+									"Peripheral sensory neuropathy",
+									"Peritoneal infection",
+									"Peritoneal necrosis",
+									"Personality change",
+									"Phantom pain",
+									"Pharyngeal anastomotic leak",
+									"Pharyngeal fistula",
+									"Pharyngeal hemorrhage",
+									"Pharyngeal mucositis",
+									"Pharyngeal necrosis",
+									"Pharyngeal stenosis",
+									"Pharyngitis",
+									"Pharyngolaryngeal pain",
+									"Phlebitis",
+									"Phlebitis infective",
+									"Photophobia",
+									"Photosensitivity",
+									"Platelet count decreased",
+									"Pleural effusion",
+									"Pleural hemorrhage",
+									"Pleural infection",
+									"Pleuritic pain",
+									"Pneumonitis",
+									"Pneumothorax",
+									"Portal hypertension",
+									"Portal vein thrombosis",
+									"Postnasal drip",
+									"Postoperative hemorrhage",
+									"Postoperative thoracic procedure complication",
+									"Precocious puberty",
+									"Pregnancy loss",
+									"Pregnancy, puerperium and perinatal conditions - Other, specify",
+									"Premature delivery",
+									"Premature menopause",
+									"Presyncope",
+									"Proctitis",
+									"Productive cough",
+									"Prolapse of intestinal stoma",
+									"Prolapse of urostomy",
+									"Prostate infection",
+									"Prostatic hemorrhage",
+									"Prostatic obstruction",
+									"Prostatic pain",
+									"Proteinuria",
+									"Pruritus",
+									"Psychiatric disorders - Other, specify",
+									"Psychosis",
+									"Pulmonary edema",
+									"Pulmonary fibrosis",
+									"Pulmonary fistula",
+									"Pulmonary hypertension",
+									"Pulmonary valve disease",
+									"Purpura",
+									"Pyramidal tract syndrome",
+									"Radiation recall reaction (dermatologic)",
+									"Radiculitis",
+									"Rash acneiform",
+									"Rash maculo-papular",
+									"Rash pustular",
+									"Rectal anastomotic leak",
+									"Rectal fissure",
+									"Rectal fistula",
+									"Rectal hemorrhage",
+									"Rectal mucositis",
+									"Rectal necrosis",
+									"Rectal obstruction",
+									"Rectal pain",
+									"Rectal perforation",
+									"Rectal stenosis",
+									"Rectal ulcer",
+									"Recurrent laryngeal nerve palsy",
+									"Renal and urinary disorders - Other, specify",
+									"Renal calculi",
+									"Renal colic",
+									"Renal hemorrhage",
+									"Reproductive system and breast disorders - Other, specify",
+									"Respiratory failure",
+									"Respiratory, thoracic and mediastinal disorders - Other, specify",
+									"Restlessness",
+									"Restrictive cardiomyopathy",
+									"Retinal detachment",
+									"Retinal tear",
+									"Retinal vascular disorder",
+									"Retinoic acid syndrome",
+									"Retinopathy",
+									"Retroperitoneal hemorrhage",
+									"Reversible posterior leukoencephalopathy syndrome",
+									"Rhabdomyolysis",
+									"Rhinitis infective",
+									"Rhinorrhea",
+									"Right ventricular dysfunction",
+									"Rotator cuff injury",
+									"Salivary duct inflammation",
+									"Salivary gland fistula",
+									"Salivary gland infection",
+									"Scalp pain",
+									"Scleral disorder",
+									"Scoliosis",
+									"Scrotal infection",
+									"Scrotal pain",
+									"Seizure",
+									"Sepsis",
+									"Seroma",
+									"Serum amylase increased",
+									"Serum sickness",
+									"Shingles",
+									"Sick sinus syndrome",
+									"Sinus bradycardia",
+									"Sinus disorder",
+									"Sinus pain",
+									"Sinus tachycardia",
+									"Sinusitis",
+									"Sinusoidal obstruction syndrome",
+									"Skin and subcutaneous tissue disorders - Other, specify",
+									"Skin atrophy",
+									"Skin hyperpigmentation",
+									"Skin hypopigmentation",
+									"Skin induration",
+									"Skin infection",
+									"Skin papilloma",
+									"Skin ulceration",
+									"Sleep apnea",
+									"Small intestinal anastomotic leak",
+									"Small intestinal mucositis",
+									"Small intestinal obstruction",
+									"Small intestinal perforation",
+									"Small intestinal stenosis",
+									"Small intestine infection",
+									"Small intestine ulcer",
+									"Sneezing",
+									"Social circumstances - Other, specify",
+									"Soft tissue infection",
+									"Soft tissue necrosis lower limb",
+									"Soft tissue necrosis upper limb",
+									"Somnolence",
+									"Sore throat",
+									"Spasticity",
+									"Spermatic cord anastomotic leak",
+									"Spermatic cord hemorrhage",
+									"Spermatic cord obstruction",
+									"Spinal cord compression",
+									"Spinal fracture",
+									"Splenic infection",
+									"Stenosis of gastrointestinal stoma",
+									"Stevens-Johnson syndrome",
+									"Stoma site infection",
+									"Stomach pain",
+									"Stomal ulcer",
+									"Stridor",
+									"Stroke",
+									"Subcutaneous emphysema",
+									"Sudden death NOS",
+									"Suicidal ideation",
+									"Suicide attempt",
+									"Superficial soft tissue fibrosis",
+									"Superficial thrombophlebitis",
+									"Superior vena cava syndrome",
+									"Supraventricular tachycardia",
+									"Surgical and medical procedures - Other, specify",
+									"Syncope",
+									"Telangiectasia",
+									"Tendon reflex decreased",
+									"Testicular disorder",
+									"Testicular hemorrhage",
+									"Testicular pain",
+									"Testosterone deficiency",
+									"Thromboembolic event",
+									"Thrombotic thrombocytopenic purpura",
+									"Thrush",
+									"Thyroid stimulating hormone increased",
+									"Tinnitus",
+									"Tooth development disorder",
+									"Tooth discoloration",
+									"Tooth infection",
+									"Toothache",
+									"Toxic epidermal necrolysis",
+									"Tracheal fistula",
+									"Tracheal hemorrhage",
+									"Tracheal mucositis",
+									"Tracheal obstruction",
+									"Tracheal stenosis",
+									"Tracheitis",
+									"Tracheostomy site bleeding",
+									"Transient ischemic attacks",
+									"Treatment related secondary malignancy",
+									"Tremor",
+									"Tricuspid valve disease",
+									"Trigeminal nerve disorder",
+									"Trismus",
+									"Trochlear nerve disorder",
+									"Tumor hemorrhage",
+									"Tumor lysis syndrome",
+									"Tumor pain",
+									"Typhlitis",
+									"Unequal limb length",
+									"Upper gastrointestinal hemorrhage",
+									"Upper respiratory infection",
+									"Ureteric anastomotic leak",
+									"Urethral anastomotic leak",
+									"Urethral infection",
+									"Urinary fistula",
+									"Urinary frequency",
+									"Urinary incontinence",
+									"Urinary retention",
+									"Urinary tract infection",
+									"Urinary tract obstruction",
+									"Urinary tract pain",
+									"Urinary urgency",
+									"Urine discoloration",
+									"Urine output decreased",
+									"Urostomy leak",
+									"Urostomy obstruction",
+									"Urostomy site bleeding",
+									"Urostomy stenosis",
+									"Urticaria",
+									"Uterine anastomotic leak",
+									"Uterine fistula",
+									"Uterine hemorrhage",
+									"Uterine infection",
+									"Uterine obstruction",
+									"Uterine pain",
+									"Uterine perforation",
+									"Uveitis",
+									"Vaccination complication",
+									"Vaccination site lymphadenopathy",
+									"Vaginal anastomotic leak",
+									"Vaginal discharge",
+									"Vaginal dryness",
+									"Vaginal fistula",
+									"Vaginal hemorrhage",
+									"Vaginal infection",
+									"Vaginal inflammation",
+									"Vaginal obstruction",
+									"Vaginal pain",
+									"Vaginal perforation",
+									"Vaginal stricture",
+									"Vagus nerve disorder",
+									"Vas deferens anastomotic leak",
+									"Vascular access complication",
+									"Vascular disorders - Other, specify",
+									"Vasculitis",
+									"Vasovagal reaction",
+									"Venous injury",
+									"Ventricular arrhythmia",
+									"Ventricular fibrillation",
+									"Ventricular tachycardia",
+									"Vertigo",
+									"Vestibular disorder",
+									"Viremia",
+									"Virilization",
+									"Visceral arterial ischemia",
+									"Vision decreased",
+									"Vital capacity abnormal",
+									"Vitreous hemorrhage",
+									"Voice alteration",
+									"Vomiting",
+									"Vulval infection",
+									"Watering eyes",
+									"Weight gain",
+									"Weight loss",
+									"Wheezing",
+									"White blood cell decreased",
+									"Wound complication",
+									"Wound dehiscence",
+									"Wound infection",
+									"Wrist fracture"
+								]
+							},
+							"meta": {
+								"displayName": "Adverse Events",
+								"notes": "To include multiple values, separate values with a pipe delimiter '|' within your file."
+							}
+						},
+						{
+							"name": "clinical_trials_database",
+							"description": "If the donor is a participant in a clinical trial, indicate the clinical trial database where the clinical trial is registered.",
+							"valueType": "string",
+							"meta": {
+								"display name": "Clinical Trials Database"
+							},
+							"restrictions": {
+								"codeList": ["NCI Clinical Trials", "EU Clinical Trials Register"]
+							}
+						},
+						{
+							"name": "clinical_trial_number",
+							"description": "Based on the clinical_trial_database, indicate the unique NCT or EudraCT clinical trial identifier of which the donor is a participant.",
+							"valueType": "string",
+							"meta": {
+								"display name": "Clinical Trial Number",
+								"dependsOn": "treatment.clinical_trials_database",
+								"examples": "2016-002120-83,NCT02465060"
+							},
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n      // checks for a string just consisting of whitespace\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      \n      //regex check for clinical trial number\n      const NCTCheck = (entry) => {return /(^([Nn][Cc][Tt])[0-9]{8})/.test(decodeURI(entry))};\n      const EudraCTCheck = (entry) => {return /(^[2][0-9]{3}-[0-9]{6}-[0-9]{2})/.test(decodeURI(entry))};\n\n      // list of valid clinical trial databases\n      const clinical_dbs = [\"nci clinical trials\", \"eu clinical trials register\"];\n      \n      if ($row.clinical_trials_database && $field) {\n          const trialNumber = $field.trim();\n          const clinicalTrialsDB = $row.clinical_trials_database.trim().toLowerCase();\n          if ((clinicalTrialsDB === \"nci clinical trials\") && (!NCTCheck(trialNumber))) {\n            result = {valid: false, message: 'The submitted NCI clinical trial number is in incorrect format.'};\n          }\n          else if ((clinicalTrialsDB === \"eu clinical trials register\") && (!EudraCTCheck(trialNumber))) {\n            result = {valid: false, message: \"The submitted EudraCT clinical trial number is in incorrect format.\"};\n          }\n          else if (!clinical_dbs.includes(clinicalTrialsDB)) {\n            result = {valid: false, message: \"The submitted clinical trials database '${$row.clinical_trials_database}' is not included in the list of clinical trial database.\"};\n          }\n      }\n      else if ((!$row.clinical_trials_database || checkforEmpty($row.clnical_trials_database)) && (!$field || checkforEmpty($field))) {\n          result = {valid: true, message: \"Ok\"};\n      }\n      else if ($row.clinical_trials_database && !$field) {\n          if (clinical_dbs.includes($row.clinical_trials_database.trim().toLowerCase())) {\n            result = {valid: false, message: \"'${$name}' must be provided if 'clinical_trial_database' is set to '${$row.clinical_trials_database}'.\"};\n          } \n      }\n      return result;\n    })"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "chemotherapy",
+					"description": "The collection of data elements describing the details of a chemotherapy treatment regimen completed by a donor. To submit multiple treatment drugs for a single regimen, submit multiple rows in the chemotherapy file.",
+					"meta": {
+						"parent": "treatment"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_treatment_id",
+							"valueType": "string",
+							"description": "Unique identifier of the treatment, as assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "treatment.submitter_treatment_id",
+								"displayName": "Submitter Treatment ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "drug_rxnormcui",
+							"description": "The unique RxNormID assigned to the treatment regimen drug.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
+								"displayName": "RxNormCUI"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "drug_name",
+							"description": "Name of agent or drug administered to patient as part of the treatment regimen.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
+								"displayName": "Chemotherapy Drug Name"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "chemotherapy_dosage_units",
+							"description": "Indicate units used to record chemotherapy drug dosage.",
+							"valueType": "string",
+							"restrictions": {
+								"required": true,
+								"codeList": ["mg/m2", "IU/m2", "ug/m2", "g/m2", "mg/kg"]
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Chemotherapy Dosage Units"
+							}
+						},
+						{
+							"name": "cumulative_drug_dosage",
+							"description": "Indicate the total actual drug dose in the same units specified in chemotherapy_dosage_units.",
+							"valueType": "number",
+							"restrictions": {
+								"required": true
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Cumulative Drug Dosage"
+							}
+						}
+					]
+				},
+				{
+					"name": "hormone_therapy",
+					"description": "The collection of data elements describing the details of a hormone treatment therapy completed by a donor. To submit multiple treatment drugs for a single regimen, submit multiple rows in the hormone_therapy file.",
+					"meta": {
+						"parent": "treatment"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_treatment_id",
+							"valueType": "string",
+							"description": "Unique identifier of the treatment, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "treatment.submitter_treatment_id",
+								"displayName": "Submitter Treatment ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "drug_rxnormcui",
+							"description": "The unique RxNormID assigned to the treatment regimen drug.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
+								"displayName": "RxNormCUI"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "drug_name",
+							"description": "Name of agent or drug administered to patient as part of the treatment regimen.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
+								"displayName": "Hormone Therapy Drug Name"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "hormone_drug_dosage_units",
+							"description": "Indicate the units used to record hormone drug dosage.",
+							"valueType": "string",
+							"restrictions": {
+								"required": true,
+								"codeList": ["mg/m2", "IU/m2", "ug/m2", "g/m2", "mg/kg"]
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Hormone Therapy Dosage Units"
+							}
+						},
+						{
+							"name": "cumulative_drug_dosage",
+							"description": "Indicate total drug dose in units specified in hormone_drug_dosage_units.",
+							"valueType": "number",
+							"restrictions": {
+								"required": true
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Cumulative Drug Dosage"
+							}
+						}
+					]
+				},
+				{
+					"name": "radiation",
+					"description": "The collection of data elements describing the details of a radiation treatment completed by a donor.",
+					"meta": {
+						"parent": "treatment"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_treatment_id",
+							"valueType": "string",
+							"description": "Unique identifier of the treatment, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "treatment.submitter_treatment_id",
+								"displayName": "Submitter Treatment ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "radiation_therapy_modality",
+							"description": "Indicate the method of radiation treatment or modality.",
+							"valueType": "string",
+							"restrictions": {
+								"required": true,
+								"codeList": ["Electron", "Heavy Ions", "Photon", "Proton"]
+							},
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"displayName": "Radiation Therapy Modality"
+							}
+						},
+						{
+							"name": "radiation_therapy_type",
+							"description": "Indicate type of radiation therapy administered.",
+							"valueType": "string",
+							"restrictions": {
+								"required": true,
+								"codeList": ["External", "Internal"]
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Type of Radiation Therapy",
+								"notes": "Internal application includes Brachytherapy."
+							}
+						},
+						{
+							"name": "radiation_therapy_fractions",
+							"description": "Indicate the total number of fractions delivered as part of treatment.",
+							"valueType": "integer",
+							"restrictions": {
+								"required": true
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Radiation Therapy Fractions"
+							}
+						},
+						{
+							"name": "radiation_therapy_dosage",
+							"description": "Indicate the total dose given in units of Gray (Gy).",
+							"valueType": "integer",
+							"restrictions": {
+								"required": true
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Radiation Therapy Dosage"
+							}
+						},
+						{
+							"name": "anatomical_site_irradiated",
+							"description": "Indicate localization site where radiation therapy was administered.",
+							"valueType": "string",
+							"restrictions": {
+								"required": true,
+								"codeList": [
+									"Abdomen",
+									"Bone",
+									"Brain",
+									"Extremities",
+									"Head",
+									"Head-Neck",
+									"Liver",
+									"Lung",
+									"Pelvis",
+									"Peritoneum",
+									"Spine",
+									"Thorax"
+								]
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Anatomical Site Irradiated"
+							}
+						},
+						{
+							"name": "radiation_boost",
+							"description": "A radiation boost is an extra radiation treatment targeted at the tumor bed, given after the regular sessions of radiation is complete (Reference NCIt: C137812). Indicate if this radiation treatment was a radiation boost.",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": ["Yes", "No"]
+							},
+							"meta": {
+								"displayName": "Radiation Boost"
+							}
+						},
+						{
+							"name": "reference_radiation_treatment_id",
+							"description": "If a radiation boost was given, indicate the 'submitter_treatment_id' of the primary radiation treatment the radiation boost treatment is linked to.",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": ["Yes", "No"]
+							},
+							"meta": {
+								"displayName": "Reference Radiation Treatment for Boost"
+							}
+						}
+					]
+				},
+				{
+					"name": "immunotherapy",
+					"description": "The collection of data elements describing the details of an immunotherapy treatment completed by a donor.",
+					"meta": {
+						"parent": "treatment"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_treatment_id",
+							"valueType": "string",
+							"description": "Unique identifier of the treatment, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "treatment.submitter_treatment_id",
+								"displayName": "Submitter Treatment ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "immunotherapy_type",
+							"valueType": "string",
+							"description": "Indicate the type of immunotherapy administered to patient.",
+							"meta": {
+								"displayName": "Immunotherapy Type"
+							},
+							"restrictions": {
+								"codeList": [
+									"Cell-based",
+									"Immune checkpoint inhibitors",
+									"Monoclonal antibodies other than immune checkpoint inhibitors",
+									"Other immunomodulatory substances"
+								]
+							}
+						},
+						{
+							"name": "drug_rxnormcui",
+							"description": "The unique RxNormID assigned to the treatment regimen drug.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
+								"displayName": "RxNormCUI"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "drug_name",
+							"description": "Name of agent or drug administered to patient as part of the treatment regimen.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"core": true,
+								"notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
+								"displayName": "Immunotherapy Drug Name"
+							},
+							"restrictions": {
+								"required": true
+							}
+						}
+					]
+				},
+				{
+					"name": "follow_up",
+					"description": "The collection of data elements related to a specific follow-up visit to a donor. A follow-up is defined as any point of contact with a patient after primary diagnosis. To submit multiple follow-ups for a single donor, please submit multiple rows in the follow-up file for this donor.",
+					"meta": {
+						"parent": "donor"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"description": "Unique identifier for a follow-up event in a donor's clinical record, assigned by the data provider.",
+							"name": "submitter_follow_up_id",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"displayName": "Submitter Follow-Up ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"description": "Interval from the primary diagnosis date to the follow-up date, in days.",
+							"name": "interval_of_followup",
+							"valueType": "integer",
+							"restrictions": {
+								"required": true
+							},
+							"meta": {
+								"core": true,
+								"units": "days",
+								"displayName": "Interval Of Follow-Up",
+								"notes": "The associated primary diagnosis is used as the reference point for this interval. To calculate this, find the number of days since the date of primary diagnosis."
+							}
+						},
+						{
+							"description": "Indicate the donor's disease status at time of follow-up. (Reference: RECIST)",
+							"name": "disease_status_at_followup",
+							"valueType": "string",
+							"restrictions": {
+								"required": true,
+								"codeList": [
+									"Complete remission",
+									"Distant progression",
+									"Loco-regional progression",
+									"No evidence of disease",
+									"Partial remission",
+									"Progression NOS",
+									"Relapse or recurrence",
+									"Stable"
+								]
+							},
+							"meta": {
+								"core": true,
+								"displayName": "Disease Status at Follow-Up"
+							}
+						},
+						{
+							"name": "submitter_primary_diagnosis_id",
+							"valueType": "string",
+							"description": "Indicate if the follow-up is related to a specific primary diagnosis event in the clinical timeline.",
+							"meta": {
+								"displayName": "Submitter Primary Diagnosis ID",
+								"primaryId": true
+							},
+							"restrictions": {
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_treatment_id",
+							"valueType": "string",
+							"description": "Indicate if the follow-up is related to a specific treatment event in the clinical timeline.",
+							"meta": {
+								"primaryId": true,
+								"displayName": "Submitter Treatment ID"
+							},
+							"restrictions": {
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"description": "Indicate the donor's weight, in kilograms (kg), at the time of follow-up.",
+							"name": "weight_at_followup",
+							"valueType": "integer",
+							"restrictions": {},
+							"meta": {
+								"displayName": "Weight at Follow-Up"
+							}
+						},
+						{
+							"description": "Indicate the donor's relapse type.",
+							"name": "relapse_type",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Distant recurrence/metastasis",
+									"Local recurrence",
+									"Local recurrence and distant metastasis",
+									"Progression (liquid tumours)"
+								],
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        \n        /* required field, cannot be null */\n        const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();\n    \n        const stateOfProgression = (entry) => {return /(progression)$/.test(decodeURI(entry))}; \n        const relapseOrRecurrence = diseaseStatus === \"relapse or recurrence\";\n   \n        // checks for a string just consisting of whitespace\n        const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n\n\n        if ((!$field || checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set a state of progression, relapse, or recurrence.` }\n        }\n        else if (!(!$field || checkforEmpty($field)) && !stateOfProgression(diseaseStatus) && !relapseOrRecurrence) {\n            result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not a state of progression, relapse, or recurrence.` }\n        }\n        return  result;\n    })"
+								]
+							},
+							"meta": {
+								"core": true,
+								"dependsOn": "follow_up.disease_status_at_followup",
+								"notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.",
+								"displayName": "Relapse Type"
+							}
+						},
+						{
+							"description": "If the donor was clinically disease free following primary treatment and then relapse or recurrence or progression (for liquid tumours) occurred afterwards, then this field will indicate the length of disease free interval, in days.",
+							"name": "relapse_interval",
+							"valueType": "integer",
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n      \n      /* required field, cannot be null */\n      const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();\n      const intervalOfFollowup = parseInt($row.interval_of_followup);\n\n      const stateOfProgression = (entry) => {return /(progression)$/.test(decodeURI(entry))}; \n      const relapseOrRecurrence = diseaseStatus === \"relapse or recurrence\";\n  \n      // checks for a string just consisting of whitespace\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n\n\n      if ((!$field || checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n          result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set a state of progression, relapse, or recurrence.` }\n      }\n      else if (!(!$field || checkforEmpty($field)) && !stateOfProgression(diseaseStatus) && !relapseOrRecurrence) {\n          result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not a state of progression, relapse, or recurrence.` }\n      }\n      else if (!(checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n          relapseInterval = parseInt($field);\n          if (relapseInterval > intervalOfFollowup) {\n              result = {valid: false, message: `'${$name}' cannot be greater than the 'interval_of_followup'.` }\n          }\n      }\n      return  result;\n    })"
+								]
+							},
+							"meta": {
+								"core": true,
+								"units": "days",
+								"dependsOn": "follow_up.disease_status_at_followup",
+								"notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.",
+								"displayName": "Relapse Interval"
+							}
+						},
+						{
+							"description": "Indicate the method(s) used to confirm the donor's progression or relapse or recurrence disease status. (Reference: caDSR CDE ID 6161031)",
+							"name": "method_of_progression_status",
+							"valueType": "string",
+							"isArray": true,
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        \n        /* required field, cannot be null */\n        const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();\n    \n        const stateOfProgression = (entry) => {return /(progression)$/.test(decodeURI(entry))}; \n        const relapseOrRecurrence = diseaseStatus === \"relapse or recurrence\";\n   \n        // checks for a string just consisting of whitespace\n        const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n\n\n        if ((!$field || checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set a state of progression, relapse, or recurrence.` }\n        }\n        else if (!(!$field || checkforEmpty($field)) && !stateOfProgression(diseaseStatus) && !relapseOrRecurrence) {\n            result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not a state of progression, relapse, or recurrence.` }\n        }\n        return  result;\n    })"
+								],
+								"codeList": [
+									"Biomarker in liquid biopsy (e.g. tumour marker in blood or urine)",
+									"Biopsy",
+									"Blood draw",
+									"Bone marrow aspirate",
+									"Core biopsy",
+									"Cystoscopy",
+									"Cytology",
+									"Debulking",
+									"Diagnostic imaging",
+									"Dilation and curettage procedure",
+									"Enucleation",
+									"Excisional biopsy",
+									"Fine needle aspiration",
+									"Imaging",
+									"Incisional biopsy",
+									"Laparoscopy",
+									"Laparotomy",
+									"Other",
+									"Pap Smear",
+									"Pathologic review",
+									"Physical exam",
+									"Surgical resection",
+									"Thoracentesis",
+									"Ultrasound guided biopsy"
+								]
+							},
+							"meta": {
+								"core": true,
+								"dependsOn": "follow_up.disease_status_at_followup",
+								"notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.\nTo include multiple values, separate values with a pipe delimiter '|' within your file.",
+								"displayName": "Method Of Progression Status"
+							}
+						},
+						{
+							"description": "Indicate the ICD-O-3 topography code for the anatomic site where disease progression, relapse or recurrence occurred, according to the International Classification of Diseases for Oncology, 3rd Edition (WHO ICD-O-3). Refer to the ICD-O-3 manual for guidelines at https://apps.who.int/iris/handle/10665/42344.",
+							"name": "anatomic_site_progression_or_recurrences",
+							"valueType": "string",
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        \n        /* required field, cannot be null */\n        const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();\n    \n        const stateOfProgression = (entry) => {return /(progression)$/.test(decodeURI(entry))}; \n        const relapseOrRecurrence = diseaseStatus === \"relapse or recurrence\";\n   \n        // checks for a string just consisting of whitespace\n        const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n\n\n        if ((!$field || checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set a state of progression, relapse, or recurrence.` }\n        }\n        else if (!(!$field || checkforEmpty($field)) && !stateOfProgression(diseaseStatus) && !relapseOrRecurrence) {\n            result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not a state of progression, relapse, or recurrence.` }\n        }\n        return  result;\n    })"
+								],
+								"regex": "^[C][0-9]{2}(.[0-9]{1})?$"
+							},
+							"meta": {
+								"core": true,
+								"dependsOn": "follow_up.disease_status_at_followup",
+								"displayName": "Anatomic Site Progression or Recurrences",
+								"examples": "C50.1,C18",
+								"notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence."
+							}
+						},
+						{
+							"description": "Specify the tumour staging system used to stage the cancer at time of retreatment for recurrence or disease progression. This may be represented as rTNM in the medical report.",
+							"name": "recurrence_tumour_staging_system",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"AJCC 8th edition",
+									"AJCC 7th edition",
+									"Ann Arbor staging system",
+									"Binet staging system",
+									"Durie-Salmon staging system",
+									"FIGO staging system",
+									"Lugano staging system",
+									"Rai staging system",
+									"Revised International staging system (RISS)",
+									"St Jude staging system"
+								],
+								"script": [
+									"(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    const arrayFormatter = arr => `\\n${arr.map(entry => `- \"${entry}\"`).join('\\n')}`;\n    /* This is not a required field, so first ensure that it exists */\n    if ($field) {\n      /* Contingent on the naming system for tumour staging systems to remain consistent */\n      const stagingName = $name\n        .trim()\n        .toLowerCase()\n        .split('_tumour_staging_system')[0];\n      const requiredFields = [\n        `${stagingName}_m_category`,\n        `${stagingName}_n_category`,\n        `${stagingName}_t_category`,\n      ];\n      const convertedRow = Object.fromEntries(\n        Object.entries($row).map(([fieldName, fieldVal]) => [fieldName.toLowerCase(), fieldVal]),\n      );\n      /* Check for contigous spaces wrapped with quotes (empty strings) */\n      const checkforEmpty = entry => {\n        return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'));\n      };\n\n      /* search for fields with falsy values*/\n      const emptyFields = requiredFields.filter(\n        field => !convertedRow[field] || checkforEmpty(convertedRow[field]),\n      );\n\n      /* The fields should be provided IF and ONLY IF the AJCC regex passes */\n      if (/^(AJCC)\\b/i.test($field) && emptyFields.length) {\n        result = {\n          valid: false,\n          message: `The following fields are required when ${$name} is set to an AJCC option: ${arrayFormatter(\n            emptyFields,\n          )}`,\n        };\n      } else if (!/^(AJCC)\\b/i.test($field) && emptyFields.length != requiredFields.length) {\n        const errorFields = requiredFields.filter(fieldName => !emptyFields.includes(fieldName));\n        result = {\n          valid: false,\n          message: `The following fields cannot be provided when ${$name} is not set to an AJCC option: ${arrayFormatter(\n            errorFields,\n          )}`,\n        };\n      }\n    }\n    return result;\n  })",
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n        let result = {valid: true, message: \"Ok\"};\n        \n        /* required field, cannot be null */\n        const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();\n    \n        const stateOfProgression = (entry) => {return /(progression)$/.test(decodeURI(entry))}; \n        const relapseOrRecurrence = diseaseStatus === \"relapse or recurrence\";\n   \n        // checks for a string just consisting of whitespace\n        const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n\n\n        if ((!$field || checkforEmpty($field)) && (stateOfProgression(diseaseStatus) || relapseOrRecurrence)) {\n            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set a state of progression, relapse, or recurrence.` }\n        }\n        else if (!(!$field || checkforEmpty($field)) && !stateOfProgression(diseaseStatus) && !relapseOrRecurrence) {\n            result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not a state of progression, relapse, or recurrence.` }\n        }\n        return  result;\n    })"
+								]
+							},
+							"meta": {
+								"core": true,
+								"dependsOn": "follow_up.disease_status_at_followup",
+								"notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.",
+								"displayName": "Recurrance Tumour Staging System"
+							}
+						},
+						{
+							"name": "recurrence_t_category",
+							"description": "The code to represent the extent of the primary tumour (T) based on evidence obtained from clinical assessment parameters determined at the time of retreatment for a recurrence or disease progression, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "follow_up.recurrence_tumour_staging_system",
+								"notes": "This field is required only if the selected recurrence_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Recurrence T Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"T0",
+									"T1",
+									"T1a",
+									"T1a1",
+									"T1a2",
+									"T1b",
+									"T1b1",
+									"T1b2",
+									"T1c",
+									"T1d",
+									"T1mi",
+									"T2",
+									"T2a",
+									"T2a1",
+									"T2a2",
+									"T2b",
+									"T2c",
+									"T2d",
+									"T3",
+									"T3a",
+									"T3b",
+									"T3c",
+									"T3d",
+									"T3e",
+									"T4",
+									"T4a",
+									"T4b",
+									"T4c",
+									"T4d",
+									"T4e",
+									"Ta",
+									"Tis",
+									"Tis(DCIS)",
+									"Tis(LAMN)",
+									"Tis(LCIS)",
+									"Tis(Paget)",
+									"Tis(Paget’s)",
+									"Tis pd",
+									"Tis pu",
+									"TX"
+								]
+							}
+						},
+						{
+							"name": "recurrence_n_category",
+							"description": "The code to represent the stage of cancer defined by the extent of the regional lymph node (N) involvement for the cancer based on evidence obtained from clinical assessment parameters determined at the time of retreatment for a recurrence or disease progression, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "follow_up.recurrence_tumour_staging_system",
+								"notes": "This field is required only if the selected recurrence_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Recurrence N Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"N0",
+									"N0a",
+									"N0a (biopsy)",
+									"N0b",
+									"N0b (no biopsy)",
+									"N0(i+)",
+									"N0(i-)",
+									"N0(mol+)",
+									"N0(mol-)",
+									"N1",
+									"N1a",
+									"N1a(sn)",
+									"N1b",
+									"N1c",
+									"N1mi",
+									"N2",
+									"N2a",
+									"N2b",
+									"N2c",
+									"N2mi",
+									"N3",
+									"N3a",
+									"N3b",
+									"N3c",
+									"N4",
+									"NX"
+								]
+							}
+						},
+						{
+							"name": "recurrence_m_category",
+							"description": "The code to represent the stage of cancer defined by the extent of the distant metastasis (M) for the cancer based on evidence obtained from clinical assessment parameters determined at the time of retreatment for a recurrence or disease progression, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "follow_up.recurrence_tumour_staging_system",
+								"notes": "This field is required only if the selected recurrence_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Recurrence M Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"M0",
+									"M0(i+)",
+									"M1",
+									"M1a",
+									"M1a(0)",
+									"M1a(1)",
+									"M1b",
+									"M1b(0)",
+									"M1b(1)",
+									"M1c",
+									"M1c(0)",
+									"M1c(1)",
+									"M1d",
+									"M1d(0)",
+									"M1d(1)",
+									"M1e"
+								]
+							}
+						},
+						{
+							"name": "recurrence_stage_group",
+							"description": "The code to represent the stage group of the tumour, as assigned by the reporting recurrence_tumour_staging_system, that indicates the overall prognostic tumour stage (ie. Stage I, Stage II, Stage III etc.) at the time of retreatment for a recurrence or disease progression.",
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"dependsOn": "follow_up.recurrence_tumour_staging_system",
+								"notes": "This field is dependent on the selected recurrence_tumour_staging_system.\nPlease refer to the documentation for Tumour Staging Classifications: http://docs.icgc-argo.org/docs/submission/dictionary-overview#tumour-staging-classifications",
+								"displayName": "Recurrence Stage Group"
+							},
+							"restrictions": {
+								"codeList": [
+									"Stage 0",
+									"Stage 0a",
+									"Stage 0is",
+									"Stage I",
+									"Stage IA",
+									"Stage IA1",
+									"Stage IA2",
+									"Stage IA3",
+									"Stage IB",
+									"Stage IB1",
+									"Stage IB2",
+									"Stage IC",
+									"Stage IS",
+									"Stage IE",
+									"Stage II",
+									"Stage IIA",
+									"Stage IIA1",
+									"Stage IIA2",
+									"Stage IIE",
+									"Stage IIB",
+									"Stage IIC",
+									"Stage III",
+									"Stage IIIA",
+									"Stage IIIA1",
+									"Stage IIIA2",
+									"Stage IIIB",
+									"Stage IIIC",
+									"Stage IIIC1",
+									"Stage IIIC2",
+									"Stage IIID",
+									"Stage IV",
+									"Stage IVA",
+									"Stage IVA1",
+									"Stage IVA2",
+									"Stage IVB",
+									"Stage IVC",
+									"Occult carcinoma",
+									"Stage 1",
+									"Stage 1A",
+									"Stage 1B",
+									"Stage ISA",
+									"Stage ISB",
+									"Stage IEA",
+									"Stage IEB",
+									"Stage IIEA",
+									"Stage IIEB",
+									"Stage IIES",
+									"Stage IIESA",
+									"Stage IIESB",
+									"Stage IIS",
+									"Stage IISA",
+									"Stage IISB",
+									"Stage IIIE",
+									"Stage IIIEA",
+									"Stage IIIEB",
+									"Stage IIIES",
+									"Stage IIIESA",
+									"Stage IIIESB",
+									"Stage IIIS",
+									"Stage IIISA",
+									"Stage IIISB",
+									"Stage IAB",
+									"Stage A",
+									"Stage B",
+									"Stage C"
+								],
+								"script": [
+									"(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    if ($row.recurrence_tumour_staging_system && $field) {\n      let codeList = [];\n      switch ($row.recurrence_tumour_staging_system && $row.recurrence_tumour_staging_system.trim().toLowerCase()) {\n        case 'revised international staging system (riss)':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii'\n          ];\n          break;\n        case 'lugano staging system':\n          codeList = [\n             'stage i',\n             'stage ia',\n             'stage ib',\n             'stage ie',\n             'stage iea',\n             'stage ieb',\n             'stage ii',\n             'stage iia',\n             'stage iib',\n             'stage iie',\n             'stage iiea',\n             'stage iieb',\n             'stage iii',\n             'stage iiia',\n             'stage iiib',\n             'stage iv',\n             'stage iva',\n             'stage ivb'\n          ];\n          break;\n        case 'st jude staging system':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii',\n            'stage iv'\n          ];\n          break;\n        case 'ann arbor staging system':\n          codeList = [\n            'stage i',\n            'stage ia',\n            'stage ib',\n            'stage ie',\n            'stage is',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iie',\n            'stage iis',\n            'stage iii',\n            'stage iiia',\n            'stage iiib',\n            'stage iiie',\n            'stage iiis',\n            'stage iv',\n            'stage iva',\n            'stage ivb',\n            'stage ive',\n            'stage ivs'\n          ];\n          break;\n        case 'rai staging system':\n          codeList = [\n             'stage 0',\n             'stage i',\n             'stage ii',\n             'stage iii',\n             'stage iv'\n          ];\n          break;\n        case 'durie-salmon staging system':\n          codeList = [\n            'stage 1',\n            'stage 1a',\n            'stage 1b',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iii',\n            'stage iiia',\n            'stage iiib'\n          ];\n          break;\n        case 'figo staging system':\n          codeList = [\n            'stage ia',\n            'stage ia1',\n            'stage ia2',\n            'stage ib',\n            'stage ib1',\n            'stage ib2',\n            'stage iia',\n            'stage iab',\n            'stage iiia',\n            'stage iiib',\n            'stage iva',\n            'stage ivb'\n          ];\n          break;\n        case 'binet staging system':\n          codeList = [\n             'stage a',\n             'stage b',\n             'stage c'\n         ];\n          break;\n        case 'ajcc 8th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ia3','stage ib','stage ib1','stage ib2','stage ic','stage ie','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iie','stage iii','stage iiia','stage iiia1','stage iiia2','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iiid','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'];\n          break;\n        case 'ajcc 7th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ib','stage ib1','stage ib2','stage ic','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iii','stage iiia','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'\n];\n          break;\n        default:\n          codelist = [];\n      }\n\n      if (!codeList.includes($field.trim().toLowerCase()) && codeList.length) {\n        const msg = `'${$field}' is not a permissible value. When 'recurrence_tumour_staging_system' is set to '${\n          $row.recurrence_tumour_staging_system\n        }', 'recurrence_stage_group' must be one of the following: \\n${codeList\n          .map(code => `- \"${code}\"`)\n          .join('\\n')}`;\n\n        result.valid = false;\n        result.message = msg;\n      }\n    }\n    return result;\n  })"
+								]
+							}
+						},
+						{
+							"description": "Specify the tumour staging system used to stage the cancer after treatment for patients receiving systemic and/or radiation therapy alone or as a component of their initial treatment, or as neoadjuvant therapy before planned surgery. This may be represented as ypTNM or ycTNM in the medical report.",
+							"name": "posttherapy_tumour_staging_system",
+							"valueType": "string",
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n    const {$row, $name, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    const arrayFormatter = arr => `\\n${arr.map(entry => `- \"${entry}\"`).join('\\n')}`;\n    /* This is not a required field, so first ensure that it exists */\n    if ($field) {\n      /* Contingent on the naming system for tumour staging systems to remain consistent */\n      const stagingName = $name\n        .trim()\n        .toLowerCase()\n        .split('_tumour_staging_system')[0];\n      const requiredFields = [\n        `${stagingName}_m_category`,\n        `${stagingName}_n_category`,\n        `${stagingName}_t_category`,\n      ];\n      const convertedRow = Object.fromEntries(\n        Object.entries($row).map(([fieldName, fieldVal]) => [fieldName.toLowerCase(), fieldVal]),\n      );\n      /* Check for contigous spaces wrapped with quotes (empty strings) */\n      const checkforEmpty = entry => {\n        return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'));\n      };\n\n      /* search for fields with falsy values*/\n      const emptyFields = requiredFields.filter(\n        field => !convertedRow[field] || checkforEmpty(convertedRow[field]),\n      );\n\n      /* The fields should be provided IF and ONLY IF the AJCC regex passes */\n      if (/^(AJCC)\\b/i.test($field) && emptyFields.length) {\n        result = {\n          valid: false,\n          message: `The following fields are required when ${$name} is set to an AJCC option: ${arrayFormatter(\n            emptyFields,\n          )}`,\n        };\n      } else if (!/^(AJCC)\\b/i.test($field) && emptyFields.length != requiredFields.length) {\n        const errorFields = requiredFields.filter(fieldName => !emptyFields.includes(fieldName));\n        result = {\n          valid: false,\n          message: `The following fields cannot be provided when ${$name} is not set to an AJCC option: ${arrayFormatter(\n            errorFields,\n          )}`,\n        };\n      }\n    }\n    return result;\n  })"
+								],
+								"codeList": [
+									"AJCC 8th edition",
+									"AJCC 7th edition",
+									"Ann Arbor staging system",
+									"Binet staging system",
+									"Durie-Salmon staging system",
+									"FIGO staging system",
+									"Lugano staging system",
+									"Rai staging system",
+									"Revised International staging system (RISS)",
+									"St Jude staging system"
+								]
+							},
+							"meta": {
+								"displayName": "Post-therapy Tumour Staging System"
+							}
+						},
+						{
+							"name": "posttherapy_t_category",
+							"description": "The code to represent the extent of the primary tumour (T) based on evidence obtained from clinical assessment parameters determined after treatment for patients receiving systemic and/or radiation therapy alone or as a component of their initial treatment, or as neoadjuvant therapy before planned surgery, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"dependsOn": "follow_up.posttherapy_tumour_staging_system",
+								"notes": "This field is required only if the selected posttherapy_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Post-therapy T Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"T0",
+									"T1",
+									"T1a",
+									"T1a1",
+									"T1a2",
+									"T1b",
+									"T1b1",
+									"T1b2",
+									"T1c",
+									"T1d",
+									"T1mi",
+									"T2",
+									"T2a",
+									"T2a1",
+									"T2a2",
+									"T2b",
+									"T2c",
+									"T2d",
+									"T3",
+									"T3a",
+									"T3b",
+									"T3c",
+									"T3d",
+									"T3e",
+									"T4",
+									"T4a",
+									"T4b",
+									"T4c",
+									"T4d",
+									"T4e",
+									"Ta",
+									"Tis",
+									"Tis(DCIS)",
+									"Tis(LAMN)",
+									"Tis(LCIS)",
+									"Tis(Paget)",
+									"Tis(Paget’s)",
+									"Tis pd",
+									"Tis pu",
+									"TX"
+								]
+							}
+						},
+						{
+							"name": "posttherapy_n_category",
+							"description": "The code to represent the stage of cancer defined by the extent of the regional lymph node (N) involvement for the cancer based on evidence obtained from clinical assessment parameters determined determined after treatment for patients receiving systemic and/or radiation therapy alone or as a component of their initial treatment, or as neoadjuvant therapy before planned surgery, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"dependsOn": "follow_up.posttherapy_tumour_staging_system",
+								"notes": "This field is required only if the selected posttherapy_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Post-therapy N Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"N0",
+									"N0a",
+									"N0a (biopsy)",
+									"N0b",
+									"N0b (no biopsy)",
+									"N0(i+)",
+									"N0(i-)",
+									"N0(mol+)",
+									"N0(mol-)",
+									"N1",
+									"N1a",
+									"N1a(sn)",
+									"N1b",
+									"N1c",
+									"N1mi",
+									"N2",
+									"N2a",
+									"N2b",
+									"N2c",
+									"N2mi",
+									"N3",
+									"N3a",
+									"N3b",
+									"N3c",
+									"N4",
+									"NX"
+								]
+							}
+						},
+						{
+							"name": "posttherapy_m_category",
+							"description": "The code to represent the stage of cancer defined by the extent of the distant metastasis (M) for the cancer based on evidence obtained from clinical assessment parameters determined after treatment for patients receiving systemic and/or radiation therapy alone or as a component of their initial treatment, or as neoadjuvant therapy before planned surgery, according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.",
+							"valueType": "string",
+							"meta": {
+								"dependsOn": "follow_up.posttherapy_tumour_staging_system",
+								"notes": "This field is required only if the selected posttherapy_tumour_staging_system is any edition of the AJCC cancer staging system.",
+								"displayName": "Post-therapy M Category"
+							},
+							"restrictions": {
+								"codeList": [
+									"M0",
+									"M0(i+)",
+									"M1",
+									"M1a",
+									"M1a(0)",
+									"M1a(1)",
+									"M1b",
+									"M1b(0)",
+									"M1b(1)",
+									"M1c",
+									"M1c(0)",
+									"M1c(1)",
+									"M1d",
+									"M1d(0)",
+									"M1d(1)",
+									"M1e"
+								]
+							}
+						},
+						{
+							"name": "posttherapy_stage_group",
+							"description": "The code to represent the stage group of the tumour, as assigned by the reporting posttherapy_tumour_staging_system, that indicates the overall prognostic tumour stage (ie. Stage I, Stage II, Stage III etc.) after treatment for patients receiving systemic and/or radiation therapy alone or as a component of their initial treatment, or as neoadjuvant therapy before planned surgery.",
+							"valueType": "string",
+							"meta": {
+								"dependsOn": "follow_up.posttherapy_tumour_staging_system",
+								"notes": "This field is dependent on the selected posttherapy_tumour_staging_system.\nPlease refer to the documentation for Tumour Staging Classifications: http://docs.icgc-argo.org/docs/submission/dictionary-overview#tumour-staging-classifications",
+								"displayName": "Post-therapy Stage Group"
+							},
+							"restrictions": {
+								"codeList": [
+									"Stage 0",
+									"Stage 0a",
+									"Stage 0is",
+									"Stage I",
+									"Stage IA",
+									"Stage IA1",
+									"Stage IA2",
+									"Stage IA3",
+									"Stage IB",
+									"Stage IB1",
+									"Stage IB2",
+									"Stage IC",
+									"Stage IS",
+									"Stage IE",
+									"Stage II",
+									"Stage IIA",
+									"Stage IIA1",
+									"Stage IIA2",
+									"Stage IIE",
+									"Stage IIB",
+									"Stage IIC",
+									"Stage III",
+									"Stage IIIA",
+									"Stage IIIA1",
+									"Stage IIIA2",
+									"Stage IIIB",
+									"Stage IIIC",
+									"Stage IIIC1",
+									"Stage IIIC2",
+									"Stage IIID",
+									"Stage IV",
+									"Stage IVA",
+									"Stage IVA1",
+									"Stage IVA2",
+									"Stage IVB",
+									"Stage IVC",
+									"Occult carcinoma",
+									"Stage 1",
+									"Stage 1A",
+									"Stage 1B",
+									"Stage ISA",
+									"Stage ISB",
+									"Stage IEA",
+									"Stage IEB",
+									"Stage IIEA",
+									"Stage IIEB",
+									"Stage IIES",
+									"Stage IIESA",
+									"Stage IIESB",
+									"Stage IIS",
+									"Stage IISA",
+									"Stage IISB",
+									"Stage IIIE",
+									"Stage IIIEA",
+									"Stage IIIEB",
+									"Stage IIIES",
+									"Stage IIIESA",
+									"Stage IIIESB",
+									"Stage IIIS",
+									"Stage IIISA",
+									"Stage IIISB",
+									"Stage IAB",
+									"Stage A",
+									"Stage B",
+									"Stage C"
+								],
+								"script": [
+									"(function validate(inputs) {\n    const {$row, $field} = inputs;\n    let result = { valid: true, message: 'Ok' };\n    if ($row.posttherapy_tumour_staging_system && $field) {\n      let codeList = [];\n      switch ($row.posttherapy_tumour_staging_system && $row.posttherapy_tumour_staging_system.trim().toLowerCase()) {\n        case 'revised international staging system (riss)':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii'\n          ];\n          break;\n        case 'lugano staging system':\n          codeList = [\n             'stage i',\n             'stage ia',\n             'stage ib',\n             'stage ie',\n             'stage iea',\n             'stage ieb',\n             'stage ii',\n             'stage iia',\n             'stage iib',\n             'stage iie',\n             'stage iiea',\n             'stage iieb',\n             'stage iii',\n             'stage iiia',\n             'stage iiib',\n             'stage iv',\n             'stage iva',\n             'stage ivb'\n          ];\n          break;\n        case 'st jude staging system':\n          codeList = [\n            'stage i',\n            'stage ii',\n            'stage iii',\n            'stage iv'\n          ];\n          break;\n        case 'ann arbor staging system':\n          codeList = [\n            'stage i',\n            'stage ia',\n            'stage ib',\n            'stage ie',\n            'stage is',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iie',\n            'stage iis',\n            'stage iii',\n            'stage iiia',\n            'stage iiib',\n            'stage iiie',\n            'stage iiis',\n            'stage iv',\n            'stage iva',\n            'stage ivb',\n            'stage ive',\n            'stage ivs'\n          ];\n          break;\n        case 'rai staging system':\n          codeList = [\n             'stage 0',\n             'stage i',\n             'stage ii',\n             'stage iii',\n             'stage iv'\n          ];\n          break;\n        case 'durie-salmon staging system':\n          codeList = [\n            'stage 1',\n            'stage 1a',\n            'stage 1b',\n            'stage ii',\n            'stage iia',\n            'stage iib',\n            'stage iii',\n            'stage iiia',\n            'stage iiib'\n          ];\n          break;\n        case 'figo staging system':\n          codeList = [\n            'stage ia',\n            'stage ia1',\n            'stage ia2',\n            'stage ib',\n            'stage ib1',\n            'stage ib2',\n            'stage iia',\n            'stage iab',\n            'stage iiia',\n            'stage iiib',\n            'stage iva',\n            'stage ivb'\n          ];\n          break;\n        case 'binet staging system':\n          codeList = [\n             'stage a',\n             'stage b',\n             'stage c'\n         ];\n          break;\n        case 'ajcc 8th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ia3','stage ib','stage ib1','stage ib2','stage ic','stage ie','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iie','stage iii','stage iiia','stage iiia1','stage iiia2','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iiid','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'];\n          break;\n        case 'ajcc 7th edition':\n          codeList = ['stage 0','stage 0a','stage 0is','stage i','stage ia','stage ia1','stage ia2','stage ib','stage ib1','stage ib2','stage ic','stage is','stage ii','stage iia','stage iia1','stage iia2','stage iib','stage iic','stage iii','stage iiia','stage iiib','stage iiic','stage iiic1','stage iiic2','stage iv','stage iva','stage iva1','stage iva2','stage ivb','stage ivc','occult carcinoma','stage 1'\n];\n          break;\n        default:\n          codelist = [];\n      }\n\n      if (!codeList.includes($field.trim().toLowerCase()) && codeList.length) {\n        const msg = `'${$field}' is not a permissible value. When 'posttherapy_tumour_staging_system' is set to '${\n          $row.posttherapy_tumour_staging_system\n        }', 'posttherapy_stage_group' must be one of the following: \\n${codeList\n          .map(code => `- \"${code}\"`)\n          .join('\\n')}`;\n\n        result.valid = false;\n        result.message = msg;\n      }\n    }\n    return result;\n  })"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "family_history",
+					"description": "The collection of data elements describing a donors familial relationships and familial cancer history.",
+					"meta": {
+						"parent": "donor"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"description": "Unique identifier of the relative, assigned by the data provider.",
+							"name": "family_relative_id",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Family Relative ID",
+								"notes": "This field is required to ensure that family members are identified in unique records.  Ids can be as simple as an incremented numeral to ensure uniqueness."
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"description": "Indicate if patient has any genetic relatives with a history of cancer. (Reference: NCIt C159104, caDSR CDE ID 6161023)",
+							"name": "relative_with_cancer_history",
+							"restrictions": {
+								"codeList": ["Yes", "No", "Unknown"]
+							},
+							"valueType": "string",
+							"meta": {
+								"displayName": "Relative with Cancer History"
+							}
+						},
+						{
+							"description": "Indicate genetic relationship of the relative to patient. (Reference: caDSR CDE ID 2179937)",
+							"name": "relationship_type",
+							"restrictions": {
+								"codeList": [
+									"Aunt",
+									"Brother",
+									"Cousin",
+									"Daughter",
+									"Father",
+									"Grandchild",
+									"Grandfather",
+									"Grandmother",
+									"Maternal Aunt",
+									"Maternal Cousin",
+									"Maternal Grandfather",
+									"Maternal Grandmother",
+									"Maternal Half-brother",
+									"Maternal Half-sister",
+									"Mother",
+									"Nephew",
+									"Niece",
+									"Other",
+									"Paternal Aunt",
+									"Paternal Cousin",
+									"Paternal Grandfather",
+									"Paternal Grandmother",
+									"Paternal Half-brother",
+									"Paternal Half-sister",
+									"Sister",
+									"Son",
+									"Unknown"
+								]
+							},
+							"valueType": "string",
+							"meta": {
+								"displayName": "Relationship Type"
+							}
+						},
+						{
+							"description": "The self-reported gender of related individual.",
+							"name": "gender_of_relative",
+							"restrictions": {
+								"codeList": ["Female", "Male", "Other", "Unknown"]
+							},
+							"valueType": "string",
+							"meta": {
+								"displayName": "Gender of Relative"
+							}
+						},
+						{
+							"description": "The age (in years) when the patient's relative was first diagnosed. (Reference: caDSR CDE ID 5300571)",
+							"name": "age_of_relative_at_diagnosis",
+							"restrictions": {},
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Age Of Relative At Diagnosis"
+							}
+						},
+						{
+							"name": "cancer_type_code_of_relative",
+							"valueType": "string",
+							"description": "The code to describe the malignant diagnosis of the patient's relative with a history of cancer using the WHO ICD-10 code (https://icd.who.int/browse10/2019/en) classification.",
+							"restrictions": {
+								"regex": "^[C|D][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$"
+							},
+							"meta": {
+								"core": true,
+								"examples": "C41.1,C16.9,C00.5,D46.9",
+								"displayName": "Cancer Type Code (ICD-10) of Relative"
+							}
+						},
+						{
+							"description": "Indicate the cause of the death of the relative.",
+							"name": "cause_of_death_of_relative",
+							"restrictions": {
+								"codeList": ["Died of cancer", "Died of other reasons", "Unknown"]
+							},
+							"valueType": "string",
+							"meta": {
+								"core": true,
+								"displayName": "Cause of Death of Relative"
+							}
+						},
+						{
+							"description": "Indicate how long, in years, the relative survived from the time of diagnosis if the patient's relative died from the cancer they were diagnosed with.",
+							"name": "relative_survival_time",
+							"restrictions": {},
+							"valueType": "integer",
+							"meta": {
+								"displayName": "Survival Time Of Relative"
+							}
+						}
+					]
+				},
+				{
+					"name": "exposure",
+					"description": "The collection of data elements related to a donor's clinically relevant information not immediately resulting from genetic predispositions.",
+					"meta": {
+						"parent": "donor"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"description": "Indicate the type(s) of tobacco used by donor. (Reference: NCIT)",
+							"name": "tobacco_type",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Tobacco Type",
+								"notes": "To include multiple values, separate values with a pipe delimiter '|' within your file."
+							},
+							"isArray": true,
+							"restrictions": {
+								"codeList": [
+									"Chewing Tobacco",
+									"Cigar",
+									"Cigarettes",
+									"Electronic cigarettes",
+									"Roll-ups",
+									"Snuff",
+									"Unknown",
+									"Waterpipe"
+								]
+							}
+						},
+						{
+							"description": "Indicate donor's self-reported smoking status and history. (Reference: caDSR CDE ID 2181650)",
+							"name": "tobacco_smoking_status",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Tobacco Smoking Status",
+								"notes": "Current smoker: Has smoked 100 cigarettes in their lifetime and who currently smokes. Includes daily smokers and non-daily smokers (also known as occassional smokers). Current reformed smoker for >15 years: A person who currently does not smoke and has been a non-smoker for more than 15 years, but has smoked at least 100 cigarettes in their life. Current reformed smoker for <= 15 years: A person who currently does not smoke and has been a non-smoker for less than 15 years, but has smoked at least 100 cigarettes in their life. Current reformed smoker, duration not specified: A person who currently does not smoke and has been a non-smoker for unspecified time, but has smoked at least 100 cigarettes in their lifetime. Smoking history not documented: Smoking history has not be recorded or is unknown."
+							},
+							"restrictions": {
+								"codeList": [
+									"Current reformed smoker for <= 15 years",
+									"Current reformed smoker for > 15 years",
+									"Current reformed smoker, duration not specified",
+									"Current smoker",
+									"Lifelong non-smoker (<100 cigarettes smoked in lifetime)",
+									"Smoking history not documented"
+								]
+							}
+						},
+						{
+							"description": "This field applies to cigarettes. Indicate the smoking intensity in Pack Years, where the number of pack years is defined as the number of cigarettes smoked per day times (x) the number of years smoked divided (/) by 20. (Reference: caDSR CDE ID 2955385)",
+							"name": "pack_years_smoked",
+							"valueType": "number",
+							"meta": {
+								"displayName": "Pack Years Smoked",
+								"notes": "Current smoker: Has smoked 100 cigarettes in their lifetime and who currently smokes. Includes daily smokers and non-daily smokers (also known as occassional smokers). Current reformed smoker for >15 years: A person who currently does not smoke and has been a non-smoker for more than 15 years, but has smoked at least 100 cigarettes in their life. Current reformed smoker for <= 15 years: A person who currently does not smoke and has been a non-smoker for less than 15 years, but has smoked at least 100 cigarettes in their life. Current reformed smoker, duration not specified: A person who currently does not smoke and has been a non-smoker for unspecified time, but has smoked at least 100 cigarettes in their lifetime. Smoking history not documented: Smoking history has not be recorded or is unknown."
+							},
+							"restrictions": {
+								"min": 0
+							}
+						},
+						{
+							"description": "Indicate if the donor has consumed at least 12 drinks of any alcoholic beverage in their lifetime. (Reference: caDSR CDE ID 2201918)",
+							"name": "alcohol_history",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Alcohol History"
+							},
+							"restrictions": {
+								"codeList": ["Yes", "No", "Unknown"]
+							}
+						},
+						{
+							"description": "Describe the donor's current level of alcohol use as self-reported by the donor. (Reference: caDSR CDE ID 3457767)",
+							"name": "alcohol_consumption_category",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Alcohol Consumption Category",
+								"notes": ""
+							},
+							"restrictions": {
+								"codeList": [
+									"Daily Drinker",
+									"None",
+									"Not Documented",
+									"Occasional Drinker (< once a month)",
+									"Social Drinker (> once a month, < once a week)",
+									"Weekly Drinker (>=1x a week)"
+								]
+							}
+						},
+						{
+							"description": "Indicate the type(s) of alcohol the donor consumed. (Reference: NCIt CDE C173647)",
+							"name": "alcohol_type",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Alcohol Type",
+								"notes": "To include multiple values, separate values with a pipe delimiter '|' within your file."
+							},
+							"isArray": true,
+							"restrictions": {
+								"codeList": ["Beer", "Liquor", "Other", "Unknown", "Wine"]
+							}
+						},
+						{
+							"description": "Indicate if the donor has ever used opium or other opiates like opium juice, heroin, or Sukhteh regularly (at least weekly over a 6-month period).",
+							"name": "opiate_use",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Opiate Use"
+							},
+							"restrictions": {
+								"codeList": ["Never", "Unknown", "Yes, currently", "Yes, only in the past"]
+							}
+						},
+						{
+							"description": "Indicate if the donor regularly drinks tea, coffee, or other hot drinks.",
+							"name": "hot_drinks",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Hot Drink Consumption"
+							},
+							"restrictions": {
+								"codeList": ["Never", "Unknown", "Yes, currently", "Yes, only in the past"]
+							}
+						},
+						{
+							"description": "Indicate how frequently the donor eats red meat. Examples of red meat include beef, veal, pork, lamb, mutton, horse, or goat meat.",
+							"name": "red_meat",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Red Meat Consumption Frequency"
+							},
+							"restrictions": {
+								"codeList": [
+									"Never",
+									"Less than once a month",
+									"1-3 times a month",
+									"Once or twice a week",
+									"Most days but not every day",
+									"Every day",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"description": "Indicate how frequently the patient eats processed meat. Examples of processed meat include hams, salamis, or sausages.",
+							"name": "processed_meat",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Processed Meat Consumption Frequency"
+							},
+							"restrictions": {
+								"codeList": [
+									"Never",
+									"Less than once a month",
+									"1-3 times a month",
+									"Once or twice a week",
+									"Most days but not every day",
+									"Every day",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"description": "Indicate the frequency of soft drink consumption by the donor.",
+							"name": "soft_drinks",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Soft Drink Consumption Frequency"
+							},
+							"restrictions": {
+								"codeList": [
+									"Never",
+									"Less than once a month",
+									"1-3 times a month",
+									"Once or twice a week",
+									"Most days but not every day",
+									"Every day",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"description": "Indicate how many times per week the donor exercises for at least 30 minutes. (Reference: NCIt CDE C25367)",
+							"name": "exercise_frequency",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Exercise Frequency"
+							},
+							"restrictions": {
+								"codeList": [
+									"Never",
+									"Less than once a month",
+									"1-3 times a month",
+									"Once or twice a week",
+									"Most days but not every day",
+									"Every day",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"description": "Indicate the intensity of exercise. (Reference: NCIt CDE C25539)",
+							"name": "exercise_intensity",
+							"valueType": "string",
+							"meta": {
+								"displayName": "Exercise Intensity"
+							},
+							"restrictions": {
+								"codeList": [
+									"Low: No increase in the heart beat, and no perspiration",
+									"Moderate: Increase in the heart beat slightly with some light perspiration",
+									"Vigorous: Increase in the heart beat substantially with heavy perspiration"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "comorbidity",
+					"description": "The collection of data elements related to a donor's comorbidities. Comorbidities are any distinct entity that has existed or may occur during the clinical course of a patient who has the index disease under study. To submit multiple comorbidities for a single donor, submit multiple rows in the comorbidity file for this donor",
+					"meta": {
+						"parent": "donor"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "prior_malignancy",
+							"description": "Prior malignancy affecting donor.",
+							"restrictions": {
+								"codeList": ["Yes", "No", "Unknown"]
+							},
+							"valueType": "string",
+							"meta": {
+								"displayName": "Prior Malignancy"
+							}
+						},
+						{
+							"name": "laterality_of_prior_malignancy",
+							"description": "If donor has history of prior malignancy, indicate laterality of previous diagnosis. (Reference: caDSR CDE ID 4122391)",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Bilateral",
+									"Left",
+									"Midline",
+									"Not applicable",
+									"Right",
+									"Unilateral, Side not specified",
+									"Unknown"
+								],
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n\n      const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n      \n      /* checks for a string just consisting of whitespace */\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      const invalidTypes = [\"no\", \"unknown\"]\n   \n      if ($name === \"laterality_of_prior_malignancy\") {\n         if (($row.prior_malignancy === null || invalidTypes.includes($row.prior_malignancy.trim().toLowerCase())) && (currField || (!(checkforEmpty(currField))!= null))) {\n            result = {\n               valid: false,\n               message: `The 'prior_malignancy' field should be submitted as 'Yes' if the '${$name}' field is submitted.`\n            };\n         }\n      }\n      return result;\n  })"
+								]
+							},
+							"meta": {
+								"dependsOn": "comorbidity.prior_malignancy",
+								"displayName": "Laterality at Prior Malignancy"
+							}
+						},
+						{
+							"name": "age_at_comorbidity_diagnosis",
+							"valueType": "integer",
+							"description": "Indicate the age of comorbidity diagnosis, in years.",
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n\n      const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n      \n      /* checks for a string just consisting of whitespace */\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      const invalidTypes = [\"no\", \"unknown\"]\n      optionalFields = [\"age_at_comorbidity_diagnosis\", \"comorbidity_treatment_status\", \"comorbidity_treatment\"];\n   \n      if (optionalFields.includes($name) && (currField || (!(checkforEmpty(currField))))) {\n         if (($row.comorbidity_type_code === null || checkforEmpty($row.comorbidity_type_code))) {\n            result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_type_code' field is not submitted.`};\n         }\n         if ($name === \"comorbidity_treatment\" && currField && !(checkforEmpty(currField))) {\n            if ($row.comorbidity_treatment_status === null || checkforEmpty($row.comorbidity_treatment_status)) {\n               result = { valid: false, message: `The 'comorbidity_treatment_status' field should be submitted as 'Yes' if '${$name}' field is submitted.`};\n            }\n            else if (invalidTypes.includes($row.comorbidity_treatment_status.trim().toLowerCase())) {\n               result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_treatment_status' field is not 'Yes'.`};\n            }\n         }\n     }\n     return result;\n  })"
+								],
+								"range": {
+									"exclusiveMin": 0
+								}
+							},
+							"meta": {
+								"units": "years",
+								"dependsOn": "comorbidity.comorbidity_type_code",
+								"displayName": "Age at Comorbidity Diagnosis"
+							}
+						},
+						{
+							"name": "comorbidity_type_code",
+							"valueType": "string",
+							"description": "Indicate the code for the comorbidity using the WHO ICD-10 code classification (https://icd.who.int/browse10/2019/en).",
+							"restrictions": {
+								"required": true,
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n      const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n      \n      /* checks for a string just consisting of whitespace */\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      const invalidTypes = [\"no\", \"unknown\"]\n      /* check if ICD-10 code is for neoplasms */\n      const neoplasmCode = (entry) => {return /^[c|d][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$/.test(decodeURI(entry))};\n\n      if (currField || (!(checkforEmpty(currField)))) {\n         if ($row.prior_malignancy === \"yes\" && (!(neoplasmCode(currField)))) {\n            result = { valid: false, message: `The ICD-10 code submitted in the '${$name}' field must be a code for cancer if 'prior_malignancy' is 'Yes'.`}\n         }\n         else if (($row.prior_malignancy === null || invalidTypes.includes($row.prior_malignancy.trim().toLowerCase())) && neoplasmCode(currField)) {\n            result = {valid: false, message: `If an ICD-10 code for cancer is submitted in the '${$name}' field, then 'prior_malignancy' should be submitted as 'Yes'.`}\n         }\n      }\n      else if (checkforEmpty(currField)) {\n         if ($row.prior_malignancy === \"yes\") { \n            result = {valid: false, message: `The 'comorbidity_type_code' field is required if '${$name}' field is 'Yes'.`}\n         }\n         else if ($row.prior_malignancy === null || checkforEmpty($row.prior_malignancy)) {\n            result = {valid: false, message: `The 'comorbidity_type_code' field is required.`}\n         }\n      }\n      return result;\n  })"
+								],
+								"regex": "^[A-Z][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$"
+							},
+							"meta": {
+								"primaryId": true,
+								"dependsOn": "comorbidity.prior_malignancy",
+								"examples": "E10, C50.1, I11, M06",
+								"displayName": "Comorbidity Type Code"
+							}
+						},
+						{
+							"name": "comorbidity_treatment_status",
+							"valueType": "string",
+							"description": "Indicate if the patient is being treated for the comorbidity (this includes prior malignancies).",
+							"restrictions": {
+								"codeList": ["Yes", "No", "Unknown"],
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n\n      const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n      \n      /* checks for a string just consisting of whitespace */\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      const invalidTypes = [\"no\", \"unknown\"]\n      optionalFields = [\"age_at_comorbidity_diagnosis\", \"comorbidity_treatment_status\", \"comorbidity_treatment\"];\n   \n      if (optionalFields.includes($name) && (currField || (!(checkforEmpty(currField))))) {\n         if (($row.comorbidity_type_code === null || checkforEmpty($row.comorbidity_type_code))) {\n            result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_type_code' field is not submitted.`};\n         }\n         if ($name === \"comorbidity_treatment\" && currField && !(checkforEmpty(currField))) {\n            if ($row.comorbidity_treatment_status === null || checkforEmpty($row.comorbidity_treatment_status)) {\n               result = { valid: false, message: `The 'comorbidity_treatment_status' field should be submitted as 'Yes' if '${$name}' field is submitted.`};\n            }\n            else if (invalidTypes.includes($row.comorbidity_treatment_status.trim().toLowerCase())) {\n               result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_treatment_status' field is not 'Yes'.`};\n            }\n         }\n     }\n     return result;\n  })"
+								]
+							},
+							"meta": {
+								"dependsOn": "comorbidity.comorbidity_type_code",
+								"displayName": "Comorbidity Treatment"
+							}
+						},
+						{
+							"name": "comorbidity_treatment",
+							"valueType": "string",
+							"description": "Indicate treatment details for the comorbidity (this includes prior malignancies).",
+							"restrictions": {
+								"script": [
+									"(function validate(inputs) {\n      const {$row, $name, $field} = inputs;\n      let result = {valid: true, message: \"Ok\"};\n\n      const currField = typeof($field) === 'string' ? $field.trim().toLowerCase() : $field;\n      \n      /* checks for a string just consisting of whitespace */\n      const checkforEmpty = (entry) => {return /^\\s+$/g.test(decodeURI(entry).replace(/^\"(.*)\"$/, '$1'))};\n      const invalidTypes = [\"no\", \"unknown\"]\n      optionalFields = [\"age_at_comorbidity_diagnosis\", \"comorbidity_treatment_status\", \"comorbidity_treatment\"];\n   \n      if (optionalFields.includes($name) && (currField || (!(checkforEmpty(currField))))) {\n         if (($row.comorbidity_type_code === null || checkforEmpty($row.comorbidity_type_code))) {\n            result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_type_code' field is not submitted.`};\n         }\n         if ($name === \"comorbidity_treatment\" && currField && !(checkforEmpty(currField))) {\n            if ($row.comorbidity_treatment_status === null || checkforEmpty($row.comorbidity_treatment_status)) {\n               result = { valid: false, message: `The 'comorbidity_treatment_status' field should be submitted as 'Yes' if '${$name}' field is submitted.`};\n            }\n            else if (invalidTypes.includes($row.comorbidity_treatment_status.trim().toLowerCase())) {\n               result = { valid: false, message: `The '${$name}' field should not be submitted if the 'comorbidity_treatment_status' field is not 'Yes'.`};\n            }\n         }\n     }\n     return result;\n  })"
+								]
+							},
+							"meta": {
+								"dependsOn": "comorbidity.comorbidity_treatment_status",
+								"displayName": "Comorbidity Treatment Type"
+							}
+						}
+					]
+				},
+				{
+					"name": "biomarker",
+					"description": "The collection of data elements describing a donor's biomarker tests. A biomarker is a biological molecule found in blood, other body fluids, or tissues that is indicative of the presence of cancer in the body. Each row should include biomarker tests associated with a particular clinical event or time interval.",
+					"meta": {
+						"parent": "donor"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"name": "submitter_donor_id",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_specimen_id",
+							"description": "Unique identifier of the specimen, assigned by the data provider.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_specimen_id",
+								"displayName": "Submitter Specimen ID"
+							},
+							"restrictions": {
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_primary_diagnosis_id",
+							"valueType": "string",
+							"description": "If the biomarker test was done at the time of primary diagnosis, then indicate the associated submitter_primary_diagnosis_id here.",
+							"meta": {
+								"displayName": "Submitter Primary Diagnosis ID",
+								"primaryId": true
+							},
+							"restrictions": {
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_treatment_id",
+							"valueType": "string",
+							"description": "If the biomarker test was done at the initiation of a specific treatment regimen, indicate the associated submitter_treatment_id here.",
+							"meta": {
+								"primaryId": true,
+								"displayName": "Submitter Treatment ID"
+							},
+							"restrictions": {
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"description": "If the biomarker test was done during a follow-up event, then indicate the associated submitter_follow_up_id here.",
+							"name": "submitter_follow_up_id",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"displayName": "Submitter Follow-Up ID"
+							},
+							"restrictions": {
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"description": "If the biomarker test was not associated with a specific follow-up, primary diagnosis or treatment event, then indicate the interval of time since primary diagnosis that the biomarker test was performced at, in days.",
+							"name": "test_interval",
+							"valueType": "integer",
+							"restrictions": {
+								"range": {
+									"exclusiveMin": 0
+								}
+							},
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"units": "days",
+								"displayName": "Interval Of Test",
+								"notes": "This field is required if the biomarker test is not associated with a primary diagnosis, treatment or follow-up event. The associated primary diagnosis is used as the reference point for this interval. To calculate this, find the number of days since the date of primary diagnosis."
+							}
+						},
+						{
+							"description": "Indicate the level of carbohydrate antigen 19-9 (CA19-9). Carbohydrate antigen 19-9 testing is useful to monitor the response to treatment in pancreatic cancer patients. (Reference: LOINC: 24108-3)",
+							"name": "ca19-9_level",
+							"valueType": "integer",
+							"restrictions": {
+								"range": {
+									"exclusiveMin": 0
+								}
+							},
+							"meta": {
+								"displayName": "CA19-9 Level"
+							}
+						},
+						{
+							"description": "Indicate the quantitative measurement of the amount of C-reactive protein (CRP), an inflammatory marker, in the blood in mg/L. (Reference: NCIt C64548)",
+							"name": "crp_levels",
+							"valueType": "integer",
+							"restrictions": {
+								"range": {
+									"exclusiveMin": 0
+								}
+							},
+							"meta": {
+								"displayName": "C-reactive protein (CRP) Level"
+							}
+						},
+						{
+							"description": "Indicate the level of lactate dehydrogenase (LDH), in IU/L.",
+							"name": "ldl_level",
+							"valueType": "integer",
+							"restrictions": {
+								"range": {
+									"exclusiveMin": 0
+								}
+							},
+							"meta": {
+								"displayName": "Lactate Dehydrogenase (LDH) Level"
+							}
+						},
+						{
+							"description": "Indicate the value for a hemotology laboratory test for the absolute number of neutrophil cells (ANC) present in a sample of peripheral blood from a donor, in cells/uL. (Reference: caDSR CDE ID 2180198)",
+							"name": "anc",
+							"valueType": "integer",
+							"restrictions": {
+								"range": {
+									"exclusiveMin": 0
+								}
+							},
+							"meta": {
+								"displayName": "Absolute Neutrophil Count (ANC)"
+							}
+						},
+						{
+							"description": "Indicate the absolute number of lymphocytes (ALC) found in a given volume of blood, as cells/uL. (Reference: NCIt: C113237)",
+							"name": "alc",
+							"valueType": "integer",
+							"restrictions": {
+								"range": {
+									"exclusiveMin": 0
+								}
+							},
+							"meta": {
+								"displayName": "Absolute Lymphocyte Count (ALC)"
+							}
+						},
+						{
+							"description": "Indicate whether donor is a carrier of a mutation in a BRCA gene.",
+							"name": "brca_carrier",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"BRCA1",
+									"BRCA2",
+									"Both BRCA1 and BRCA2",
+									"No",
+									"Not applicable",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "BRCA Carrier"
+							}
+						},
+						{
+							"description": "Indicate the expression of estrogen receptor (ER). (Reference: NAACCR 3827)",
+							"name": "er_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "Estrogen Receptor Status"
+							}
+						},
+						{
+							"description": "Indicate the Allred score. The Allred score is based on the percentage of cells that stain positive by immunohistochemistry (IHC) for estrogen receptor (ER) and the intensity of that staining. (Reference: NAACCR: 3828, caDSR CDE ID 2725288)",
+							"name": "er_allred_score",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Total ER Allred score of 1",
+									"Total ER Allred score of 2",
+									"Total ER Allred score of 3",
+									"Total ER Allred score of 4",
+									"Total ER Allred score of 5",
+									"Total ER Allred score of 6",
+									"Total ER Allred score of 7",
+									"Total ER Allred score of 8",
+									"Not applicable",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "Estrogen Receptor Allred Score"
+							}
+						},
+						{
+							"description": "Indicate the expression of human epidermal growth factor receptor-2 (HER2) assessed by immunohistochemistry (IHC). (Reference: AJCC 8th Edition, Chapter 48)",
+							"name": "her2_ihc_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Equivocal",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "HER2 IHC Status",
+								"notes": "Negative: 0 or 1+ staining, Equivocal: 2+ staining, Positive: 3+ staining"
+							}
+						},
+						{
+							"description": "Indicate the expression of human epidermal growth factor receptor-2 (HER2) assessed by in situ hybridization (ISH). (Reference: NAACCR: 3854)",
+							"name": "her2_ish_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Equivocal",
+									"Positive",
+									"Negative",
+									"Not applicable",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "HER2 ISH Status"
+							}
+						},
+						{
+							"description": "Indicate the expression of progestrone receptor (PR). (Reference: NAACCR 3915)",
+							"name": "pr_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "Progesterone Receptor Status"
+							}
+						},
+						{
+							"description": "Indicate the Allred score. The Allred score is based on the percentage of cells that stain positive by IHC for the progesterone receptor (PR) and the intensity of that staining. (Reference: NAACCR: 3916)",
+							"name": "pr_allred_score",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Total PR Allred score of 1",
+									"Total PR Allred score of 2",
+									"Total PR Allred score of 3",
+									"Total PR Allred score of 4",
+									"Total PR Allred score of 5",
+									"Total PR Allred score of 6",
+									"Total PR Allred score of 7",
+									"Total PR Allred score of 8",
+									"Not applicable",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "Progesterone Receptor Allred Score"
+							}
+						},
+						{
+							"description": "Indicate the immunohistochemical test result that refers to the overexpression or lack of expression of programmed death ligand 1 (PD-L1) in a tissue sample of a primary or metastatic malignant neoplasm. (Reference NCIt: C122807)",
+							"name": "pd-l1_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "PD-L1 Status"
+							}
+						},
+						{
+							"description": "Indicate the expression of anaplastic lymphoma receptor tyrosine kinase (ALK) as assessed by immunohistochemistry (IHC).",
+							"name": "alk_ihc_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "ALK IHC Status"
+							}
+						},
+						{
+							"description": "Indicate the intensity of anaplastic lymphoma receptor tyrosine kinase (ALK) as assessed by immunohistochemistry (IHC).",
+							"name": "alk_ihc_intensity",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": ["0 (No stain)", "+1", "+2", "+3"]
+							},
+							"meta": {
+								"displayName": "ALK IHC Intensity"
+							}
+						},
+						{
+							"description": "Indicate the expression of anaplastic lymphoma receptor tyrosine kinase (ALK) as assessed by flurescence in situ hybridization (FISH).",
+							"name": "alk_fish_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "ALK FISH Status"
+							}
+						},
+						{
+							"description": "Indicate the expression of receptor lymphoma kinase (ROS1) as assessed by immunohistochemistry (IHC).",
+							"name": "ros1_ihc_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "ROS1 IHC Status"
+							}
+						},
+						{
+							"description": "Indicate the expression of Pan-TRK as assessed by immunohistochemistry (IHC).",
+							"name": "pan-trk_ihc_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "Pan-TRK IHC Status"
+							}
+						},
+						{
+							"description": "Indicate the expression of gene arrangement involving the RET proto-oncogene (RET1) as assessed by fluoresence in situ hybridization (FISH). RET gene rearrangements are associated with several different neoplastic conditions. (Reference: NCIt C46005)",
+							"name": "ret_fish_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "RET1 FISH Status"
+							}
+						},
+						{
+							"description": "Indicate the expression of tropomyosin receptor kinase (TRK) as assessed by immunohistochemistry (IHC).",
+							"name": "trk_ihc_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "TRK IHC Status"
+							}
+						},
+						{
+							"description": "Indicate the expression of Human papillomavirus (HPV) p16 as assessed by immunohistochemistry (IHC).",
+							"name": "hpv_ihc_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "HPV IHC Status"
+							}
+						},
+						{
+							"description": "Indicate the expression of Human papillomavirus (HPV) as assessed using a laboratory test in which cells are scraped from the cervix to look for DNA of HPV. (Reference: NCIt C93141)",
+							"name": "hpv_dna_status",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": [
+									"Cannot be determined",
+									"Negative",
+									"Not applicable",
+									"Positive",
+									"Unknown"
+								]
+							},
+							"meta": {
+								"displayName": "HPV DNA Status"
+							}
+						}
+					]
+				},
+				{
+					"name": "surgery",
+					"description": "The collection of data elements related to a donor's surgical treatment at a specific point in the clinical record. To submit multiple surgeries for a single donor, please submit multiple rows in the treatment file for this donor.",
+					"meta": {
+						"parent": "donor"
+					},
+					"fields": [
+						{
+							"name": "program_id",
+							"valueType": "string",
+							"description": "Unique identifier of the ARGO program.",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.program_id",
+								"displayName": "Program ID"
+							},
+							"restrictions": {
+								"required": true
+							}
+						},
+						{
+							"name": "submitter_donor_id",
+							"description": "Unique identifier of the donor, assigned by the data provider.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"foreignKey": "sample_registration.submitter_donor_id",
+								"displayName": "Submitter Donor ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "submitter_treatment_id",
+							"description": "Unique identifier of the treatment, assigned by the data provider.",
+							"valueType": "string",
+							"meta": {
+								"validationDependency": true,
+								"primaryId": true,
+								"displayName": "Submitter Treatment ID"
+							},
+							"restrictions": {
+								"required": true,
+								"regex": "^[A-Za-z0-9\\-\\._]{1,64}"
+							}
+						},
+						{
+							"name": "procedure_type",
+							"valueType": "string",
+							"description": "Indicate they type of surgical procedure that was performed.",
+							"meta": {
+								"displayName": "Procedure Type "
+							},
+							"restrictions": {
+								"codeList": [
+									"Biopsy",
+									"Breast-conserving surgery (BCN)",
+									"Bypass procedure / Jejunostomy only",
+									"Cholecystojejunostomy",
+									"Choledochojejunostomy",
+									"Classic Whipple",
+									"Distal Pancreatectomy",
+									"Gastrectomy: Completion",
+									"Gastrectomy: Distal",
+									"Gastrectomy: Extended Total",
+									"Gastrectomy: Merendino",
+									"Gastrectomy: Proximal",
+									"Gastrectomy: Total",
+									"Gastrojejunostomy",
+									"Hepaticojejunostomy",
+									"Jejunostomy",
+									"Laparotomy",
+									"Laparotomy (Open and Shut)",
+									"Lobectomy",
+									"Lumpectomy",
+									"Lymph node dissection performed at time of resection of primary",
+									"Lymph node surgery",
+									"Mastectomy",
+									"Minimally Invasive Oesophagectomy",
+									"Morcellation",
+									"Oesophagectomy: 2 – Phase (Ivor-Lewis)",
+									"Oesophagectomy: 3 – Phase (McKeown)",
+									"Oesophagectomy: Left thoraco-abdominal approach",
+									"Oesophagectomy: Transhiatal",
+									"Omentectomy",
+									"Other",
+									"Partial Resection",
+									"Pneumonectomy",
+									"Prophylactic mastectomy",
+									"Pylorus Whipple",
+									"Radical Whipple",
+									"Sleeve Resection",
+									"Stent",
+									"Subtotal Pancreatectomy",
+									"Surgical resection",
+									"Thoracotomy (Open & Shut)",
+									"Total Pancreatectomy",
+									"Wedge resection (Segmentectomy)",
+									"Wedge/localised gastric resection"
+								]
+							}
+						},
+						{
+							"name": "biopsy_type",
+							"valueType": "string",
+							"description": "If Biopsy was selected as the `procedure_type', indicate the type of biopsy that was performed.",
+							"meta": {
+								"displayName": "Biopsy Type",
+								"dependsOn": "surgery.procedure_type"
+							},
+							"restrictions": {
+								"codeList": [
+									"Biopsy",
+									"Endoscopic biopsy",
+									"Endoscopic brushing ",
+									"Fine Need Aspiration (FNA) ",
+									"NOS",
+									"Open/Surgical biopsy ",
+									"Other",
+									"Percutaneous",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"name": "procedure_intent",
+							"description": "Indicate the intended disease outcome for which the procedure is given. (Reference: NCIt C124307)",
+							"valueType": "string",
+							"restrictions": {
+								"codeList": ["Exploratory", "Curative", "Palliative", "Other", "Staging", "Unknown"]
+							},
+							"meta": {
+								"displayName": "Procedure  Intent"
+							}
+						},
+						{
+							"name": "procedure_interval",
+							"valueType": "integer",
+							"description": "The interval between primary diagnosis and when the surgical procedure was performed, in days.",
+							"meta": {
+								"displayName": "Procedure Interval"
+							},
+							"restrictions": {
+								"range": {
+									"exclusiveMin": 0
+								}
+							}
+						},
+						{
+							"name": "procedure_site",
+							"valueType": "string",
+							"description": "Indicate the ICD-O-3 topography code for the anatomic site where procedure was performed, according to the International Classification of Diseases for Oncology, 3rd Edition (WHO ICD-O-3).",
+							"meta": {
+								"displayName": "Procedure Site",
+								"notes": "Refer to the ICD-O-3 manual for guidelines at https://apps.who.int/iris/handle/10665/42344."
+							},
+							"restrictions": {
+								"regex": "^[C][0-9]{2}(.[0-9]{1})?$"
+							}
+						},
+						{
+							"name": "procedure_site_other",
+							"valueType": "string",
+							"description": "Free text to indicate additional details about the procedure site.",
+							"meta": {
+								"displayName": "Procedure Site Details"
+							},
+							"restrictions": {}
+						},
+						{
+							"name": "procedure_location",
+							"valueType": "string",
+							"description": "Indicate whether procedure was done on primary, local recurrence or metastatic location.",
+							"meta": {
+								"displayName": "Procedure Location"
+							},
+							"restrictions": {
+								"codeList": ["Local recurrence", "Metastatic", "Primary"]
+							}
+						},
+						{
+							"name": "tumour_size_status",
+							"valueType": "string",
+							"description": "Indicate if tumour size was determined during the procedure.",
+							"meta": {
+								"displayName": "Tumour Size Status"
+							},
+							"restrictions": {
+								"codeList": ["Yes", "No", "Not Reported", "Not Applicable", "Unknown"]
+							}
+						},
+						{
+							"name": "tumour_length",
+							"valueType": "number",
+							"description": "Indicate the length of the tumour, in mm.",
+							"meta": {
+								"displayName": "Tumour Length"
+							},
+							"restrictions": {
+								"range": {
+									"exclusiveMin": 0
+								}
+							}
+						},
+						{
+							"name": "tumour_width",
+							"valueType": "number",
+							"description": "Indicate the width of the tumour, in mm.",
+							"meta": {
+								"displayName": "Tumour Width"
+							},
+							"restrictions": {
+								"range": {
+									"exclusiveMin": 0
+								}
+							}
+						},
+						{
+							"name": "total_tumour_size",
+							"valueType": "number",
+							"description": "Indicate the total tumour size, in mm.",
+							"meta": {
+								"displayName": "Total Tumour Size"
+							},
+							"restrictions": {
+								"range": {
+									"exclusiveMin": 0
+								}
+							}
+						},
+						{
+							"name": "tumour_focality",
+							"valueType": "string",
+							"description": "Indicate the tumour focality, the definition of the limitaion to a specific area of a tumour. ",
+							"meta": {
+								"displayName": "Tumour Focality"
+							},
+							"restrictions": {
+								"codeList": ["Cannot be assessed", "Multifocal", "Unifocal"]
+							}
+						},
+						{
+							"name": "margin_status",
+							"valueType": "string",
+							"description": "Indicate if intraoperative margins were involved.",
+							"meta": {
+								"displayName": "Margin Status"
+							},
+							"restrictions": {
+								"codeList": ["Negative", "Other", "Positive", "Suspicious for cancer", "Unknown"]
+							}
+						},
+						{
+							"name": "proximal_margin",
+							"valueType": "string",
+							"description": "Indicate if proximal margin is involved.",
+							"meta": {
+								"displayName": "Proximal Margin"
+							},
+							"restrictions": {
+								"codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
+							}
+						},
+						{
+							"name": "distal_margin",
+							"valueType": "string",
+							"description": "Indicate if distal margin is involved.",
+							"meta": {
+								"displayName": "Distal Margin"
+							},
+							"restrictions": {
+								"codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
+							}
+						},
+						{
+							"name": "circumferential_resection_margin",
+							"valueType": "string",
+							"description": "Indicate if circumferential margin is involved.",
+							"meta": {
+								"displayName": "Circumferential Resection Margin"
+							},
+							"restrictions": {
+								"codeList": ["Yes", "No", "Not Reported"]
+							}
+						},
+						{
+							"name": "lymphovascular_invasion",
+							"valueType": "string",
+							"description": "Indicate whether lymphovascular invasion (LVI) has occurred.",
+							"meta": {
+								"displayName": "Lymphovascular Invasion (LVI)"
+							},
+							"restrictions": {
+								"codeList": [
+									"Not present",
+									"Present",
+									"Lymphatic and small vessel invasion only",
+									"Venous (large vessel) invasion only",
+									"Both lymphatic and small vessel and venous (large vessel) invasion",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"name": "perineural_invasion",
+							"valueType": "string",
+							"description": "Indicate whether perineural invasion has occurred.",
+							"meta": {
+								"displayName": "Perineural Invasion"
+							},
+							"restrictions": {
+								"codeList": [
+									"Absent or not identified",
+									"Cannot be assessed",
+									"Present or identified",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"name": "microvenous_invasion",
+							"valueType": "string",
+							"description": "Indicate whether microvenous invasion has occurred.",
+							"meta": {
+								"displayName": "Microvenous Invasion"
+							},
+							"restrictions": {
+								"codeList": ["Indeterminate", "No", "Yes", "Unknown"]
+							}
+						},
+						{
+							"name": "intraoperative_findings",
+							"valueType": "string",
+							"description": "Indicate other additional intraoperative findings.",
+							"meta": {
+								"displayName": "Intraoperative Findings"
+							},
+							"restrictions": {
+								"codeList": [
+									"Ascites",
+									"Borderline resectable",
+									"Coeliac axis involvement",
+									"Metastasis to distant lymph nodes",
+									"Metastasis to other sites",
+									"None",
+									"Peritoneal dissemination",
+									"Resectable",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"name": "common_bile_duct_margin",
+							"valueType": "string",
+							"description": "Indicate if common bile duct margin is involved.",
+							"meta": {
+								"displayName": "Common Bile Duct Margin"
+							},
+							"restrictions": {
+								"codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
+							}
+						},
+						{
+							"name": "unicinate_margin",
+							"valueType": "string",
+							"description": "Indicate if unicinate margin (retroperitoneal/superior mesenteric artery) is involved.",
+							"meta": {
+								"displayName": "Unicinate Margin"
+							},
+							"restrictions": {
+								"codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
+							}
+						},
+						{
+							"name": "periuncinate_margin",
+							"valueType": "string",
+							"description": "Indicate if periuncinate margin is involved.",
+							"meta": {
+								"displayName": "Periuncinate Margin"
+							},
+							"restrictions": {
+								"codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
+							}
+						},
+						{
+							"name": "pancreatic_carcinoma_groove_margin",
+							"valueType": "string",
+							"description": "Indicate if pancreatic carcinoma groove margin is involved.",
+							"meta": {
+								"displayName": "Pancreatic Carcinoma Groove Margin"
+							},
+							"restrictions": {
+								"codeList": ["Cannot be assessed", "Involved", "Not involved", "Not applicable"]
+							}
+						},
+						{
+							"name": "state_of_pv_smv",
+							"valueType": "string",
+							"description": "Indicate the state of portal vein and/or superior mesenteric vein.",
+							"meta": {
+								"displayName": "State of Portal/Superior Mesenteric Vein"
+							},
+							"restrictions": {
+								"codeList": [
+									"Abutment (<180 degree contact)",
+									"Encasement",
+									"Indeterminate",
+									"No involvement",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"name": "state_of_pma",
+							"valueType": "string",
+							"description": "Indicate the state of superior mesenteric artery.",
+							"meta": {
+								"displayName": "State of Superior Mesenteric Artery"
+							},
+							"restrictions": {
+								"codeList": [
+									"Abutment (<180 degree contact)",
+									"Encasement",
+									"Indeterminate",
+									"No involvement",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"name": "state_of_duodenal",
+							"valueType": "string",
+							"description": "Indicate the state of duodenal involvement.",
+							"meta": {
+								"displayName": "State of Duodenal Involvement"
+							},
+							"restrictions": {
+								"codeList": [
+									"Abutment (<180 degree contact)",
+									"Encasement",
+									"Indeterminate",
+									"No involvement",
+									"Unknown"
+								]
+							}
+						},
+						{
+							"name": "state_of_common_bile_duct",
+							"valueType": "string",
+							"description": "Indicate the state of common bile duct involvement",
+							"meta": {
+								"displayName": "State of Common Bile Duct Involvement"
+							},
+							"restrictions": {
+								"codeList": [
+									"Abutment (<180 degree contact)",
+									"Encasement",
+									"Indeterminate",
+									"No involvement",
+									"Unknown"
+								]
+							}
+						}
+					]
+				}
+			],
+			"name": "ARGO Clinical Submission",
+			"version": "1.0"
+		}
+	]
 }

--- a/test/integration/submission/migration_utils/schema_builder.ts
+++ b/test/integration/submission/migration_utils/schema_builder.ts
@@ -41,7 +41,7 @@ const getSchema = (
 ): MutableSchemaDefinition => {
 	const schema = dictionary.schemas.find((s) => s.name == schemaName);
 	if (!schema) throw new Error('schema not found');
-	return schema as MutableSchemaDefinition;
+	return { ...schema, fields: [...schema.fields] } as MutableSchemaDefinition;
 };
 
 const getField = (
@@ -93,6 +93,7 @@ export const buildDynamicStubSchema = () => {
 				valueType: dictionaryEntities.ValueType.STRING,
 			},
 		],
+		restrictions: {},
 	});
 
 	// Change #8.1.2.1 removing a value from enum

--- a/test/unit/exception/applyException.spec.ts
+++ b/test/unit/exception/applyException.spec.ts
@@ -53,6 +53,7 @@ const mockSpecimenSchema: dictionaryEntities.SchemaDefinition = {
 			meta: { core: true },
 		},
 	],
+	restrictions: {},
 };
 
 const mockTreatmentSchema: dictionaryEntities.SchemaDefinition = {
@@ -66,6 +67,7 @@ const mockTreatmentSchema: dictionaryEntities.SchemaDefinition = {
 			meta: { core: true },
 		},
 	],
+	restrictions: {},
 };
 
 describe('submission service apply exceptions', () => {


### PR DESCRIPTION
## Link to Issue

[#2624](https://app.zenhub.com/workspaces/icgc-argo-platform-dk-production-board-5e542d38415f5034e9fed89d/issues/gh/icgc-argo/platform-ui/2624)

## Description
Sorts Invalid Clinical Records to the top of the list

Donor records already include sorting rules for `isValid`; this change impacts Clinical Entity records

Relates to UI changes in: https://github.com/icgc-argo/platform-ui/pull/2763

Testing examples are in ticket comments

Updates Lectern Client to 1.5 so that all errors have populated values; allows accurate sorting into invalid/valid entity record groups

<img width="1156" alt="Screenshot 2024-05-16 at 3 08 02 PM" src="https://github.com/icgc-argo/argo-clinical/assets/15621876/0f665d5c-2ab5-4993-a421-e052f8d66498">

## Checklist

### Type of Change

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
