### PR TITLE
fix rxnorm failing status report

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -158,7 +158,9 @@ async function pingRxNorm(pool: Pool) {
 		setStatus('rxNormDb', { status: Status.OK });
 
 		// Recursively checks for rxnorm connection every 5 minutes
-		setTimeout(pingRxNorm, 5 * 60 * 1000);
+		setTimeout(() => {
+			pingRxNorm(pool);
+		}, 5 * 60 * 1000);
 	} catch (err) {
 		L.error('cannot get connection to rxnorm', err);
 		setStatus('rxNormDb', { status: Status.ERROR });


### PR DESCRIPTION
the change herein should be fairly self explanatory based on the error we're getting 🤞 

```
error: cannot get connection to rxnormCannot read properties of undefined (reading 'getConnection') {"stack":"TypeError: Cannot read properties of undefined (reading 'getConnection')
    at Timeout.<anonymous> (/app/dist/src/bootstrap.js:184:43)
    at Generator.next (<anonymous>)
    at /app/dist/src/bootstrap.js:49:71
    at new Promise (<anonymous>)
    at __awaiter (/app/dist/src/bootstrap.js:45:12)
    at Timeout.pingRxNorm [as _onTimeout] (/app/dist/src/bootstrap.js:182:12)
    at listOnTimeout (node:internal/timers:569:17)
    at process.processTimers (node:internal/timers:512:7)"}
```