### PR TITLE
Fix/1189 get current dictionary switches versions

### DIFF
--- a/src/dictionary/manager.ts
+++ b/src/dictionary/manager.ts
@@ -18,20 +18,20 @@
  */
 
 import {
+	analyzer,
 	entities as dictionaryEntities,
+	restClient as dictionaryRestClient,
 	functions as dictionaryService,
 	parallel,
-	analyzer,
-	restClient as dictionaryRestClient,
 } from '@overturebio-stack/lectern-client';
-import { schemaRepo } from './repo';
-import { loggerFor } from '../logger';
-import { Donor } from '../clinical/clinical-entities';
 import { DeepReadonly } from 'deep-freeze';
-import { ClinicalEntitySchemaNames } from '../common-model/entities';
 import _ from 'lodash';
+import { Donor } from '../clinical/clinical-entities';
+import { ClinicalEntitySchemaNames } from '../common-model/entities';
 import { getClinicalEntitiesFromDonorBySchemaName } from '../common-model/functions';
+import { loggerFor } from '../logger';
 import { MigrationManager } from '../submission/migration/migration-manager';
+import { schemaRepo } from './repo';
 const L = loggerFor(__filename);
 
 let manager: SchemaManager;
@@ -51,20 +51,7 @@ class SchemaManager {
 	constructor(private schemaServiceUrl: string) {}
 
 	getCurrent = async (): Promise<dictionaryEntities.SchemasDictionary> => {
-		await this.updateManagerDictionaryIfNeeded();
 		return this.currentSchemaDictionary;
-	};
-
-	updateManagerDictionaryIfNeeded = async () => {
-		const name = this.currentSchemaDictionary.name;
-		const versionToIgnore = this.currentSchemaDictionary.version;
-
-		// try to get dictionary with different version
-		const dictionaryWithDiffVer = await schemaRepo.get(name, { versionToIgnore });
-		if (dictionaryWithDiffVer !== undefined) {
-			// dictionaryWithDiffVer found so update manager dictionary
-			this.currentSchemaDictionary = dictionaryWithDiffVer;
-		}
 	};
 
 	getCurrentName = (): string => {


### PR DESCRIPTION
## Link to Issue

- https://github.com/icgc-argo/argo-clinical/issues/1189

## Description

Dictionary manager is updated to do less work when getting the current active dictionary. The previous implementation had logic to double check if the current dictionary was no longer latest every time we asked for the dictionary. We no longer want to do this, instead only updating the current dictionary when a migration takes place.

Along with this change, we need to update the dictionary repo's code to get dictionary so that it will retrieve the most recent version dictionary from the database when a specific version is not specified.

These changes are needed in response to the changes made to keep a reference to old dictionaries after we migrate to a new dictionary. Before this, the database only kept a single dictionary so we didn't need any logic to determine which of the stored dictionaries was the correct version.

## Checklist

### Type of Change

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [x] Check branch (code change PRs go to `develop` not master)
- [c] Check copyrights for new files
- [c] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
- [x] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
