### PR TITLE
🕷️ Fix Reference Radiation prev treatment validation

### DIFF
--- a/src/common-model/entities.ts
+++ b/src/common-model/entities.ts
@@ -219,6 +219,8 @@ export enum SurgeryFieldsEnum {
 
 export enum RadiationFieldsEnum {
 	radiation_therapy_modality = 'radiation_therapy_modality',
+	radiation_boost = 'radiation_boost',
+	reference_radiation_treatment_id = 'reference_radiation_treatment_id',
 }
 
 export enum ImmunotherapyFields {

--- a/src/submission/validation-clinical/therapy.ts
+++ b/src/submission/validation-clinical/therapy.ts
@@ -130,7 +130,10 @@ const validateRadiationRecords = async (
 	// Compare across all Treatments
 	const { donors } = await donorDao.findByPaginatedProgramId(programId, query);
 
-	const storedTreatments = donors.filter((donor) => Boolean(donor?.treatments)).flat();
+	const storedTreatments = donors
+		.filter((donor) => Boolean(donor?.treatments))
+		.map((donor) => donor.treatments)
+		.flat();
 
 	let errors: SubmissionValidationError[] = [];
 

--- a/test/unit/submission/stubs.ts
+++ b/test/unit/submission/stubs.ts
@@ -801,6 +801,13 @@ export const stubs = {
 						[PrimaryDiagnosisFieldsEnum.submitter_primary_diagnosis_id]: 'PP1',
 					},
 				},
+				{
+					primaryDiagnosisId: 2,
+					clinicalInfo: {
+						[PrimaryDiagnosisFieldsEnum.submitter_donor_id]: 'AB10',
+						[PrimaryDiagnosisFieldsEnum.submitter_primary_diagnosis_id]: 'PP2',
+					},
+				},
 			],
 			clinicalInfo: {
 				[DonorFieldsEnum.vital_status]: 'Deceased',
@@ -836,6 +843,23 @@ export const stubs = {
 							therapyType: 'radiation',
 							clinicalInfo: {
 								[TreatmentFieldsEnum.submitter_treatment_id]: 'T_03',
+							},
+						},
+					],
+				},
+				{
+					treatmentId: 1,
+					clinicalInfo: {
+						[TreatmentFieldsEnum.submitter_treatment_id]: 'T_07',
+						[TreatmentFieldsEnum.submitter_donor_id]: 'AB10',
+						[TreatmentFieldsEnum.submitter_primary_diagnosis_id]: 'PP2',
+						[TreatmentFieldsEnum.treatment_type]: ['Chemotherapy', 'Radiation therapy'],
+					},
+					therapies: [
+						{
+							therapyType: 'radiation',
+							clinicalInfo: {
+								[TreatmentFieldsEnum.submitter_treatment_id]: 'T_07',
 							},
 						},
 					],

--- a/test/unit/submission/stubs.ts
+++ b/test/unit/submission/stubs.ts
@@ -782,5 +782,65 @@ export const stubs = {
 				},
 			],
 		}),
+
+		existingDonor13: (): Donor => ({
+			schemaMetadata: {
+				isValid: true,
+				lastValidSchemaVersion: '1.0',
+				originalSchemaVersion: '1.0',
+			},
+			_id: '22f23223f',
+			submitterId: 'AB10',
+			programId: 'PEME-CA',
+			donorId: 10,
+			primaryDiagnoses: [
+				{
+					primaryDiagnosisId: 1,
+					clinicalInfo: {
+						[PrimaryDiagnosisFieldsEnum.submitter_donor_id]: 'AB10',
+						[PrimaryDiagnosisFieldsEnum.submitter_primary_diagnosis_id]: 'PP1',
+					},
+				},
+			],
+			clinicalInfo: {
+				[DonorFieldsEnum.vital_status]: 'Deceased',
+			},
+			gender: 'Female',
+			specimens: [
+				{
+					submitterId: 'SPID1',
+					specimenTissueSource: 'Other',
+					clinicalInfo: {},
+					tumourNormalDesignation: 'Normal',
+					specimenType: 'Normal',
+					samples: [
+						{
+							sampleType: 'Other',
+							submitterId: 'SID1',
+						},
+					],
+				},
+			],
+			followUps: [],
+			treatments: [
+				{
+					treatmentId: 1,
+					clinicalInfo: {
+						[TreatmentFieldsEnum.submitter_treatment_id]: 'T_03',
+						[TreatmentFieldsEnum.submitter_donor_id]: 'AB10',
+						[TreatmentFieldsEnum.submitter_primary_diagnosis_id]: 'PP1',
+						[TreatmentFieldsEnum.treatment_type]: ['Chemotherapy', 'Radiation therapy'],
+					},
+					therapies: [
+						{
+							therapyType: 'radiation',
+							clinicalInfo: {
+								[TreatmentFieldsEnum.submitter_treatment_id]: 'T_03',
+							},
+						},
+					],
+				},
+			],
+		}),
 	},
 };

--- a/test/unit/submission/validation.spec.ts
+++ b/test/unit/submission/validation.spec.ts
@@ -3134,6 +3134,57 @@ describe('data-validator', () => {
 			chai.expect(result[ClinicalEntitySchemaNames.SURGERY].dataErrors[0]).to.deep.eq(error);
 		});
 
+		it('should error when submitted reference_radiation_treatment_id does not match an existing treatment_id', async () => {
+			const existingDonor = stubs.validation.existingDonor13();
+			const submissionRecordsMap = {};
+			ClinicalSubmissionRecordsOperations.addRecord(
+				ClinicalEntitySchemaNames.TREATMENT,
+				submissionRecordsMap,
+				{
+					[SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB1-',
+					[TreatmentFieldsEnum.submitter_treatment_id]: 'T_02',
+					[TreatmentFieldsEnum.treatment_type]: ['Radiation'],
+					index: 0,
+				},
+			);
+
+			ClinicalSubmissionRecordsOperations.addRecord(
+				ClinicalEntitySchemaNames.RADIATION,
+				submissionRecordsMap,
+				{
+					[SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB10',
+					[TreatmentFieldsEnum.submitter_treatment_id]: 'T_02',
+					[RadiationFieldsEnum.radiation_therapy_modality]: 'Proton',
+					[RadiationFieldsEnum.radiation_boost]: 'Yes',
+					[RadiationFieldsEnum.reference_radiation_treatment_id]: 'T_03',
+					index: 0,
+				},
+			);
+
+			const result = await dv
+				.validateSubmissionData({ ICGC_0002: submissionRecordsMap }, { ICGC_0002: existingDonor })
+				.catch((err: any) => fail(err));
+
+			console.log(result.radiation.dataErrors);
+
+			// const error: SubmissionValidationError = {
+			// 	fieldName: DonorFieldsEnum.submitter_donor_id,
+			// 	message:
+			// 		"When submitter_specimen_id is not submitted, the combination of [submitter_donor_id = 'ICGC_0002' and submitter_treatment_id = 'Tr-1' ] should only be submitted once in the Surgery schema. Please correct your data submission.",
+			// 	type: DataValidationErrors.DUPLICATE_SURGERY_WHEN_SPECIMEN_NOT_SUBMITTED,
+			// 	index: 0,
+			// 	info: {
+			// 		submitter_donor_id: 'ICGC_0002',
+			// 		submitter_treatment_id: 'Tr-1',
+			// 		donorSubmitterId: 'ICGC_0002',
+			// 		value: 'ICGC_0002',
+			// 	},
+			// };
+
+			// chai.expect(result[ClinicalEntitySchemaNames.SURGERY].dataErrors.length).equal(1);
+			// chai.expect(result[ClinicalEntitySchemaNames.SURGERY].dataErrors[0]).to.deep.eq(error);
+		});
+
 		it('should error when submitter_specimen_id is not submitted, two surgeries are associated with the same submitter_donor_id and submitter_treatment_id', async () => {
 			const existingDonor = stubs.validation.existingDonor09();
 			const submissionRecordsMap = {};

--- a/test/unit/submission/validation.spec.ts
+++ b/test/unit/submission/validation.spec.ts
@@ -3134,6 +3134,37 @@ describe('data-validator', () => {
 			chai.expect(result[ClinicalEntitySchemaNames.SURGERY].dataErrors[0]).to.deep.eq(error);
 		});
 
+		it('should succeed when submitted reference_radiation_treatment_id matched the current Donors treatment_id', async () => {
+			const existingDonor = stubs.validation.existingDonor13();
+			donorDaoFindByPaginatedProgramId.restore();
+
+			sinon
+				.stub(donorDao, 'findByPaginatedProgramId')
+				.resolves({ donors: [existingDonor], totalDonors: 1 });
+
+			const submissionRecordsMap = {};
+
+			// Success Case
+			ClinicalSubmissionRecordsOperations.addRecord(
+				ClinicalEntitySchemaNames.RADIATION,
+				submissionRecordsMap,
+				{
+					[SampleRegistrationFieldsEnum.submitter_donor_id]: 'AB10',
+					[TreatmentFieldsEnum.submitter_treatment_id]: 'T_03',
+					[RadiationFieldsEnum.radiation_therapy_modality]: 'Proton',
+					[RadiationFieldsEnum.radiation_boost]: 'Yes',
+					[RadiationFieldsEnum.reference_radiation_treatment_id]: 'T_03',
+					index: 0,
+				},
+			);
+
+			const result = await dv
+				.validateSubmissionData({ ICGC_0002: submissionRecordsMap }, { ICGC_0002: existingDonor })
+				.catch((err: any) => fail(err));
+
+			chai.expect(result[ClinicalEntitySchemaNames.RADIATION].dataErrors.length).equal(0);
+		});
+
 		it('should error when submitted reference_radiation_treatment_id does not match submitted treatment_id', async () => {
 			const existingDonor = stubs.validation.existingDonor13();
 


### PR DESCRIPTION
## Link to Issue

<!-- Link of the form: https://github.com/icgc-argo/roadmap/issues/xxxx -->

## Description

@lindaxiang found that reference radiation ID validation was incorrectly triggering errors when the reference radiation id matched an existing treatment id

PR updates validation logic to correctly check treatment records, with added unit test

## Checklist

### Type of Change

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
