### PR TITLE
Schema Manager will return latest dictionary after migratons

### DIFF
--- a/src/dictionary/manager.ts
+++ b/src/dictionary/manager.ts
@@ -207,7 +207,7 @@ class SchemaManager {
 		newVersion: string,
 	): Promise<dictionaryEntities.SchemasDictionary> => {
 		const newSchema = await this.loadSchemaByVersion(name, newVersion);
-		if (newSchema == undefined) {
+		if (newSchema === undefined) {
 			throw new Error("couldn't save/update new schema, schema is undefined.");
 		}
 		const result = await schemaRepo.createOrUpdate(newSchema);

--- a/src/dictionary/manager.ts
+++ b/src/dictionary/manager.ts
@@ -32,6 +32,7 @@ import { getClinicalEntitiesFromDonorBySchemaName } from '../common-model/functi
 import { loggerFor } from '../logger';
 import { MigrationManager } from '../submission/migration/migration-manager';
 import { schemaRepo } from './repo';
+import { migrationRepo } from '../submission/migration/migration-repo';
 const L = loggerFor(__filename);
 
 let manager: SchemaManager;
@@ -50,11 +51,34 @@ class SchemaManager {
 
 	constructor(private schemaServiceUrl: string) {}
 
+	/**
+	 * This will get the currently in use dictionary version. This call will double check with the db
+	 * to see if there has been a successful migration that has changed the current version, and if so
+	 * it will update the current version to the dictionary from the latest migration. This update will
+	 * read the dictionary data either from the DB, or from Lectern if it is not in the DB yet.
+	 *
+	 * @throws An error if no data for the latest dictionary can be found
+	 *
+	 * @returns the current dictionary according to the lateset migration in the DB
+	 */
 	getCurrent = async (): Promise<dictionaryEntities.SchemasDictionary> => {
+		const latestMigration = await migrationRepo.getLatestSuccessful();
+		if (!latestMigration) {
+			return this.currentSchemaDictionary;
+		}
+		if (latestMigration.toVersion === this.currentSchemaDictionary.version) {
+			return this.currentSchemaDictionary;
+		}
+		const newDictionary = await this.loadSchemaAndSave(
+			this.currentSchemaDictionary.name,
+			latestMigration.toVersion,
+		);
+		this.currentSchemaDictionary = newSchema;
 		return this.currentSchemaDictionary;
 	};
 
 	getCurrentName = (): string => {
+		// This does not need to use this.getCurrent() since we have no situation where the name will update
 		return this.currentSchemaDictionary.name;
 	};
 
@@ -170,6 +194,11 @@ class SchemaManager {
 		return result;
 	};
 
+	/**
+	 * Fetches schema from lectern server and then saves it to `this.currentSchemaDictionary`.
+	 *
+	 * @throws Throws an error if fetch fails.
+	 */
 	loadAndSaveNewVersion = async (
 		name: string,
 		newVersion: string,
@@ -186,6 +215,11 @@ class SchemaManager {
 		return this.currentSchemaDictionary;
 	};
 
+	/**
+	 * Fetches schema from lectern server,
+	 *
+	 * @throws Throws an error if fetch fails.
+	 */
 	loadSchemaByVersion = async (
 		name: string,
 		version: string,
@@ -203,23 +237,20 @@ class SchemaManager {
 		}
 	};
 
+	/**
+	 * Loads new schema data from the DB. If the data is not available in the DB, attempts to fetch
+	 * the data from lectern. If the data is found, this will create a new DB entry and set the current
+	 * dictionary with that data.
+	 *
+	 * @throws Error when the fetch fails to return the new dictionary, or when a db write fails
+	 */
 	loadSchemaAndSave = async (
 		name: string,
-		initialVersion: string,
+		version: string,
 	): Promise<dictionaryEntities.SchemasDictionary> => {
-		L.debug(`in loadSchema ${initialVersion}`);
-		if (!initialVersion) {
-			throw new Error('initial version cannot be empty.');
-		}
-		const storedSchema = await schemaRepo.get(name, {});
-		if (storedSchema === undefined) {
-			L.info(`schema not found in db`);
-			this.currentSchemaDictionary = {
-				schemas: [],
-				name: name,
-				version: initialVersion,
-			};
-		} else {
+		L.debug(`in loadSchema ${version}`);
+		const storedSchema = await schemaRepo.get(name, { requestedVersion: version });
+		if (storedSchema) {
 			L.info(`schema found in db`);
 			this.currentSchemaDictionary = storedSchema;
 		}
@@ -247,8 +278,10 @@ class SchemaManager {
 		return this.currentSchemaDictionary;
 	};
 
+	/**
+	 * Initiate new migration to new schema version
+	 */
 	updateSchemaVersion = async (toVersion: string, updater: string, sync?: boolean) => {
-		// submit the migration request
 		const currentDictionaryVersion = await this.getCurrentVersion();
 		return await MigrationManager.submitMigration(
 			currentDictionaryVersion,

--- a/src/dictionary/manager.ts
+++ b/src/dictionary/manager.ts
@@ -73,7 +73,7 @@ class SchemaManager {
 			this.currentSchemaDictionary.name,
 			latestMigration.toVersion,
 		);
-		this.currentSchemaDictionary = newSchema;
+		this.currentSchemaDictionary = newDictionary;
 		return this.currentSchemaDictionary;
 	};
 
@@ -253,29 +253,24 @@ class SchemaManager {
 		if (storedSchema) {
 			L.info(`schema found in db`);
 			this.currentSchemaDictionary = storedSchema;
+			return storedSchema;
 		}
 
 		// if the schema is not complete we need to load it from the
 		// schema service (lectern)
-		if (
-			!this.currentSchemaDictionary.schemas ||
-			this.currentSchemaDictionary.schemas.length === 0
-		) {
-			L.debug(`fetching schema from schema service.`);
-			const result = await this.loadSchemaByVersion(name, this.currentSchemaDictionary.version);
-			if (result == undefined) {
-				throw new Error("couldn't save/update new schema, schema is undefined.");
-			}
-			L.info(`fetched schema ${result.version}`);
-			this.currentSchemaDictionary.schemas = result.schemas;
-			const saved = await schemaRepo.createOrUpdate(this.currentSchemaDictionary);
-			if (!saved) {
-				throw new Error("couldn't save/update new schema");
-			}
-			L.info(`schema saved in db`);
-			return saved;
+		L.debug(`fetching schema from schema service.`);
+		const result = await this.loadSchemaByVersion(name, version);
+		if (result == undefined) {
+			throw new Error("couldn't save/update new schema, schema is undefined.");
 		}
-		return this.currentSchemaDictionary;
+		L.info(`fetched schema ${result.version}`);
+		this.currentSchemaDictionary = result;
+		const saved = await schemaRepo.createOrUpdate(this.currentSchemaDictionary);
+		if (!saved) {
+			throw new Error("couldn't save/update new schema");
+		}
+		L.info(`schema saved in db`);
+		return saved;
 	};
 
 	/**

--- a/src/dictionary/manager.ts
+++ b/src/dictionary/manager.ts
@@ -78,7 +78,10 @@ class SchemaManager {
 	};
 
 	getCurrentName = (): string => {
-		// This does not need to use this.getCurrent() since we have no situation where the name will update
+		// Unlike the other getters in this class, this one can be synchronous because it does not require
+		// to use this.getCurrent(). Since this is only returning the Dictionary name, and the dictionary name
+		// once set will never change (migrations keep dictionary name the same) we can return the local
+		// value without checking for the latest dictionary.
 		return this.currentSchemaDictionary.name;
 	};
 

--- a/src/dictionary/manager.ts
+++ b/src/dictionary/manager.ts
@@ -346,4 +346,12 @@ export function instance() {
 
 export function create(schemaServiceUrl: string) {
 	manager = new SchemaManager(schemaServiceUrl);
+	manager
+		.getCurrent()
+		.catch((e) =>
+			L.error(
+				'Was unable to retrieve latest Schemas during initialization of SchemaManager.',
+				undefined,
+			),
+		);
 }


### PR DESCRIPTION
## Link to Issue

- https://github.com/icgc-argo/argo-clinical/issues/1235

## Description

Addresses the issue where multiple concurrent instances of this service can have the dictionary data be out of date after a migration. This will force the SchemaManager to always check the DB if it has the latest schema information loaded, and to fetch it (from DB or Lectern) when needed.

## Checklist

### Type of Change

- [ ] Bug
- [ ] Refactor
- [x] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Check copyrights for new files
- [ ] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [ ] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
- [x] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
