### PR TITLE
Add entity exception does no check for existing program exception

### DIFF
--- a/src/exception/property-exceptions/property-exception-api.ts
+++ b/src/exception/property-exceptions/property-exception-api.ts
@@ -110,12 +110,6 @@ class ExceptionController {
 	@HasFullWriteAccess()
 	async createEntityException(req: Request, res: Response) {
 		const programId = req.params.programId;
-		const programException = await programExceptionRepository.find(programId);
-
-		if (programException?.exceptions?.length) {
-			L.debug('program exception exists already');
-			return res.status(400).send('Program exception already exists');
-		}
 
 		const records = await parseTSV(req.file.path);
 		// validate tsv structure using cols, does not validate field data


### PR DESCRIPTION
## Link to Issue

https://github.com/icgc-argo/roadmap/issues/1184

## Description

Add entity exceptions had a check that prevented entity exceptions from being added if exceptions were registered for that program. There is no reason to do this check. In fact, if you add entity exceptions it was already possible to then add program exception. Both types of exceptions are being used in validation.

This removes the uneccessary check.

## Checklist

### Type of Change

- [x] Bug
- [ ] Refactor
- [ ] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Check copyrights for new files
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
- [x] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
