### PR TITLE
Clinical Upload single rxnorm db query optimise

### DIFF
--- a/src/rxnorm/api.ts
+++ b/src/rxnorm/api.ts
@@ -26,5 +26,5 @@ export interface RxNormConcept {
 }
 
 export interface RxNormService {
-	lookupByRxcui(rxcui: string): Promise<RxNormConcept[]>;
+	lookupBulkByRxcui(rxcui: string[]): Promise<Map<string, RxNormConcept[]>>;
 }

--- a/src/rxnorm/service.ts
+++ b/src/rxnorm/service.ts
@@ -20,30 +20,52 @@
 import mysql from 'mysql2/promise';
 import { RxNormConcept, RxNormService } from './api';
 import { getPool } from './pool';
+import { loggerFor } from '../logger';
 
-// we take the first one orderd alphabetically
-const rxcuiQuery = 'select RXCUI, STR from RXNCONSO where RXCUI = ? order by STR asc';
+const L = loggerFor(__filename);
 
 type RxNormRecord = { RXCUI: string; STR: string };
 
 class MysqlRxNormService implements RxNormService {
-	async lookupByRxcui(rxcui: string): Promise<RxNormConcept[]> {
+	async lookupBulkByRxcui(rxcuis: string[]): Promise<Map<string, RxNormConcept[]>> {
+		if (rxcuis.length === 0) {
+			return new Map();
+		}
+
+		const lookupBulkStart = Date.now();
+
 		const pool = getPool();
-		const formattedQuery = mysql.format(rxcuiQuery, [rxcui]);
+
+		const bulkQuery = 'SELECT RXCUI, STR FROM RXNCONSO WHERE RXCUI IN (?) ORDER BY STR ASC';
+		const formattedQuery = mysql.format(bulkQuery, [rxcuis]);
 
 		const connection = await pool.getConnection();
 		const [result] = await connection.query(formattedQuery);
 		pool.releaseConnection(connection);
 
+		L.debug(`lookupBulkByRxcui: ${Date.now() - lookupBulkStart}ms for ${rxcuis.length} rxcuis`);
+
+		/**
+		 * one RXCUI can have many string representations
+		 * eg. 239 - Aclarubicin, 239 Aclarubicin (substance) (public data)
+		 */
+		const resultMap = new Map<string, RxNormConcept[]>();
+
 		if (Array.isArray(result)) {
 			const records = result as RxNormRecord[];
-			return records.map((r) => ({
-				rxcui: r['RXCUI'],
-				str: r['STR'],
-			}));
-		} else {
-			return new Array<RxNormConcept>();
+			records.forEach((r) => {
+				const rxcui = r['RXCUI'];
+				if (!resultMap.has(rxcui)) {
+					resultMap.set(rxcui, []);
+				}
+				resultMap.get(rxcui)!.push({
+					rxcui: r['RXCUI'],
+					str: r['STR'],
+				});
+			});
 		}
+
+		return resultMap;
 	}
 }
 

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -47,11 +47,11 @@ import { notEmpty } from '../../utils';
 import { SubmittedClinicalRecord } from '../submission-entities';
 
 /**
- * query db for program or entity exceptions
+ * query db for program and entity exceptions
  * @param programId
  * @returns program and donor level exceptions for this programId
  */
-const queryForExceptions = async (programId: string) => {
+export const queryForExceptions = async (programId: string) => {
 	const programException = await programExceptionRepository.find(programId);
 	const entityException = await entityExceptionRepository.find(programId);
 
@@ -193,6 +193,7 @@ const isValidNumericExceptionType = (
  * @param programId
  * @param record
  * @param schemaValidationErrors
+ * @param exceptionsCache optional cache of exceptions db query
  */
 export const checkForProgramAndEntityExceptions = async ({
 	programId,
@@ -200,21 +201,35 @@ export const checkForProgramAndEntityExceptions = async ({
 	schemaName,
 	entitySchema,
 	validationErrors,
+	exceptionsCache,
 }: {
-	programId: string;
+	programId?: string;
 	record: DeepReadonly<TypedDataRecord>;
 	schemaName: ClinicalEntitySchemaNames;
 	entitySchema: dictionaryEntities.SchemaDefinition | undefined;
 	validationErrors: dictionaryEntities.SchemaValidationError[];
+	exceptionsCache?: {
+		programException: ProgramException | null;
+		entityException: EntityException | null;
+	};
 }) => {
 	const filteredErrors: dictionaryEntities.SchemaValidationError[] = [];
 	let normalizedRecord = record;
 
-	// retrieve submitted exceptions for program id (both program level and entity level)
-	const { programException, entityException } = await queryForExceptions(programId);
+	/*
+	 * retrieve submitted exceptions for program id (both program level and entity level)
+	 *
+	 * if exceptionsCache is provided, reads from it (no write)
+	 * else, queries exception db using programId
+	 */
+	const exceptions = exceptionsCache
+		? exceptionsCache
+		: programId
+		? await queryForExceptions(programId)
+		: undefined;
 
 	// if there are submitted exceptions for this program, check if they match record values
-	if (!(programException || entityException)) {
+	if (!(exceptions?.programException || exceptions?.entityException)) {
 		return { filteredErrors: validationErrors, normalizedRecord };
 	}
 
@@ -247,8 +262,8 @@ export const checkForProgramAndEntityExceptions = async ({
 
 			const valueHasException = validateFieldValueWithExceptions({
 				record,
-				programException,
-				entityException,
+				programException: exceptions.programException,
+				entityException: exceptions.entityException,
 				schemaName,
 				validationErrorFieldName: validationError.fieldName,
 				fieldValue: normalizedFieldValue,

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -872,7 +872,7 @@ export namespace operations {
 		let errorsAccumulator: DeepReadonly<SubmissionValidationError[]> = [];
 		const validRecordsAccumulator: any[] = [];
 
-		let rxNormCache: Map<string, RxNormConcept[]> | null = null;
+		let rxNormCache: Map<string, RxNormConcept[]> | undefined;
 		if (isRxNormTherapy(command.clinicalType)) {
 			const rxNormIds = new Set<string>();
 
@@ -992,7 +992,7 @@ export namespace operations {
 		r: dictionaryEntities.TypedDataRecord,
 		index: number,
 		therapyType: ClinicalEntitySchemaNames,
-		rxNormCache: Map<string, RxNormConcept[]> | null,
+		rxNormCache: Map<string, RxNormConcept[]> | undefined,
 	): Promise<{
 		record: dictionaryEntities.TypedDataRecord | undefined;
 		error: SubmissionValidationError | undefined;
@@ -1024,7 +1024,7 @@ export namespace operations {
 	async function lookupRxNormConcept(
 		therapyRecord: dictionaryEntities.TypedDataRecord,
 		index: number,
-		rxNormCache: Map<string, RxNormConcept[]> | null,
+		rxNormCache: Map<string, RxNormConcept[]> | undefined,
 	): Promise<{
 		rxNormRecord: RxNormConcept | undefined;
 		error: SubmissionValidationError | undefined;

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -872,6 +872,27 @@ export namespace operations {
 		let errorsAccumulator: DeepReadonly<SubmissionValidationError[]> = [];
 		const validRecordsAccumulator: any[] = [];
 
+		let rxNormCache: Map<string, RxNormConcept[]> | null = null;
+		if (isRxNormTherapy(command.clinicalType)) {
+			const rxNormIds = new Set<string>();
+
+			// collect unique RxCUIs from records
+			command.records.forEach((record) => {
+				const rxcui = record[TherapyRxNormFieldsEnum.drug_rxnormid];
+				if (rxcui && !Array.isArray(rxcui) && !isEmptyString(rxcui)) {
+					rxNormIds.add(rxcui.trim());
+				}
+			});
+
+			// ONE database query for ALL RxCUIs
+			if (rxNormIds.size > 0) {
+				L.debug(`Pre-loading ${rxNormIds.size} unique RxNorm IDs...`);
+				const cacheStart = Date.now();
+				rxNormCache = await dbRxNormService.lookupBulkByRxcui(Array.from(rxNormIds));
+				L.debug(`RxNorm cache loaded in ${Date.now() - cacheStart}ms`);
+			}
+		}
+
 		await Promise.all(
 			command.records.map(async (record, index) => {
 				let processedRecord: any = {};
@@ -881,8 +902,8 @@ export namespace operations {
 
 				if (schemaResult.validationErrors.length > 0) {
 					let validationErrors = [...schemaResult.validationErrors];
-
 					if (featureFlags.FEATURE_SUBMISSION_EXCEPTIONS_ENABLED) {
+						const exceptionStart = Date.now();
 						/***
 						 * Checking if a valid exception exists and the record value matches it
 						 * If there's a match, we allow the value to pass schema validation
@@ -897,6 +918,8 @@ export namespace operations {
 							entitySchema,
 							validationErrors: [...schemaResult.validationErrors],
 						});
+						L.debug(`[Record ${index}] Exception check: ${Date.now() - exceptionStart}ms`);
+
 						validationErrors = filteredErrors;
 						processedRecord = normalizedRecord;
 					}
@@ -930,7 +953,14 @@ export namespace operations {
 					isRxNormTherapy(command.clinicalType) &&
 					!hasDrugDbFields
 				) {
-					const result = await validateRxNormFields(processedRecord, index, schemaName);
+					const rxStart = Date.now();
+					const result = await validateRxNormFields(
+						processedRecord,
+						index,
+						schemaName,
+						rxNormCache,
+					);
+					L.debug(`[Record ${index}] RxNorm: ${Date.now() - rxStart}ms`);
 					if (result.error != undefined) {
 						errorsAccumulator = errorsAccumulator.concat([result.error]);
 					}
@@ -962,11 +992,12 @@ export namespace operations {
 		r: dictionaryEntities.TypedDataRecord,
 		index: number,
 		therapyType: ClinicalEntitySchemaNames,
+		rxNormCache: Map<string, RxNormConcept[]> | null,
 	): Promise<{
 		record: dictionaryEntities.TypedDataRecord | undefined;
 		error: SubmissionValidationError | undefined;
 	}> {
-		const rxnormConceptLookupResult = await lookupRxNormConcept(r, index);
+		const rxnormConceptLookupResult = await lookupRxNormConcept(r, index, rxNormCache);
 		if (rxnormConceptLookupResult.error != undefined) {
 			rxnormConceptLookupResult.error.info = getValidationErrorInfoObject(
 				therapyType,
@@ -993,6 +1024,7 @@ export namespace operations {
 	async function lookupRxNormConcept(
 		therapyRecord: dictionaryEntities.TypedDataRecord,
 		index: number,
+		rxNormCache: Map<string, RxNormConcept[]> | null,
 	): Promise<{
 		rxNormRecord: RxNormConcept | undefined;
 		error: SubmissionValidationError | undefined;
@@ -1000,7 +1032,8 @@ export namespace operations {
 		// if the id is provided we do a look up and double check against the name (if provided)
 		if (isNotAbsent(therapyRecord[TherapyRxNormFieldsEnum.drug_rxnormid] as string)) {
 			const rxcui = therapyRecord[TherapyRxNormFieldsEnum.drug_rxnormid] as string;
-			const rxRecords = await dbRxNormService.lookupByRxcui(rxcui.trim());
+			const rxRecords = rxNormCache?.get(rxcui.trim()) || [];
+
 			if (_.isEmpty(rxRecords)) {
 				const error: SubmissionValidationError = {
 					fieldName: TherapyRxNormFieldsEnum.drug_rxnormid,

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -55,7 +55,7 @@ import {
 	notEmpty,
 	toString,
 } from '../utils';
-import { checkForProgramAndEntityExceptions } from './exceptions/exceptions';
+import { checkForProgramAndEntityExceptions, queryForExceptions } from './exceptions/exceptions';
 import { registrationRepository } from './registration-repo';
 import {
 	ActiveClinicalSubmission,
@@ -97,6 +97,9 @@ import {
 } from './validation-clinical/utils';
 import * as dataValidator from './validation-clinical/validation';
 import { checkUniqueRecords, validateSubmissionData } from './validation-clinical/validation';
+import programExceptionRepository from '../exception/property-exceptions/repo/program';
+import entityExceptionRepository from '../exception/property-exceptions/repo/entity';
+import { ProgramException, EntityException } from '../exception/property-exceptions/types';
 
 const L = loggerFor(__filename);
 
@@ -872,6 +875,7 @@ export namespace operations {
 		let errorsAccumulator: DeepReadonly<SubmissionValidationError[]> = [];
 		const validRecordsAccumulator: any[] = [];
 
+		// cache rxNorm once before iterating records
 		let rxNormCache: Map<string, RxNormConcept[]> | undefined;
 		if (isRxNormTherapy(command.clinicalType)) {
 			const rxNormIds = new Set<string>();
@@ -893,6 +897,21 @@ export namespace operations {
 			}
 		}
 
+		// cache exceptions for program before iterating records
+		let exceptionsCache:
+			| {
+					programException: ProgramException | null;
+					entityException: EntityException | null;
+			  }
+			| undefined;
+
+		if (featureFlags.FEATURE_SUBMISSION_EXCEPTIONS_ENABLED) {
+			L.debug(`Preload exceptions for program ${command.programId}`);
+			const exceptionCacheStart = Date.now();
+			exceptionsCache = await queryForExceptions(command.programId);
+			L.debug(`Exception cache loaded in ${Date.now() - exceptionCacheStart}ms`);
+		}
+
 		await Promise.all(
 			command.records.map(async (record, index) => {
 				let processedRecord: any = {};
@@ -902,7 +921,7 @@ export namespace operations {
 
 				if (schemaResult.validationErrors.length > 0) {
 					let validationErrors = [...schemaResult.validationErrors];
-					if (featureFlags.FEATURE_SUBMISSION_EXCEPTIONS_ENABLED) {
+					if (featureFlags.FEATURE_SUBMISSION_EXCEPTIONS_ENABLED && exceptionsCache) {
 						const exceptionStart = Date.now();
 						/***
 						 * Checking if a valid exception exists and the record value matches it
@@ -912,11 +931,11 @@ export namespace operations {
 						 * Normalizing is setting the value to start Upper case and to trim whitespace
 						 */
 						const { filteredErrors, normalizedRecord } = await checkForProgramAndEntityExceptions({
-							programId: command.programId,
 							record: schemaResult.processedRecord,
 							schemaName,
 							entitySchema,
 							validationErrors: [...schemaResult.validationErrors],
+							exceptionsCache,
 						});
 						L.debug(`[Record ${index}] Exception check: ${Date.now() - exceptionStart}ms`);
 


### PR DESCRIPTION
- rxnorm db queries were not being batched which causes very long processing times due to db connection limits (eg. 6000 records waiting on a pool of 10 connections)
- makes 1 DB query for all rxcui lookup values at the start of validation if applicable
- remove old service db query, it was only in use in this instance of clinical upload
- uses cache in the same pattern as exceptions by passing it as an arg
- kept some logs around but using application debugger, they will only show under "debug" log level