### PR TITLE
Entity ID Prefixing to uniquely Identify Data Center

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,12 @@ CLINICAL_DB_USERNAME=
 CLINICAL_DB_PASSWORD=
 
 # Seeds (inclusive)
-DONOR_ID_SEED= 
-SPECIMEN_ID_SEED= 
-SAMPLE_ID_SEED= 
+DONOR_ID_SEED=
+SPECIMEN_ID_SEED=
+SAMPLE_ID_SEED=
+
+# Optional datacenter prefix prepended to entity IDs (e.g. CA produces CA-DO123). Leave empty for no prefix.
+# DATACENTER_ID_PREFIX=
 
 # Disable test endpoints
 DISABLE_TEST_APIS=true

--- a/README.md
+++ b/README.md
@@ -142,19 +142,3 @@ it's recommended to use mysql 5.7, 5.6. or 5.5 mysql 8 has issues, but works non
 - move all mysql scripts from scripts folder to rrf folder.
 
 the job to import this: https://jenkins.qa.cancercollaboratory.org/job/ARGO/job/devops/job/rxnorm-import/
-
-# Lectern client
-
-## work live with overture client without publishing new versions
-
-in clinical package json:
-
-1. "@overturebio-stack/lectern-client": "file:/home/ballabadi/dev/repos/overture/js-lectern-client",
-2. go to lectern client, update code and `npm run build`
-3. install the updated version `npm i`
-
-## how to debug schema client :
-
-1. put debug point here: manager.ts function
-2. when break point hits, step into lectern client func
-3. place break point in lectern client file

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@apollo/server": "^4.11.0",
 				"@apollo/subgraph": "2.5.2",
 				"@icgc-argo/ego-token-utils": "^8.5.0",
-				"@overturebio-stack/lectern-client": "^1.5.0",
+				"@overture-stack/lectern-client": "^1.5.0",
 				"@types/mongoose-paginate-v2": "^1.3.11",
 				"adm-zip": "^0.4.16",
 				"apollo-server-core": "^3.12.0",
@@ -1536,9 +1536,10 @@
 			"dev": true
 		},
 		"node_modules/@colors/colors": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.1.90"
 			}
@@ -1556,24 +1557,15 @@
 			}
 		},
 		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+			"integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+			"license": "MIT",
 			"dependencies": {
-				"colorspace": "1.1.x",
+				"@so-ric/colorspace": "^1.1.6",
 				"enabled": "2.0.x",
 				"kuler": "^2.0.0"
 			}
-		},
-		"node_modules/@dabh/diagnostics/node_modules/enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
-		},
-		"node_modules/@dabh/diagnostics/node_modules/kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
 		},
 		"node_modules/@fastify/busboy": {
 			"version": "2.1.1",
@@ -1786,10 +1778,11 @@
 				"sparse-bitfield": "^3.0.3"
 			}
 		},
-		"node_modules/@overturebio-stack/lectern-client": {
+		"node_modules/@overture-stack/lectern-client": {
 			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@overturebio-stack/lectern-client/-/lectern-client-1.5.0.tgz",
-			"integrity": "sha512-WYLwlWE09yR/SG6FqhAbbFynY3+ViclVbGJO0PO6Uspe5Pe7YKOfzWO9udlO4f40y+ZnwDlzkaJgMsk/AocyhQ==",
+			"resolved": "https://registry.npmjs.org/@overture-stack/lectern-client/-/lectern-client-1.5.0.tgz",
+			"integrity": "sha512-aIKWUQw7Ql2PR4o2qp0qCI3LoiHM+y5nFBYZ+uJQHa5aZ2R4b5upaRprZ8fdEzp4QT8dqrWQRc4qa4E6kYo8mw==",
+			"license": "AGPL-3.0",
 			"dependencies": {
 				"cd": "^0.3.3",
 				"deep-freeze": "^0.0.1",
@@ -1801,73 +1794,11 @@
 				"winston": "^3.3.3"
 			}
 		},
-		"node_modules/@overturebio-stack/lectern-client/node_modules/fecha": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
-		},
-		"node_modules/@overturebio-stack/lectern-client/node_modules/is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@overturebio-stack/lectern-client/node_modules/logform": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.4.2.tgz",
-			"integrity": "sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==",
-			"dependencies": {
-				"@colors/colors": "1.5.0",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
-			}
-		},
-		"node_modules/@overturebio-stack/lectern-client/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-		},
-		"node_modules/@overturebio-stack/lectern-client/node_modules/one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"dependencies": {
-				"fn.name": "1.x.x"
-			}
-		},
-		"node_modules/@overturebio-stack/lectern-client/node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/@overturebio-stack/lectern-client/node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/@overturebio-stack/lectern-client/node_modules/ts-node": {
+		"node_modules/@overture-stack/lectern-client/node_modules/ts-node": {
 			"version": "9.1.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
 			"integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+			"license": "MIT",
 			"dependencies": {
 				"arg": "^4.1.0",
 				"create-require": "^1.1.0",
@@ -1887,40 +1818,6 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=2.7"
-			}
-		},
-		"node_modules/@overturebio-stack/lectern-client/node_modules/winston": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
-			"integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
-			"dependencies": {
-				"@colors/colors": "1.5.0",
-				"@dabh/diagnostics": "^2.0.2",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.5.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/@overturebio-stack/lectern-client/node_modules/winston-transport": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-			"integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
-			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 6.4.0"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -2863,6 +2760,16 @@
 			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"optional": true
 		},
+		"node_modules/@so-ric/colorspace": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+			"integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+			"license": "MIT",
+			"dependencies": {
+				"color": "^5.0.2",
+				"text-hex": "1.0.x"
+			}
+		},
 		"node_modules/@swc/core": {
 			"version": "1.3.32",
 			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.32.tgz",
@@ -3504,6 +3411,12 @@
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
 			"integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
 			"dev": true
+		},
+		"node_modules/@types/triple-beam": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+			"license": "MIT"
 		},
 		"node_modules/@types/uuid": {
 			"version": "8.3.4",
@@ -4629,6 +4542,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/caller-callsite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -4931,18 +4857,23 @@
 			}
 		},
 		"node_modules/color": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-			"integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+			"integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+			"license": "MIT",
 			"dependencies": {
-				"color-convert": "^1.9.1",
-				"color-string": "^1.5.2"
+				"color-convert": "^3.1.3",
+				"color-string": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -4950,37 +4881,49 @@
 		"node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"node_modules/color-string": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-			"integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+			"integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+			"license": "MIT",
 			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
-		"node_modules/colornames": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
-			"integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
-		},
-		"node_modules/colors": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+				"color-name": "^2.0.0"
+			},
 			"engines": {
-				"node": ">=0.1.90"
+				"node": ">=18"
 			}
 		},
-		"node_modules/colorspace": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
-			"integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+		"node_modules/color-string/node_modules/color-name": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
+			}
+		},
+		"node_modules/color/node_modules/color-convert": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+			"integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+			"license": "MIT",
 			"dependencies": {
-				"color": "3.0.x",
-				"text-hex": "1.0.x"
+				"color-name": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.6"
+			}
+		},
+		"node_modules/color/node_modules/color-name": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
 			}
 		},
 		"node_modules/combined-stream": {
@@ -5652,16 +5595,6 @@
 				"npm": "1.2.8000 || >= 1.4.16"
 			}
 		},
-		"node_modules/diagnostics": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
-			"integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
-			"dependencies": {
-				"colorspace": "1.1.x",
-				"enabled": "1.0.x",
-				"kuler": "1.0.x"
-			}
-		},
 		"node_modules/diff": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -5798,6 +5731,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -5833,12 +5780,10 @@
 			"dev": true
 		},
 		"node_modules/enabled": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
-			"integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
-			"dependencies": {
-				"env-variable": "0.0.x"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+			"license": "MIT"
 		},
 		"node_modules/encodeurl": {
 			"version": "1.0.2",
@@ -5856,11 +5801,6 @@
 			"dependencies": {
 				"once": "^1.4.0"
 			}
-		},
-		"node_modules/env-variable": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
-			"integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
 		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
@@ -5884,12 +5824,10 @@
 			}
 		},
 		"node_modules/es-define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-			"dependencies": {
-				"get-intrinsic": "^1.2.4"
-			},
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5898,6 +5836,18 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -6246,11 +6196,6 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
-		"node_modules/fast-safe-stringify": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-			"integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
-		},
 		"node_modules/fast-xml-parser": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
@@ -6288,9 +6233,10 @@
 			}
 		},
 		"node_modules/fecha": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
-			"integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+			"license": "MIT"
 		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
@@ -6366,7 +6312,8 @@
 		"node_modules/fn.name": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+			"license": "MIT"
 		},
 		"node_modules/foreground-child": {
 			"version": "3.3.0",
@@ -6573,15 +6520,21 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
 			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
 				"function-bind": "^1.1.2",
-				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3",
-				"hasown": "^2.0.0"
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6600,6 +6553,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/get-stdin": {
@@ -6660,11 +6626,12 @@
 			}
 		},
 		"node_modules/gopd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-			"dependencies": {
-				"get-intrinsic": "^1.1.3"
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -6753,21 +6720,11 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/has-proto": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/has-symbols": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -7126,6 +7083,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7343,12 +7301,10 @@
 			}
 		},
 		"node_modules/kuler": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
-			"integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
-			"dependencies": {
-				"colornames": "^1.1.1"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+			"license": "MIT"
 		},
 		"node_modules/lazystream": {
 			"version": "1.0.1",
@@ -7515,21 +7471,27 @@
 			}
 		},
 		"node_modules/logform": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
-			"integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+			"integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+			"license": "MIT",
 			"dependencies": {
-				"colors": "^1.2.1",
-				"fast-safe-stringify": "^2.0.4",
-				"fecha": "^2.3.3",
+				"@colors/colors": "1.6.0",
+				"@types/triple-beam": "^1.3.2",
+				"fecha": "^4.2.0",
 				"ms": "^2.1.1",
+				"safe-stable-stringify": "^2.3.1",
 				"triple-beam": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/logform/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
 		},
 		"node_modules/loglevel": {
 			"version": "1.8.1",
@@ -7582,6 +7544,15 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
 			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
@@ -8708,9 +8679,13 @@
 			}
 		},
 		"node_modules/one-time": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
-			"integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"license": "MIT",
+			"dependencies": {
+				"fn.name": "1.x.x"
+			}
 		},
 		"node_modules/opencollective-postinstall": {
 			"version": "2.0.2",
@@ -9539,9 +9514,10 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/safe-stable-stringify": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
-			"integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -9800,19 +9776,6 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
 		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
-		"node_modules/simple-swizzle/node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-		},
 		"node_modules/simple-update-notifier": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -9921,8 +9884,19 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/sparse-bitfield": {
@@ -10376,7 +10350,8 @@
 		"node_modules/text-hex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+			"license": "MIT"
 		},
 		"node_modules/through2": {
 			"version": "2.0.5",
@@ -10444,9 +10419,13 @@
 			}
 		},
 		"node_modules/triple-beam": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.0.0"
+			}
 		},
 		"node_modules/ts-node": {
 			"version": "10.9.1",
@@ -10784,42 +10763,65 @@
 			}
 		},
 		"node_modules/winston": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
-			"integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+			"integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+			"license": "MIT",
 			"dependencies": {
-				"async": "^2.6.1",
-				"diagnostics": "^1.1.1",
-				"is-stream": "^1.1.0",
-				"logform": "^2.1.1",
-				"one-time": "0.0.4",
-				"readable-stream": "^3.1.1",
+				"@colors/colors": "^1.6.0",
+				"@dabh/diagnostics": "^2.0.8",
+				"async": "^3.2.3",
+				"is-stream": "^2.0.0",
+				"logform": "^2.7.0",
+				"one-time": "^1.0.0",
+				"readable-stream": "^3.4.0",
+				"safe-stable-stringify": "^2.3.1",
 				"stack-trace": "0.0.x",
 				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.3.0"
+				"winston-transport": "^4.9.0"
 			},
 			"engines": {
-				"node": ">= 6.4.0"
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/winston-transport": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
-			"integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+			"integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+			"license": "MIT",
 			"dependencies": {
-				"readable-stream": "^2.3.6",
-				"triple-beam": "^1.2.0"
+				"logform": "^2.7.0",
+				"readable-stream": "^3.6.2",
+				"triple-beam": "^1.3.0"
 			},
 			"engines": {
-				"node": ">= 6.4.0"
+				"node": ">= 12.0.0"
 			}
 		},
-		"node_modules/winston/node_modules/async": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+		"node_modules/winston-transport/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
 			"dependencies": {
-				"lodash": "^4.17.14"
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/winston/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/winston/node_modules/readable-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "argo-clinical",
-	"version": "1.89.1",
+	"version": "1.89.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "argo-clinical",
-			"version": "1.88.1",
+			"version": "1.89.2",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@apollo/server": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"@apollo/server": "^4.11.0",
 		"@apollo/subgraph": "2.5.2",
 		"@icgc-argo/ego-token-utils": "^8.5.0",
-		"@overturebio-stack/lectern-client": "^1.5.0",
+		"@overture-stack/lectern-client": "^1.5.0",
 		"@types/mongoose-paginate-v2": "^1.3.11",
 		"adm-zip": "^0.4.16",
 		"apollo-server-core": "^3.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "argo-clinical",
-	"version": "1.89.1",
+	"version": "1.89.2",
 	"description": "Clinical submission system and repo.",
 	"scripts": {
 		"start": "npm run serve",

--- a/src/clinical/clinical-service.ts
+++ b/src/clinical/clinical-service.ts
@@ -20,7 +20,7 @@
 import {
 	entities as dictionaryEntities,
 	functions as dictionaryService,
-} from '@overturebio-stack/lectern-client';
+} from '@overture-stack/lectern-client';
 import { DeepReadonly } from 'deep-freeze';
 import _ from 'lodash';
 import {

--- a/src/common-model/entities.ts
+++ b/src/common-model/entities.ts
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { z as zod } from 'zod';
 
 // this is temporary to keep code compiling until surgery is ready in dictionary, to be removed in favor of

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ export interface AppConfig {
 	egoUrl(): string;
 	egoClientId(): string;
 	egoClientSecret(): string;
+	datacenterPrefix(): string | undefined;
 }
 
 class ConfigManager {

--- a/src/dictionary/api.ts
+++ b/src/dictionary/api.ts
@@ -20,7 +20,7 @@
 import * as manager from './manager';
 import { Request, Response } from 'express';
 import { loggerFor } from '../logger';
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { setStatus, Status } from '../app-health';
 import { ControllerUtils } from '../utils';
 import { ClinicalEntitySchemaNames } from '../common-model/entities';

--- a/src/dictionary/manager.ts
+++ b/src/dictionary/manager.ts
@@ -23,7 +23,7 @@ import {
 	restClient as dictionaryRestClient,
 	functions as dictionaryService,
 	parallel,
-} from '@overturebio-stack/lectern-client';
+} from '@overture-stack/lectern-client';
 import { DeepReadonly } from 'deep-freeze';
 import _ from 'lodash';
 import { Donor } from '../clinical/clinical-entities';

--- a/src/dictionary/repo.ts
+++ b/src/dictionary/repo.ts
@@ -18,7 +18,7 @@
  */
 
 import mongoose from 'mongoose';
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { loggerFor } from '../logger';
 import { MongooseUtils } from '../utils';
 const L = loggerFor(__filename);

--- a/src/exception/property-exceptions/validation.ts
+++ b/src/exception/property-exceptions/validation.ts
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { isEqual } from 'lodash';
 import * as dictionaryManager from '../../dictionary/manager';
 import { loggerFor } from '../../logger';

--- a/src/server.ts
+++ b/src/server.ts
@@ -141,6 +141,9 @@ let server: Server;
 		egoClientSecret(): string {
 			return process.env.EGO_CLIENT_SECRET || secrets.EGO_CLIENT_SECRET || '';
 		},
+		datacenterPrefix(): string | undefined {
+			return process.env.DATACENTER_ID_PREFIX;
+		},
 	};
 
 	let connection: any;

--- a/src/submission/exceptions/exceptions.ts
+++ b/src/submission/exceptions/exceptions.ts
@@ -17,8 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
-import { TypedDataRecord } from '@overturebio-stack/lectern-client/lib/schema-entities';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
+import { TypedDataRecord } from '@overture-stack/lectern-client/lib/schema-entities';
 import { DeepReadonly } from 'deep-freeze';
 import _ from 'lodash';
 import {

--- a/src/submission/migration/migration-entities.ts
+++ b/src/submission/migration/migration-entities.ts
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { ClinicalEntitySchemaNames } from '../../common-model/entities';
 
 export type MigrationStage = 'SUBMITTED' | 'ANALYZED' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED';

--- a/src/submission/migration/migration-manager.ts
+++ b/src/submission/migration/migration-manager.ts
@@ -20,8 +20,8 @@
 import {
 	entities as dictionaryEntities,
 	functions as dictionaryService,
-} from '@overturebio-stack/lectern-client';
-import { ValueType } from '@overturebio-stack/lectern-client/lib/schema-entities';
+} from '@overture-stack/lectern-client';
+import { ValueType } from '@overture-stack/lectern-client/lib/schema-entities';
 import { DeepReadonly } from 'deep-freeze';
 import _ from 'lodash';
 import { Status, setStatus } from '../../app-health';

--- a/src/submission/submission-entities.ts
+++ b/src/submission/submission-entities.ts
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { DeepReadonly } from 'deep-freeze';
 import {
 	BiomarkerFieldsEnum,

--- a/src/submission/submission-service.ts
+++ b/src/submission/submission-service.ts
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { DeepReadonly } from 'deep-freeze';
 import _ from 'lodash';
 import { v1 as uuid } from 'uuid';

--- a/src/submission/submission-to-clinical/validate-donors.ts
+++ b/src/submission/submission-to-clinical/validate-donors.ts
@@ -22,7 +22,7 @@ import { Donor } from '../../clinical/clinical-entities';
 
 import { loggerFor } from '../../logger';
 import { cloneDeep } from 'lodash';
-import { SchemasDictionary } from '@overturebio-stack/lectern-client/lib/schema-entities';
+import { SchemasDictionary } from '@overture-stack/lectern-client/lib/schema-entities';
 const L = loggerFor(__filename);
 
 /**

--- a/src/submission/validation-clinical/utils.ts
+++ b/src/submission/validation-clinical/utils.ts
@@ -43,7 +43,7 @@ import {
 	SubmissionErrorBaseInfo,
 } from '../submission-error-messages';
 import _ from 'lodash';
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { Donor, ClinicalInfo, Specimen } from '../../clinical/clinical-entities';
 import {
 	getSingleClinicalEntityFromDonorBySchemaName,

--- a/src/submission/validation-clinical/validation.ts
+++ b/src/submission/validation-clinical/validation.ts
@@ -45,7 +45,7 @@ import {
 } from '../../common-model/entities';
 import { donorDao } from '../../clinical/donor-repo';
 import { DeepReadonly } from 'deep-freeze';
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { submissionValidator } from './index';
 import { validationErrorMessage } from '../submission-error-messages';
 import {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ import fs from 'fs';
 import jwt from 'jsonwebtoken';
 import _ from 'lodash';
 import mongoose from 'mongoose';
-import { isArray } from 'util';
+import { config } from './config';
 import { SubmissionBatchError } from './submission/submission-entities';
 
 const fsPromises = fs.promises;
@@ -163,13 +163,28 @@ export namespace DonorUtils {
 	export const specimenIdPrefix = 'SP';
 	export const sampleIdPrefix = 'SA';
 
-	export const parseDonorId = (stringId: string): number =>
-		Number(stringId.replace(donorIdPrefix, ''));
-	export const prefixDonorId = (donorId: number): string => `${donorIdPrefix}${donorId}`;
+	const applyDatacenterPrefix = (entityId: string): string => {
+		const datacenterPrefix = config.getConfig().datacenterPrefix();
+		return datacenterPrefix ? `${datacenterPrefix}-${entityId}` : entityId;
+	};
+
+	export const parseDonorId = (stringId: string): number => {
+		const datacenterPrefix = config.getConfig().datacenterPrefix();
+		const withoutDatacenterPrefix =
+			datacenterPrefix && stringId.startsWith(`${datacenterPrefix}-`)
+				? stringId.slice(datacenterPrefix.length + 1)
+				: stringId;
+		return Number(withoutDatacenterPrefix.replace(donorIdPrefix, ''));
+	};
+
+	export const prefixDonorId = (donorId: number): string =>
+		applyDatacenterPrefix(`${donorIdPrefix}${donorId}`);
 
 	export const prefixSpecimenId = (specimenId: number): string =>
-		`${specimenIdPrefix}${specimenId}`;
-	export const prefixSampleId = (sampleId: number): string => `${sampleIdPrefix}${sampleId}`;
+		applyDatacenterPrefix(`${specimenIdPrefix}${specimenId}`);
+
+	export const prefixSampleId = (sampleId: number): string =>
+		applyDatacenterPrefix(`${sampleIdPrefix}${sampleId}`);
 }
 
 export namespace Checks {
@@ -335,7 +350,7 @@ export function deepFind(obj: any, path: string) {
 }
 
 export function isValueEqual(value: any, other: any) {
-	if (isArray(value) && isArray(other)) {
+	if (Array.isArray(value) && Array.isArray(other)) {
 		return _.difference(value, other).length === 0; // check equal, ignore order
 	}
 
@@ -353,3 +368,20 @@ export function convertToTrimmedString(
 }
 
 export const F = deepFreeze;
+
+// generic terms
+const DOCUMENT_TYPE = 'documentType';
+const INDEX = 'index';
+const TYPE = 'type';
+export const requiredConfigProperties = {
+	DOCUMENT_TYPE,
+	INDEX,
+} as const;
+
+export const arrangerConfigProperties = {
+	...requiredConfigProperties,
+};
+
+type AllConfigs =
+	// Arranger will fail without these
+	typeof requiredConfigProperties & Partial<{ x: string }>;

--- a/test/integration/clinical/clinical.spec.ts
+++ b/test/integration/clinical/clinical.spec.ts
@@ -178,6 +178,9 @@ describe('clinical Api', () => {
 					egoClientSecret() {
 						return '';
 					},
+					datacenterPrefix() {
+						return undefined;
+					},
 				});
 			} catch (err) {
 				console.error('before >>>>>>>>>>>', err);

--- a/test/integration/submission/migration_utils/schema_builder.ts
+++ b/test/integration/submission/migration_utils/schema_builder.ts
@@ -20,7 +20,7 @@
 import { migrationDiffs } from './stub-diffs';
 import _ from 'lodash';
 import fs from 'fs';
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import legacyStubSchemas from '../../stub-schema.json';
 import { ClinicalEntitySchemaNames } from '../../../../src/common-model/entities';
 import * as fieldNames from './fields';

--- a/test/integration/submission/schema-manager.spec.ts
+++ b/test/integration/submission/schema-manager.spec.ts
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { MongoDBContainer } from '@testcontainers/mongodb';
 import { promisify } from 'bluebird';
 import chai from 'chai';

--- a/test/integration/submission/submission-schema-migration.spec.ts
+++ b/test/integration/submission/submission-schema-migration.spec.ts
@@ -225,6 +225,9 @@ describe('schema migration api', () => {
 					egoClientSecret() {
 						return '';
 					},
+					datacenterPrefix() {
+						return undefined;
+					},
 				});
 			} catch (err) {
 				console.error('before >>>>>>>>>>>', err);

--- a/test/integration/submission/submission-schema-migration.spec.ts
+++ b/test/integration/submission/submission-schema-migration.spec.ts
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
 import { MongoDBContainer } from '@testcontainers/mongodb';
 import { MySqlContainer } from '@testcontainers/mysql';
 import { Network } from 'testcontainers';

--- a/test/integration/submission/submission.spec.ts
+++ b/test/integration/submission/submission.spec.ts
@@ -166,6 +166,9 @@ describe('Submission Api', () => {
 					egoClientSecret() {
 						return '';
 					},
+					datacenterPrefix() {
+						return undefined;
+					},
 				});
 				const connectionPool = pool.getPool();
 				await createtRxNormTables(connectionPool);

--- a/test/performance-test/submission.spec.ts
+++ b/test/performance-test/submission.spec.ts
@@ -157,6 +157,9 @@ describe('Submission Api', () => {
 					egoClientSecret() {
 						return '';
 					},
+					datacenterPrefix() {
+						return undefined;
+					},
 				});
 			} catch (err) {
 				return err;

--- a/test/unit/decorator/decorator.spec.ts
+++ b/test/unit/decorator/decorator.spec.ts
@@ -92,6 +92,9 @@ describe('decorator', () => {
 			egoClientSecret() {
 				return '';
 			},
+			datacenterPrefix() {
+				return '';
+			},
 		});
 	});
 

--- a/test/unit/exception/applyException.spec.ts
+++ b/test/unit/exception/applyException.spec.ts
@@ -17,8 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { entities as dictionaryEntities } from '@overturebio-stack/lectern-client';
-import { SchemaValidationErrorTypes } from '@overturebio-stack/lectern-client/lib/schema-entities';
+import { entities as dictionaryEntities } from '@overture-stack/lectern-client';
+import { SchemaValidationErrorTypes } from '@overture-stack/lectern-client/lib/schema-entities';
 import chai from 'chai';
 import sinon from 'sinon';
 import { ClinicalEntitySchemaNames } from '../../../src/common-model/entities';


### PR DESCRIPTION
## Link to Issue

<!-- Link of the form: https://github.com/icgc-argo/roadmap/issues/xxxx -->

## Description

<!-- Description of work done in PR -->
To support collecting data in multiple datacenters, we need to ensure that the generated IDs will always be unique. ARGO has previously relied on a centralized data management to enforce system wide unique IDs. As data is collected separately in different data centers without this centralized mechanism we will enable the generated IDs to remain unique by adding a prefix to the ID based on the DataCenter that is managing that data.

Clinical service generates unique IDs for 3 entity types: Donor, Specimen, and Sample.

The prefix will be added with a hyphen in advance of the generated ID: `ABC-DO123` instead of `DO123`

This Prefix is optional. The orignal ARGO datacenter should continue operating without a prefix. Any Data cetner that joins the ARGO network should define a prefix for their IDs and apply them.

This ID Prefix is configured in the environment variable: `DATACENTER_ID_PREFIX`

## Checklist

### Type of Change

- [ ] Bug
- [ ] Refactor
- [x] New Feature
- [ ] Release Candidate

### Checklist before requesting review:

- [x] Check branch (code change PRs go to `develop` not master)
- [x] Check copyrights for new files
- [x] Manual testing
- [x] Regression tests completed and passing (double check number of tests).
- [x] Spelling has been checked.
- [x] Updated swagger docs accordingly (check it's still valid)
- [ ] Set `validationDependency` in meta tag for [Argo Dictionary](https://github.com/icgc-argo/argo-dictionary) fields used in code
