### PR TITLE
Exceptions db query optimise

### DIFF
--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -47,7 +47,7 @@ import { notEmpty } from '../../utils';
 import { SubmittedClinicalRecord } from '../submission-entities';
 
 /**
- * query db for program or entity exceptions
+ * query db for program and entity exceptions
  * @param programId
  * @returns program and donor level exceptions for this programId
  */
@@ -200,21 +200,30 @@ export const checkForProgramAndEntityExceptions = async ({
 	schemaName,
 	entitySchema,
 	validationErrors,
+	exceptionsCache,
 }: {
 	programId: string;
 	record: DeepReadonly<TypedDataRecord>;
 	schemaName: ClinicalEntitySchemaNames;
 	entitySchema: dictionaryEntities.SchemaDefinition | undefined;
 	validationErrors: dictionaryEntities.SchemaValidationError[];
+	exceptionsCache?: {
+		programException: ProgramException | null;
+		entityException: EntityException | null;
+	};
 }) => {
 	const filteredErrors: dictionaryEntities.SchemaValidationError[] = [];
 	let normalizedRecord = record;
 
 	// retrieve submitted exceptions for program id (both program level and entity level)
-	const { programException, entityException } = await queryForExceptions(programId);
+	const exceptions = exceptionsCache
+		? exceptionsCache
+		: programId
+		? await queryForExceptions(programId)
+		: undefined;
 
 	// if there are submitted exceptions for this program, check if they match record values
-	if (!(programException || entityException)) {
+	if (!(exceptions?.programException || exceptions?.entityException)) {
 		return { filteredErrors: validationErrors, normalizedRecord };
 	}
 
@@ -247,8 +256,8 @@ export const checkForProgramAndEntityExceptions = async ({
 
 			const valueHasException = validateFieldValueWithExceptions({
 				record,
-				programException,
-				entityException,
+				programException: exceptions.programException,
+				entityException: exceptions.entityException,
 				schemaName,
 				validationErrorFieldName: validationError.fieldName,
 				fieldValue: normalizedFieldValue,

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -202,7 +202,7 @@ export const checkForProgramAndEntityExceptions = async ({
 	validationErrors,
 	exceptionsCache,
 }: {
-	programId: string;
+	programId?: string;
 	record: DeepReadonly<TypedDataRecord>;
 	schemaName: ClinicalEntitySchemaNames;
 	entitySchema: dictionaryEntities.SchemaDefinition | undefined;

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -51,7 +51,7 @@ import { SubmittedClinicalRecord } from '../submission-entities';
  * @param programId
  * @returns program and donor level exceptions for this programId
  */
-const queryForExceptions = async (programId: string) => {
+export const queryForExceptions = async (programId: string) => {
 	const programException = await programExceptionRepository.find(programId);
 	const entityException = await entityExceptionRepository.find(programId);
 

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -193,6 +193,7 @@ const isValidNumericExceptionType = (
  * @param programId
  * @param record
  * @param schemaValidationErrors
+ * @param exceptionsCache optional cache of exceptions db query
  */
 export const checkForProgramAndEntityExceptions = async ({
 	programId,
@@ -215,7 +216,12 @@ export const checkForProgramAndEntityExceptions = async ({
 	const filteredErrors: dictionaryEntities.SchemaValidationError[] = [];
 	let normalizedRecord = record;
 
-	// retrieve submitted exceptions for program id (both program level and entity level)
+	/*
+	 * retrieve submitted exceptions for program id (both program level and entity level)
+	 *
+	 * if exceptionsCache is provided, reads from it (no write)
+	 * else, queries exception db using programId
+	 */
 	const exceptions = exceptionsCache
 		? exceptionsCache
 		: programId

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -97,6 +97,9 @@ import {
 } from './validation-clinical/utils';
 import * as dataValidator from './validation-clinical/validation';
 import { checkUniqueRecords, validateSubmissionData } from './validation-clinical/validation';
+import programExceptionRepository from '../exception/property-exceptions/repo/program';
+import entityExceptionRepository from '../exception/property-exceptions/repo/entity';
+import { ProgramException, EntityException } from '../exception/property-exceptions/types';
 
 const L = loggerFor(__filename);
 
@@ -872,6 +875,7 @@ export namespace operations {
 		let errorsAccumulator: DeepReadonly<SubmissionValidationError[]> = [];
 		const validRecordsAccumulator: any[] = [];
 
+		// cache rxNorm once before iterating records
 		let rxNormCache: Map<string, RxNormConcept[]> | undefined;
 		if (isRxNormTherapy(command.clinicalType)) {
 			const rxNormIds = new Set<string>();
@@ -893,6 +897,25 @@ export namespace operations {
 			}
 		}
 
+		// cache exceptions for program before iterating records
+		let exceptionsCache:
+			| {
+					programException: ProgramException | null;
+					entityException: EntityException | null;
+			  }
+			| undefined;
+
+		if (featureFlags.FEATURE_SUBMISSION_EXCEPTIONS_ENABLED) {
+			L.debug(`Preload exceptions for program ${command.programId}`);
+			const exceptionCacheStart = Date.now();
+
+			const programException = await programExceptionRepository.find(command.programId);
+			const entityException = await entityExceptionRepository.find(command.programId);
+
+			exceptionsCache = { programException, entityException };
+			L.debug(`Exception cache loaded in ${Date.now() - exceptionCacheStart}ms`);
+		}
+
 		await Promise.all(
 			command.records.map(async (record, index) => {
 				let processedRecord: any = {};
@@ -902,7 +925,7 @@ export namespace operations {
 
 				if (schemaResult.validationErrors.length > 0) {
 					let validationErrors = [...schemaResult.validationErrors];
-					if (featureFlags.FEATURE_SUBMISSION_EXCEPTIONS_ENABLED) {
+					if (featureFlags.FEATURE_SUBMISSION_EXCEPTIONS_ENABLED && exceptionsCache) {
 						const exceptionStart = Date.now();
 						/***
 						 * Checking if a valid exception exists and the record value matches it
@@ -912,11 +935,11 @@ export namespace operations {
 						 * Normalizing is setting the value to start Upper case and to trim whitespace
 						 */
 						const { filteredErrors, normalizedRecord } = await checkForProgramAndEntityExceptions({
-							programId: command.programId,
 							record: schemaResult.processedRecord,
 							schemaName,
 							entitySchema,
 							validationErrors: [...schemaResult.validationErrors],
+							exceptionsCache,
 						});
 						L.debug(`[Record ${index}] Exception check: ${Date.now() - exceptionStart}ms`);
 

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -55,7 +55,7 @@ import {
 	notEmpty,
 	toString,
 } from '../utils';
-import { checkForProgramAndEntityExceptions } from './exceptions/exceptions';
+import { checkForProgramAndEntityExceptions, queryForExceptions } from './exceptions/exceptions';
 import { registrationRepository } from './registration-repo';
 import {
 	ActiveClinicalSubmission,
@@ -908,11 +908,7 @@ export namespace operations {
 		if (featureFlags.FEATURE_SUBMISSION_EXCEPTIONS_ENABLED) {
 			L.debug(`Preload exceptions for program ${command.programId}`);
 			const exceptionCacheStart = Date.now();
-
-			const programException = await programExceptionRepository.find(command.programId);
-			const entityException = await entityExceptionRepository.find(command.programId);
-
-			exceptionsCache = { programException, entityException };
+			exceptionsCache = await queryForExceptions(command.programId);
 			L.debug(`Exception cache loaded in ${Date.now() - exceptionCacheStart}ms`);
 		}
 


### PR DESCRIPTION
! Merging into https://github.com/icgc-argo/argo-clinical/pull/1237 other db optimise query
- clinical was querying for every record to two repos (eg. 6000 records => 1200 db calls)
- adds one db call because it only relies on programId, instead of calling for each record
- added optional cache and changes the programId to optional for the `checkForProgramAndEntityExceptions` method, as it's used elsewhere in the clinical service without a cache