### PR TITLE
Bug: Handle Empty RxNorm fields

### DIFF
--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -950,7 +950,7 @@ export namespace operations {
 		};
 	};
 
-	export function isRxNormTherapy(entity: string) {
+	function isRxNormTherapy(entity: string) {
 		return (
 			entity == ClinicalEntitySchemaNames.CHEMOTHERAPY ||
 			entity == ClinicalEntitySchemaNames.HORMONE_THERAPY ||


### PR DESCRIPTION
## Link to Issue

[Feedback for #1194](https://github.com/icgc-argo/argo-clinical/issues/1194)

## Description

Disables RxNorm Validation when alternate drug db fields are added

## Checklist

### Type of Change

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [ ] Check branch (code change PRs go to `develop` not master)
- [ ] Check copyrights for new files
- [ ] Manual testing
- [ ] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [ ] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
