### PR TITLE
Chore / Move Clinical Service Types

### DIFF
--- a/src/clinical/api/clinical-api.ts
+++ b/src/clinical/api/clinical-api.ts
@@ -19,7 +19,7 @@
 
 import { Request, Response } from 'express';
 import * as service from '../clinical-service';
-import { ClinicalDataQuery } from '../clinical-service';
+import { ClinicalDataQuery } from '../types';
 import { getExceptionManifestRecords } from '../../submission/exceptions/exceptions';
 import { ExceptionManifestRecord } from '../../exception/exception-manifest/types';
 import {

--- a/src/clinical/clinical-service.ts
+++ b/src/clinical/clinical-service.ts
@@ -24,11 +24,9 @@ import {
 import { DeepReadonly } from 'deep-freeze';
 import _ from 'lodash';
 import {
-	ClinicalDataSortTypes,
 	ClinicalEntityErrorRecord,
 	ClinicalEntitySchemaNames,
 	ClinicalErrorsResponseRecord,
-	EntityAlias,
 	aliasEntityNames,
 	allEntityNames,
 } from '../common-model/entities';
@@ -53,39 +51,14 @@ import { ClinicalEntityData, Donor, Sample } from './clinical-entities';
 import { DONOR_DOCUMENT_FIELDS, donorDao } from './donor-repo';
 import { runTaskInWorkerThread } from './service-worker-thread/runner';
 import { WorkerTasks } from './service-worker-thread/tasks';
-import { CompletionState } from './api/types';
+import {
+	ClinicalDataQuery,
+	ClinicalDataSortTypes,
+	ClinicalDonorEntityQuery,
+	PaginationQuery,
+} from './types';
 
 const L = loggerFor(__filename);
-
-// Base type for Clinical Data Queries
-export type ClinicalDonorEntityQuery = {
-	donorIds: number[];
-	submitterDonorIds: string[];
-	entityTypes: EntityAlias[];
-};
-
-export type PaginationQuery = {
-	page: number;
-	pageSize?: number;
-	sort: string;
-};
-
-export type ClinicalDataPaginatedQuery = ClinicalDonorEntityQuery & PaginationQuery;
-
-export type ClinicalDataQuery = ClinicalDataPaginatedQuery & {
-	completionState?: {};
-};
-
-// GQL Query Arguments
-// Submitted Data Table, SearchBar, Sidebar, etc.
-export type ClinicalDataApiFilters = ClinicalDataPaginatedQuery & {
-	completionState?: CompletionState;
-};
-
-export type ClinicalDataVariables = {
-	programShortName: string;
-	filters: ClinicalDataApiFilters;
-};
 
 export async function updateDonorSchemaMetadata(
 	donor: DeepReadonly<Donor>,

--- a/src/clinical/clinical-service.ts
+++ b/src/clinical/clinical-service.ts
@@ -24,6 +24,7 @@ import {
 import { DeepReadonly } from 'deep-freeze';
 import _ from 'lodash';
 import {
+	ClinicalDataSortTypes,
 	ClinicalEntityErrorRecord,
 	ClinicalEntitySchemaNames,
 	ClinicalErrorsResponseRecord,
@@ -69,7 +70,7 @@ export type PaginationQuery = {
 	sort: string;
 };
 
-type ClinicalDataPaginatedQuery = ClinicalDonorEntityQuery & PaginationQuery;
+export type ClinicalDataPaginatedQuery = ClinicalDonorEntityQuery & PaginationQuery;
 
 export type ClinicalDataQuery = ClinicalDataPaginatedQuery & {
 	completionState?: {};
@@ -231,8 +232,31 @@ export const getPaginatedClinicalData = async (programId: string, query: Clinica
 	// Get all donors + records for given entity
 	const { donors, totalDonors } = await donorDao.findByPaginatedProgramId(programId, query);
 
+	const donorIds = donors.map((donor) => donor.donorId);
+
+	const isDefaultDonorSort = query.sort.includes('completionStats.coreCompletionPercentage');
+	const isInvalidSort = query.sort.includes('schemaMetadata.isValid');
+
+	const clinicalErrors = isInvalidSort
+		? (await getClinicalErrors(programId, donorIds)).clinicalErrors
+		: [];
+
+	const sortType = isDefaultDonorSort
+		? ClinicalDataSortTypes.defaultDonor
+		: isInvalidSort
+		? ClinicalDataSortTypes.invalidEntity
+		: ClinicalDataSortTypes.columnSort;
+
 	const taskToRun = WorkerTasks.ExtractEntityDataFromDonors;
-	const taskArgs = [donors as Donor[], totalDonors, allSchemasWithFields, query.entityTypes, query];
+	const taskArgs = [
+		donors as Donor[],
+		totalDonors,
+		allSchemasWithFields,
+		query.entityTypes,
+		query,
+		sortType,
+		clinicalErrors,
+	];
 
 	// Return paginated data
 	const data = await runTaskInWorkerThread<{ clinicalEntities: ClinicalEntityData[] }>(

--- a/src/clinical/donor-repo.ts
+++ b/src/clinical/donor-repo.ts
@@ -18,7 +18,7 @@
  */
 
 import { Donor } from './clinical-entities';
-import { ClinicalDataQuery, ClinicalDonorEntityQuery } from './clinical-service';
+import { ClinicalDataQuery, ClinicalDonorEntityQuery } from './types';
 import { getRequiredDonorFieldsForEntityTypes } from '../common-model/functions';
 import mongoose, { PaginateModel } from 'mongoose';
 import mongoosePaginate from 'mongoose-paginate-v2';

--- a/src/clinical/service-worker-thread/tasks.ts
+++ b/src/clinical/service-worker-thread/tasks.ts
@@ -20,7 +20,9 @@
 import { DeepReadonly } from 'deep-freeze';
 import _, { isEmpty } from 'lodash';
 import {
+	ClinicalDataSortTypes,
 	ClinicalEntitySchemaNames,
+	ClinicalErrorsResponseRecord,
 	EntityAlias,
 	aliasEntityNames,
 } from '../../common-model/entities';
@@ -58,21 +60,21 @@ const isEntityInQuery = (entityName: ClinicalEntitySchemaNames, entityTypes: str
 // Main Sort Function
 const sortDocs = (
 	sortQuery: string,
-	entityName: string,
 	completionStats: CompletionDisplayRecord[],
+	sortType: keyof typeof ClinicalDataSortTypes,
+	errors: ClinicalErrorsResponseRecord[],
 ) => (currentRecord: ClinicalInfo, nextRecord: ClinicalInfo) => {
 	// Sort Value: 0 order is Unchanged, -1 Current lower index than Next, +1 Current higher index than Next
 	let order = 0;
 	const isDescending = sortQuery.startsWith('-');
-	const isDefaultSort =
-		entityName === ClinicalEntitySchemaNames.DONOR &&
-		sortQuery.includes('completionStats.coreCompletionPercentage');
 
 	const queryKey = isDescending ? sortQuery.split('-')[1] : sortQuery;
-	const key = queryKey === 'donorId' ? 'donor_id' : queryKey;
+	const key = queryKey === 'donorId' ? DONOR_ID_FIELD : queryKey;
 
-	if (isDefaultSort) {
+	if (sortType === ClinicalDataSortTypes.defaultDonor) {
 		order = sortDonorRecordsByCompletion(currentRecord, nextRecord, completionStats);
+	} else if (sortType === ClinicalDataSortTypes.invalidEntity) {
+		order = sortInvalidRecords(currentRecord, nextRecord, errors);
 	} else {
 		order = sortRecordsByColumn(currentRecord, nextRecord, key);
 	}
@@ -116,6 +118,20 @@ const sortRecordsByColumn = (
 	return valueSort;
 };
 
+// Sort Invalid Records to Top
+const sortInvalidRecords = (
+	currentRecord: ClinicalInfo,
+	nextRecord: ClinicalInfo,
+	errors: ClinicalErrorsResponseRecord[],
+) => {
+	const currentRecordIsInvalid = errors.some((record) => record.donorId === currentRecord.donor_id);
+	const nextRecordIsInvalid = errors.some((record) => record.donorId === nextRecord.donor_id);
+	const invalidSort =
+		currentRecordIsInvalid === nextRecordIsInvalid ? 0 : currentRecordIsInvalid ? -1 : 1;
+
+	return invalidSort;
+};
+
 // Formats + Organizes Clinical Data
 const mapEntityDocuments = (
 	entity: EntityClinicalInfo,
@@ -124,6 +140,8 @@ const mapEntityDocuments = (
 	entityTypes: EntityAlias[],
 	paginationQuery: PaginationQuery,
 	completionStats: CompletionDisplayRecord[],
+	sortType: keyof typeof ClinicalDataSortTypes,
+	errors: ClinicalErrorsResponseRecord[],
 ): ClinicalEntityData | undefined => {
 	const { entityName, results } = entity;
 
@@ -131,13 +149,14 @@ const mapEntityDocuments = (
 	const { page, pageSize = results.length, sort } = paginationQuery;
 	const relevantSchemaWithFields = schemas.find((s: any) => s.name === entityName);
 	const entityInQuery = isEntityInQuery(entityName, entityTypes);
+	const entityErrors = errors.filter((errorRecord) => errorRecord.entityName === entityName);
 
 	if (!relevantSchemaWithFields || !entityInQuery || isEmpty(results)) {
 		return undefined;
 	}
 
 	const totalDocs = entityName === ClinicalEntitySchemaNames.DONOR ? donorCount : results.length;
-	let records = results.sort(sortDocs(sort, entityName, completionStats));
+	let records = results.sort(sortDocs(sort, completionStats, sortType, entityErrors));
 
 	if (records.length > pageSize) {
 		// Manual Pagination
@@ -254,6 +273,8 @@ function extractEntityDataFromDonors(
 	schemasWithFields: any,
 	entityTypes: EntityAlias[],
 	paginationQuery: PaginationQuery,
+	sortType: keyof typeof ClinicalDataSortTypes,
+	errors: ClinicalErrorsResponseRecord[],
 ) {
 	let clinicalEntityData: EntityClinicalInfo[] = [];
 
@@ -312,6 +333,8 @@ function extractEntityDataFromDonors(
 				entityTypes,
 				paginationQuery,
 				completionStats,
+				sortType,
+				errors,
 			),
 		)
 		.filter(notEmpty);

--- a/src/clinical/service-worker-thread/tasks.ts
+++ b/src/clinical/service-worker-thread/tasks.ts
@@ -20,7 +20,6 @@
 import { DeepReadonly } from 'deep-freeze';
 import _, { isEmpty } from 'lodash';
 import {
-	ClinicalDataSortTypes,
 	ClinicalEntitySchemaNames,
 	ClinicalErrorsResponseRecord,
 	EntityAlias,
@@ -35,7 +34,7 @@ import {
 	getSampleRegistrationDataFromDonor,
 } from '../../common-model/functions';
 import { notEmpty } from '../../utils';
-import { ClinicalDonorEntityQuery, PaginationQuery } from '../clinical-service';
+import { ClinicalDonorEntityQuery, ClinicalDataSortTypes, PaginationQuery } from '../types';
 import {
 	ClinicalEntityData,
 	ClinicalInfo,

--- a/src/clinical/types.ts
+++ b/src/clinical/types.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { EntityAlias } from '../common-model/entities';
+import { CompletionState } from './api/types';
+
+// Types Specific to Clinical Service and Related Tasks
+
+// Base type for Clinical Data Queries
+export type ClinicalDonorEntityQuery = {
+	donorIds: number[];
+	submitterDonorIds: string[];
+	entityTypes: EntityAlias[];
+};
+
+// Types related to sorting, filtering, pagination, etc
+export type PaginationQuery = {
+	page: number;
+	pageSize?: number;
+	sort: string;
+};
+
+export type ClinicalDataPaginatedQuery = ClinicalDonorEntityQuery & PaginationQuery;
+
+export type ClinicalDataQuery = ClinicalDataPaginatedQuery & {
+	completionState?: {};
+};
+
+export const ClinicalDataSortTypes = {
+	defaultDonor: 'defaultDonor',
+	invalidEntity: 'invalidEntity',
+	columnSort: 'columnSort',
+};
+
+// GQL Query Arguments
+// Submitted Data Table, SearchBar, Sidebar, etc.
+export type ClinicalDataApiFilters = ClinicalDataPaginatedQuery & {
+	completionState?: CompletionState;
+};
+
+export type ClinicalDataVariables = {
+	programShortName: string;
+	filters: ClinicalDataApiFilters;
+};

--- a/src/common-model/entities.ts
+++ b/src/common-model/entities.ts
@@ -94,12 +94,6 @@ export interface ClinicalErrorsResponseRecord {
 	errors: ClinicalEntityErrorRecord[];
 }
 
-export const ClinicalDataSortTypes = {
-	defaultDonor: 'defaultDonor',
-	invalidEntity: 'invalidEntity',
-	columnSort: 'columnSort',
-};
-
 export type ClinicalFields =
 	| DonorFieldsEnum
 	| SpecimenFieldsEnum

--- a/src/common-model/entities.ts
+++ b/src/common-model/entities.ts
@@ -94,6 +94,12 @@ export interface ClinicalErrorsResponseRecord {
 	errors: ClinicalEntityErrorRecord[];
 }
 
+export const ClinicalDataSortTypes = {
+	defaultDonor: 'defaultDonor',
+	invalidEntity: 'invalidEntity',
+	columnSort: 'columnSort',
+};
+
 export type ClinicalFields =
 	| DonorFieldsEnum
 	| SpecimenFieldsEnum


### PR DESCRIPTION
## Link to Issue

## Description

Outcome of bugs encountered in https://github.com/icgc-argo/argo-clinical/pull/1184

Imports between Clinical Service / Service Worker Tasks were causing circular references and infinite loops; types are moved to their own file to prevent this happening again
Also helps declutter these files, keep function logic and definitions separate

## Checklist

### Type of Change

- [ ] Bug
- [x] Refactor
- [ ] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
