### PR TITLE
Hotfix/1.89.0

### DIFF
--- a/src/common-model/functions.ts
+++ b/src/common-model/functions.ts
@@ -272,6 +272,13 @@ export const calculateSpecimenCompletionStats = (
 	const normalSubmissions = normalSubmittedRecords.length;
 	const tumourSubmissions = tumourSubmittedRecords.length;
 
+	/**
+	 * if there is an exception:
+	 * - sets normalSpecimensPercentage to 1
+	 * - UI reads core complete as having errors if set to 0
+	 * - normalRegistrations and normalSubmissions are 0
+	 *
+	 */
 	const normalSpecimensPercentage = hasSingleSpecimenException
 		? 1
 		: normalRegistrations === 0 || normalSubmissions === 0

--- a/src/common-model/functions.ts
+++ b/src/common-model/functions.ts
@@ -272,10 +272,11 @@ export const calculateSpecimenCompletionStats = (
 	const normalSubmissions = normalSubmittedRecords.length;
 	const tumourSubmissions = tumourSubmittedRecords.length;
 
-	const normalSpecimensPercentage =
-		normalRegistrations === 0 || normalSubmissions === 0
-			? 0
-			: normalSubmissions / normalRegistrations;
+	const normalSpecimensPercentage = hasSingleSpecimenException
+		? 1
+		: normalRegistrations === 0 || normalSubmissions === 0
+		? 0
+		: normalSubmissions / normalRegistrations;
 
 	const tumourSpecimensPercentage =
 		tumourRegistrations === 0 || tumourSubmissions === 0

--- a/src/exception/coreComplete.ts
+++ b/src/exception/coreComplete.ts
@@ -17,19 +17,16 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import deepFreeze, { DeepReadonly } from 'deep-freeze';
-import { Result } from 'express-validator';
+import { DeepReadonly } from 'deep-freeze';
 import { Donor } from '../clinical/clinical-entities';
 import { updateDonorsCompletionStats } from '../submission/submission-to-clinical/stat-calculator';
-import { success, failure } from '../utils/results';
 import { donorDao as donorRepo } from '../clinical/donor-repo';
 import { loggerFor } from '../logger';
 
 const L = loggerFor(__filename);
 
-export const recalcCoreCompletionForProgram = async (
-	programId: string,
-): Promise<Result<DeepReadonly<Donor>>> => {
+// this is run async after request
+export const recalcCoreCompletionForProgram = async (programId: string) => {
 	try {
 		// keep mongo doc ids, important for updates
 		const donors = await donorRepo.findByProgramId(programId, {}, false);
@@ -37,8 +34,7 @@ export const recalcCoreCompletionForProgram = async (
 			((donors || []) as unknown) as DeepReadonly<Donor>[],
 		);
 
-		const savedDonors = await donorRepo.updateAll(updatedDonors);
-		return success(savedDonors);
+		await donorRepo.updateAll(updatedDonors);
 	} catch (error) {
 		const message = `Error thrown while updating donor core completion data for program ${programId}`;
 		L.error(message, error);

--- a/src/exception/coreComplete.ts
+++ b/src/exception/coreComplete.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import deepFreeze, { DeepReadonly } from 'deep-freeze';
+import { Result } from 'express-validator';
+import { Donor } from '../clinical/clinical-entities';
+import { updateDonorsCompletionStats } from '../submission/submission-to-clinical/stat-calculator';
+import { success, failure } from '../utils/results';
+import { donorDao as donorRepo } from '../clinical/donor-repo';
+import { loggerFor } from '../logger';
+
+const L = loggerFor(__filename);
+
+export const recalcCoreCompletionForProgram = async (
+	programId: string,
+): Promise<Result<DeepReadonly<Donor>>> => {
+	try {
+		// keep mongo doc ids, important for updates
+		const donors = await donorRepo.findByProgramId(programId, {}, false);
+		const updatedDonors = await updateDonorsCompletionStats(
+			((donors || []) as unknown) as DeepReadonly<Donor>[],
+		);
+
+		const savedDonors = await donorRepo.updateAll(updatedDonors);
+		return success(savedDonors);
+	} catch (error) {
+		const message = `Error thrown while updating donor core completion data for program ${programId}`;
+		L.error(message, error);
+	}
+};

--- a/src/exception/coreComplete.ts
+++ b/src/exception/coreComplete.ts
@@ -25,7 +25,12 @@ import { loggerFor } from '../logger';
 
 const L = loggerFor(__filename);
 
-// this is run async after request
+/**
+ * Recalculates core completion percentage for a provided program id
+ * Updates donors in database with updated core completion
+ *
+ * @param programId
+ */
 export const recalcCoreCompletionForProgram = async (programId: string) => {
 	try {
 		// keep mongo doc ids, important for updates

--- a/src/exception/sample-exceptions/service.ts
+++ b/src/exception/sample-exceptions/service.ts
@@ -17,10 +17,21 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import { recalcCoreCompletionForProgram } from '../coreComplete';
 import { createOrUpdate } from './repo';
 
 export const create = async ({ programIds }: { programIds: string[] }) => {
 	const uniqueExceptions = Array.from(new Set(programIds));
-	const result = createOrUpdate(uniqueExceptions);
+	const result = await createOrUpdate(uniqueExceptions);
+
+	if (result.success) {
+		const programIds = result.data.programIds;
+		// Intentionally no await here:
+		// We want this to run asynchronously after we return a response for this request. Consider this a post processing step.
+		// Same process as missing entity exception
+		programIds.forEach((programId) => {
+			recalcCoreCompletionForProgram(programId);
+		});
+	}
 	return result;
 };

--- a/src/exception/sample-exceptions/service.ts
+++ b/src/exception/sample-exceptions/service.ts
@@ -17,36 +17,30 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { difference } from 'lodash';
+import { union } from 'lodash';
 import { recalcCoreCompletionForProgram } from '../coreComplete';
 import { createOrUpdate, getExceptions } from './repo';
 import { failure } from '../../utils/results';
 
 /**
- * [newArray], [oldArray] => [updates array]
- * [], [a] => [a]
- * [a], [a] => [a]
- * [b], [a] => [b]
- * [b], [a,b] => [a]
+ * Returns an array of program ids to update
+ *
+ * [new exception program ids], [old exception program ids] => [program ids to recalc]
  */
-const getDiff = (oldArray: string[], newArray: string[]) => {
-	if (newArray.length === 0) {
-		return oldArray;
-	} else if (newArray.length === 1) {
-		return newArray;
-	} else {
-		return difference(newArray, oldArray);
-	}
+export const getProgramsToUpdate = (oldArray: string[], newArray: string[]) => {
+	return union(oldArray, newArray);
 };
 
 export const create = async ({ programIds }: { programIds: string[] }) => {
 	const uniqueExceptions = Array.from(new Set(programIds));
 	const oldExceptionsResult = await getExceptions();
+
+	// update exceptions
 	const newExceptionsResult = await createOrUpdate(uniqueExceptions);
 
 	if (oldExceptionsResult.success && newExceptionsResult.success) {
 		// program ids to update
-		const programIdsToUpdate = getDiff(
+		const programIdsToUpdate = getProgramsToUpdate(
 			oldExceptionsResult.data,
 			newExceptionsResult.data.programIds,
 		);

--- a/test/unit/submission/sample-exceptions/core-completion.spec.ts
+++ b/test/unit/submission/sample-exceptions/core-completion.spec.ts
@@ -18,8 +18,8 @@
  */
 import chai from 'chai';
 
-import { Specimen } from '../../../src/clinical/clinical-entities';
-import { calculateSpecimenCompletionStats } from '../../../src/common-model/functions';
+import { Specimen } from '../../../../src/clinical/clinical-entities';
+import { calculateSpecimenCompletionStats } from '../../../../src/common-model/functions';
 
 const specimens: Specimen[] = [
 	{

--- a/test/unit/submission/sample-exceptions/getProgramsToUpdate.spec.ts
+++ b/test/unit/submission/sample-exceptions/getProgramsToUpdate.spec.ts
@@ -19,7 +19,7 @@
 import chai from 'chai';
 import { getProgramsToUpdate } from '../../../../src/exception/sample-exceptions/service';
 
-describe.only('Sample specimen exception', () => {
+describe('Sample specimen exception', () => {
 	describe('calculates program ids to update', () => {
 		it('existing empty array, update is empty array', () => {
 			const update: string[] = [];

--- a/test/unit/submission/sample-exceptions/getProgramsToUpdate.spec.ts
+++ b/test/unit/submission/sample-exceptions/getProgramsToUpdate.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import chai from 'chai';
+import { getProgramsToUpdate } from '../../../../src/exception/sample-exceptions/service';
+
+describe.only('Sample specimen exception', () => {
+	describe('calculates program ids to update', () => {
+		it('existing empty array, update is empty array', () => {
+			const update: string[] = [];
+			const current: string[] = [];
+			const result = getProgramsToUpdate(current, update);
+			chai.expect(result).to.have.members([]);
+		});
+		it('existing program id exception, update is empty array', () => {
+			const update: string[] = [];
+			const current = ['TEST-CA'];
+			const result = getProgramsToUpdate(current, update);
+			chai.expect(result).to.have.members(['TEST-CA']);
+		});
+		it('existing program id exception, update is one program id exception', () => {
+			const update = ['TEST-CA'];
+			const current = ['TEST-CA'];
+			const result = getProgramsToUpdate(current, update);
+			chai.expect(result).to.have.members(['TEST-CA']);
+		});
+		it('existing program id exceptions, update is multiple program id exceptions', () => {
+			const update = ['TEST-CA', 'TEST-FR'];
+			const current = ['CIA-IE', 'CIA-GE'];
+			const result = getProgramsToUpdate(current, update);
+			chai.expect(result).to.have.members(['TEST-CA', 'TEST-FR', 'CIA-IE', 'CIA-GE']);
+		});
+	});
+});


### PR DESCRIPTION
- add recalc for core completion on create/update/delete
- sets `normalSpecimensPercentage` to 1 if there is an exception, important for UI to display correctly
- keeps normalRegistrations and normalSubmissions as 0
